### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/verifast/verifast.svg?branch=master)](https://travis-ci.org/verifast/verifast)
 VeriFast
 ========
 


### PR DESCRIPTION
Added the build status badge of Travis-CI to the README.md file.

This status image is generated in a per branch basis, i.e., independent of the branch you are viewing on GitHub, the status of the master branch is displayed!

Should we add this?