### PR TITLE
(unsigned) short pointer support. The predicates and supplimentary lemmas.

### DIFF
--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -26,6 +26,8 @@
 .provides ./prelude.h#char_limits
 .provides ./prelude.h#integer_limits
 .provides ./prelude.h#u_integer_limits
+.provides ./prelude.h#short_integer_limits
+.provides ./prelude.h#u_short_integer_limits
 .provides ./prelude.h#chars_limits
 .provides ./prelude.h#chars_split
 .provides ./prelude.h#chars_join
@@ -38,10 +40,14 @@
 .provides ./prelude.h#chars_of_int_char_in_bounds
 .provides ./prelude.h#chars_to_integer
 .provides ./prelude.h#chars_to_u_integer
+.provides ./prelude.h#chars_to_short_integer
+.provides ./prelude.h#chars_to_u_short_integer
 .provides ./prelude.h#chars_to_pointer
 .provides ./prelude.h#chars_to_u_pointer
 .provides ./prelude.h#integer_to_chars
 .provides ./prelude.h#u_integer_to_chars
+.provides ./prelude.h#short_integer_to_chars
+.provides ./prelude.h#u_short_integer_to_chars
 .provides ./prelude.h#u_character_to_character
 .provides ./prelude.h#character_to_u_character
 .provides ./prelude.h#pointer_to_chars

--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -57,6 +57,8 @@
 .provides ./prelude.h#uchars_inv
 .provides ./prelude.h#ints_inv
 .provides ./prelude.h#uints_inv
+.provides ./prelude.h#shorts_inv
+.provides ./prelude.h#ushorts_inv
 .provides ./prelude.h#pointers_inv
 .provides ./prelude.h#pointers_split
 .provides ./prelude.h#pointers_join
@@ -76,6 +78,8 @@
 .predicate @./prelude.h#u_character
 .predicate @./prelude.h#integer
 .predicate @./prelude.h#u_integer
+.predicate @./prelude.h#short_integer
+.predicate @./prelude.h#u_short_integer
 .predicate @./prelude.h#pointer
 .predicate @./prelude.h#divrem
 .predicate @./prelude.h#malloc_block

--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -24,6 +24,9 @@ predicate u_character(unsigned char *p; unsigned char c);
 predicate integer(int *p; int v);
 predicate u_integer(unsigned int *p; unsigned int v);
 
+predicate short_integer(short *p; short s);
+predicate u_short_integer(unsigned short *p; unsigned short v);
+
 predicate pointer(void **pp; void *p);
 
 lemma void character_limits(char *pc);
@@ -202,6 +205,26 @@ lemma_auto void uints_inv();
     requires [?f]uints(?p, ?count, ?vs);
     ensures [f]uints(p, count, vs) &*& count == length(vs);
 
+predicate shorts(short *p, short count; list<short> vs) =
+    count == 0 ?
+        vs == nil
+    :
+        short_integer(p, ?v) &*& shorts(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0);
+
+lemma_auto void shorts_inv();
+    requires [?f]shorts(?p, ?count, ?vs);
+    ensures [f]shorts(p, count, vs) &*& count == length(vs);
+
+predicate ushorts(unsigned short *p, short count; list<unsigned short> vs) =
+    count == 0 ?
+        vs == nil
+    :
+        u_short_integer(p, ?v) &*& ushorts(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0);
+
+lemma_auto void ushorts_inv();
+    requires [?f]ushorts(?p, ?count, ?vs);
+    ensures [f]ushorts(p, count, vs) &*& count == length(vs);
+
 predicate pointers(void **pp, int count; list<void *> ps) =
     count == 0 ?
         ps == nil
@@ -272,6 +295,8 @@ predicate malloc_block_chars(char *p; int count) = malloc_block(p, count);
 predicate malloc_block_uchars(unsigned char *p; int count) = malloc_block(p, count);
 predicate malloc_block_ints(int *p; int count) = malloc_block(p, ?size) &*& divrem(size, sizeof(int), count, 0);
 predicate malloc_block_uints(unsigned int *p; int count) = malloc_block(p, ?size) &*& divrem(size, sizeof(unsigned int), count, 0);
+predicate malloc_block_shorts(short *p; int count) = malloc_block(p, ?size) &*& divrem(size, sizeof(short), count, 0);
+predicate malloc_block_ushorts(unsigned short *p; int count) = malloc_block(p, ?size) &*& divrem(size, sizeof(unsigned short), count, 0);
 predicate malloc_block_pointers(void **p; int count) = malloc_block(p, ?size) &*& divrem(size, sizeof(void *), count, 0);
 
 @*/

--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -49,6 +49,14 @@ lemma void u_integer_limits(unsigned int *p);
     requires [?f]u_integer(p, ?v);
     ensures [f]u_integer(p, v) &*& p > (unsigned int *)0 &*& p + 1 <= (unsigned int *)UINTPTR_MAX &*& 0 <= v &*& v <= UINT_MAX;
 
+lemma void short_integer_limits(short *p);
+    requires [?f]short_integer(p, ?v);
+    ensures [f]short_integer(p, v) &*& p > (short *)0 &*& p + 1 <= (short *)UINTPTR_MAX &*& SHRT_MIN <= v &*& v <= SHRT_MAX;
+
+lemma void u_short_integer_limits(unsigned short *p);
+    requires [?f]u_short_integer(p, ?v);
+    ensures [f]u_short_integer(p, v) &*& p > (unsigned short *)0 &*& p + 1 <= (unsigned short *)UINTPTR_MAX &*& 0 <= v &*& v <= USHRT_MAX;
+
 lemma void pointer_distinct(void *pp1, void *pp2);
     requires pointer(pp1, ?p1) &*& pointer(pp2, ?p2);
     ensures pointer(pp1, p1) &*& pointer(pp2, p2) &*& pp1 != pp2;
@@ -148,6 +156,14 @@ lemma_auto void chars_to_u_integer(void *p);
     requires [?f]chars(p, sizeof(unsigned int), ?cs);
     ensures [f]u_integer(p, _);
 
+lemma_auto void chars_to_short_integer(void *p);
+    requires [?f]chars(p, sizeof(short), ?cs);
+    ensures [f]short_integer(p, _);
+
+lemma_auto void chars_to_u_short_integer(void *p);
+    requires [?f]chars(p, sizeof(unsigned short), ?cs);
+    ensures [f]u_short_integer(p, _);
+
 lemma_auto void chars_to_pointer(void *p);
     requires [?f]chars(p, sizeof(void *), ?cs);
     ensures [f]pointer(p, pointer_of_chars(cs));
@@ -160,6 +176,14 @@ lemma_auto void integer_to_chars(void *p);
 lemma_auto void u_integer_to_chars(void *p);
     requires [?f]u_integer(p, _);
     ensures [f]chars(p, sizeof(unsigned int), ?cs);
+
+lemma_auto void short_integer_to_chars(void *p);
+    requires [?f]short_integer(p, _);
+    ensures [f]chars(p, sizeof(short), ?cs);
+
+lemma_auto void u_short_integer_to_chars(void *p);
+    requires [?f]u_short_integer(p, _);
+    ensures [f]chars(p, sizeof(unsigned short), ?cs);
 
 lemma_auto void pointer_to_chars(void *p);
     requires [?f]pointer(p, ?v);

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -36,7 +36,7 @@ let c_keywords = [
   "define"; "endif"; "&"; "goto"; "uintptr_t"; "INT_MIN"; "INT_MAX";
   "UINTPTR_MAX"; "enum"; "static"; "signed"; "unsigned"; "long";
   "const"; "volatile"; "register"; "ifdef"; "elif"; "undef";
-  "USHRT_MAX"; "UINT_MAX"; "UCHAR_MAX"
+  "SHRT_MIN"; "SHRT_MAX"; "USHRT_MAX"; "UINT_MAX"; "UCHAR_MAX"
 ]
 
 let java_keywords = [
@@ -1256,6 +1256,8 @@ and
 | [< '(l, Kwd "INT_MAX") >] -> IntLit (l, big_int_of_string "2147483647")
 | [< '(l, Kwd "UINTPTR_MAX") >] -> CastExpr (l, false, ManifestTypeExpr (l, Int (Unsigned, 4)), IntLit (l, big_int_of_string "4294967295"))
 | [< '(l, Kwd "UCHAR_MAX") >] -> IntLit (l, big_int_of_string "255")
+| [< '(l, Kwd "SHRT_MIN") >] -> IntLit (l, big_int_of_string "-32767")
+| [< '(l, Kwd "SHRT_MAX") >] -> IntLit (l, big_int_of_string "32767")
 | [< '(l, Kwd "USHRT_MAX") >] -> IntLit (l, big_int_of_string "65535")
 | [< '(l, Kwd "UINT_MAX") >] -> CastExpr (l, false, ManifestTypeExpr (l, Int (Unsigned, 4)), IntLit (l, big_int_of_string "4294967295"))
 | [< '(l, String s); ss = rep (parser [< '(_, String s) >] -> s) >] -> 

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1256,7 +1256,7 @@ and
 | [< '(l, Kwd "INT_MAX") >] -> IntLit (l, big_int_of_string "2147483647")
 | [< '(l, Kwd "UINTPTR_MAX") >] -> CastExpr (l, false, ManifestTypeExpr (l, Int (Unsigned, 4)), IntLit (l, big_int_of_string "4294967295"))
 | [< '(l, Kwd "UCHAR_MAX") >] -> IntLit (l, big_int_of_string "255")
-| [< '(l, Kwd "SHRT_MIN") >] -> IntLit (l, big_int_of_string "-32767")
+| [< '(l, Kwd "SHRT_MIN") >] -> IntLit (l, big_int_of_string "-32768")
 | [< '(l, Kwd "SHRT_MAX") >] -> IntLit (l, big_int_of_string "32767")
 | [< '(l, Kwd "USHRT_MAX") >] -> IntLit (l, big_int_of_string "65535")
 | [< '(l, Kwd "UINT_MAX") >] -> CastExpr (l, false, ManifestTypeExpr (l, Int (Unsigned, 4)), IntLit (l, big_int_of_string "4294967295"))

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -3892,6 +3892,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let _, pointer_pred_symb, _, pointers_pred_symb, _, malloc_block_pointers_pred_symb as pointer_pointee_tuple = pointee_tuple "pointer" "pointers"
   let _, int_pred_symb, _, ints_pred_symb, _, malloc_block_ints_pred_symb as int_pointee_tuple = pointee_tuple "integer" "ints"
   let _, uint_pred_symb, _, uints_pred_symb, _, malloc_block_uints_pred_symb as uint_pointee_tuple = pointee_tuple "u_integer" "uints"
+  let _, short_pred_symb, _, shorts_pred_symb, _, malloc_block_shorts_pred_symb as short_pointee_tuple = pointee_tuple "short_integer" "shorts"
+  let _, ushort_pred_symb, _, ushorts_pred_symb, _, malloc_block_ushorts_pred_symb as ushort_pointee_tuple = pointee_tuple "u_short_integer" "ushorts"
   let _, char_pred_symb, _, chars_pred_symb, _, malloc_block_chars_pred_symb as char_pointee_tuple = pointee_tuple "character" "chars"
   let _, uchar_pred_symb, _, uchars_pred_symb, _, malloc_block_uchars_pred_symb as uchar_pointee_tuple = pointee_tuple "u_character" "uchars"
   
@@ -3903,6 +3905,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       PtrType _ -> Some pointer_pointee_tuple
     | Int (Signed, 4) -> Some int_pointee_tuple
     | Int (Unsigned, 4) -> Some uint_pointee_tuple
+    | Int (Signed, 2) -> Some short_pointee_tuple
+    | Int (Unsigned, 2) -> Some ushort_pointee_tuple
     | Int (Signed, 1) -> Some char_pointee_tuple
     | Int (Unsigned, 1) -> Some uchar_pointee_tuple
     | _ -> None
@@ -4377,6 +4381,14 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 | Int (Unsigned, 4) ->
                   let pref = new predref "u_integer" in
                   pref#set_domain [PtrType (Int (Unsigned, 4)); Int (Unsigned, 4)];
+                  [predinst pref]
+                | Int (Signed, 2) ->
+                  let pref = new predref "short_integer" in
+                  pref#set_domain [PtrType (Int (Signed, 2)); (Int (Signed, 2))];
+                  [predinst pref]
+                | Int (Unsigned, 2) ->
+                  let pref = new predref "u_short_integer" in
+                  pref#set_domain [PtrType (Int (Unsigned, 2)); Int (Unsigned, 2)];
                   [predinst pref]
                 | Int (Signed, 1) ->
                   let pref = new predref "character" in


### PR DESCRIPTION
Six predicates: `short_integer`, `u_short_integer`, `shorts`, `ushorts`, `malloc_block_shorts` and `malloc_block_ushorts`, two constants: `SHRT_MIN`, `SHRT_MAX`, necessary for basic support for pointers to standard C types: `short` and `unsigned short`.

Implemented by analogy to the `u_integer` and `uints` predicates.
Based on this discussion: https://groups.google.com/forum/#!topic/verifast/grGwdUnK4BU
And the issue: https://github.com/verifast/verifast/issues/42

P.S. the make target `testsuite` is very unstable on my laptop, I have to rerun it many times until it passes.