### PR TITLE
Allow shift by unsigned int

### DIFF
--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -2894,7 +2894,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       (operation_expr funcmap l t operator w1 w2, t, None)
     | Operation (l, (ShiftLeft | ShiftRight as op), [e1; e2]) ->
       let w1, t1 = perform_integral_promotion e1 in
-      let w2 = checkt e2 intType in
+      let w2 = try checkt e2 intType with StaticError _ -> checkt e2 (Int (Unsigned, int_size)) in
       (WOperation (l, op, [w1; w2], t1), t1, None)
     | IntLit (l, n, is_decimal, usuffix, lsuffix) ->
       if inAnnotation = Some true then


### PR DESCRIPTION
I encountered the following error when trying to shift by an unsigned int:
> Type mismatch. Actual: uint32. Expected: int.

This is an error thrown by `checkt e2 intType` . If e2 is unsigned, it is not intType (intType = Int(Signed,...) in ast.ml). I add the catch of the error and the retry with an unsigned integer.

(However, I don't know if it's the cleanest way to solve the problem).