### PR TITLE
List available provers in help and in the "No such prover" error message

### DIFF
--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -3135,6 +3135,11 @@ let banner () =
   "By Bart Jacobs, Jan Smans, and Frank Piessens, with contributions by Pieter Agten, Cedric Cuypers, Lieven Desmet, Jan Tobias Muehlberg, Willem Penninckx, Pieter Philippaerts, Amin Timany, Thomas Van Eyck, Gijs Vanspauwen, Frederic Vogels, and external contributors <https://github.com/verifast/verifast/graphs/contributors>" ^
   prover_banners ()
 
+let list_provers () =
+  let prover_names = List.map fst !prover_table in
+  let plural = if List.length prover_names > 1 then "s" else "" in
+  sprintf "available prover%s: %s" plural (String.concat ", " prover_names)
+
 let lookup_prover prover =
   match prover with
     None ->
@@ -3146,7 +3151,9 @@ let lookup_prover prover =
   | Some name ->
     begin
       match try_assoc name !prover_table with
-        None -> failwith ("No such prover: " ^ name)
+        None ->
+          failwith (sprintf "No such prover: %s; %s."
+                            name (list_provers()))
       | Some (banner, f) -> f
     end
       

--- a/src/vfconsole.ml
+++ b/src/vfconsole.ml
@@ -189,7 +189,7 @@ let _ =
   let cla = [ "-stats", Set stats, " "
             ; "-verbose", Set_int verbose, "-1 = file processing; 1 = statement executions; 2 = produce/consume steps; 4 = prover queries."
             ; "-disable_overflow_check", Set disable_overflow_check, " "
-            ; "-prover", String (fun str -> prover := Some str), "Set SMT prover (e.g. redux, z3)."
+            ; "-prover", String (fun str -> prover := Some str), "Set SMT prover (" ^ list_provers() ^ ")."
             ; "-c", Set compileOnly, "Compile only, do not perform link checking."
             ; "-shared", Set isLibrary, "The file is a library (i.e. no main function required)."
             ; "-allow_assume", Set allowAssume, "Allow assume(expr) annotations."


### PR DESCRIPTION
The help message suggests two values for the `-prover` option (redux and z3) but calling verifast with `-prover z3` fails when verifast is compiled with support for z3v4.5.

This commit adds a listing of supported provers both in the output of `verifast -help` and in the error message reported when a bad prover name is given to the `-prover` option.