### PR TITLE
CVC4 as an external prover

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -1,7 +1,5 @@
 # These dependencies are automatically generated.
 # Do not edit by hand. To generate, run 'make depend'.
-proverapi.cmo :
-proverapi.cmx :
 simplex.cmo : linux/Stopwatch.cmi simplex.cmi
 simplex.cmx : linux/Stopwatch.cmx simplex.cmi
 vfconsole.cmo : verifast0.cmx verifast.cmx util.cmx SExpressionEmitter.cmi \
@@ -50,6 +48,10 @@ assertions.cmo : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx linux/Perf.cmx parser.cmx ast.cmx
 assertions.cmx : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx linux/Perf.cmx parser.cmx ast.cmx
+verifastPluginCvc4.cmo : verifast.cmx smtlibprover.cmx smtlib.cmx \
+    proverapi.cmx
+verifastPluginCvc4.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
+    proverapi.cmx
 vfide.cmo : vfversion.cmi verifast0.cmx verifast.cmx util.cmx \
     shape_analysis/shape_analysis_frontend.cmx Printexc_proxy.cmx parser.cmx \
     lexer.cmx java_frontend/java_frontend_bridge.cmx Fonts.cmx \
@@ -88,14 +90,6 @@ verifastPluginZ3.cmo : z3prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3.cmx : z3prover.cmx verifast.cmx proverapi.cmx
 ast.cmo : util.cmx
 ast.cmx : util.cmx
-verifast.cmo : vfversion.cmi verify_expr.cmx verifast1.cmx verifast0.cmx \
-    util.cmx linux/Stopwatch.cmi stats.cmx proverapi.cmx linux/Perf.cmx \
-    parser.cmx lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx \
-    assertions.cmx
-verifast.cmx : vfversion.cmx verify_expr.cmx verifast1.cmx verifast0.cmx \
-    util.cmx linux/Stopwatch.cmx stats.cmx proverapi.cmx linux/Perf.cmx \
-    parser.cmx lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx \
-    assertions.cmx
 z3prover.cmo : proverapi.cmx linux/Perf.cmx
 z3prover.cmx : proverapi.cmx linux/Perf.cmx
 verifastPluginReduxSmtlib.cmo : verifast.cmx smtlibprover.cmx smtlib.cmx \
@@ -106,16 +100,24 @@ vfstrip.cmo :
 vfstrip.cmx :
 verifast0.cmo : util.cmx ast.cmx
 verifast0.cmx : util.cmx ast.cmx
+verifast.cmo : vfversion.cmi verify_expr.cmx verifast1.cmx verifast0.cmx \
+    util.cmx linux/Stopwatch.cmi stats.cmx proverapi.cmx linux/Perf.cmx \
+    parser.cmx lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx \
+    assertions.cmx
+verifast.cmx : vfversion.cmx verify_expr.cmx verifast1.cmx verifast0.cmx \
+    util.cmx linux/Stopwatch.cmx stats.cmx proverapi.cmx linux/Perf.cmx \
+    parser.cmx lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx \
+    assertions.cmx
 verifastPluginZ3v2.cmo : z3v2prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3v2.cmx : z3v2prover.cmx verifast.cmx proverapi.cmx
-smtlib.cmo :
-smtlib.cmx :
 stats.cmo : util.cmx linux/Stopwatch.cmi linux/Perf.cmx ast.cmx
 stats.cmx : util.cmx linux/Stopwatch.cmx linux/Perf.cmx ast.cmx
 mysh.cmo : vfconfig.cmx Fonts.cmx
 mysh.cmx : vfconfig.cmx Fonts.cmx
 verifastPluginZ3v4.cmo : z3v4prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3v4.cmx : z3v4prover.cmx verifast.cmx proverapi.cmx
+smtlib.cmo :
+smtlib.cmx :
 record_backtrace.cmo :
 record_backtrace.cmx :
 SExpressions.cmo : SExpressions.cmi
@@ -126,6 +128,8 @@ branchright_png.cmo :
 branchright_png.cmx :
 mynum.cmo :
 mynum.cmx :
+proverapi.cmo :
+proverapi.cmx :
 verifastPluginZ3v4dot5.cmo : z3v4dot5prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3v4dot5.cmx : z3v4dot5prover.cmx verifast.cmx proverapi.cmx
 SExpressionEmitter.cmi : SExpressions.cmi ast.cmx

--- a/src/.depend
+++ b/src/.depend
@@ -1,17 +1,13 @@
 # These dependencies are automatically generated.
 # Do not edit by hand. To generate, run 'make depend'.
+plugins_private.cmo : plugins.cmi
+plugins_private.cmx : plugins.cmx
 simplex.cmo : linux/Stopwatch.cmi simplex.cmi
 simplex.cmx : linux/Stopwatch.cmx simplex.cmi
-vfconsole.cmo : verifast0.cmx verifast.cmx util.cmx SExpressionEmitter.cmi \
-    linux/Perf.cmx parser.cmx lexer.cmx \
-    java_frontend/java_frontend_bridge.cmx ast.cmx
-vfconsole.cmx : verifast0.cmx verifast.cmx util.cmx SExpressionEmitter.cmx \
-    linux/Perf.cmx parser.cmx lexer.cmx \
-    java_frontend/java_frontend_bridge.cmx ast.cmx
+proverapi.cmo :
+proverapi.cmx :
 redux.cmo : linux/Stopwatch.cmi simplex.cmi proverapi.cmx linux/Perf.cmx
 redux.cmx : linux/Stopwatch.cmx simplex.cmx proverapi.cmx linux/Perf.cmx
-z3v4dot5prover.cmo : proverapi.cmx linux/Perf.cmx
-z3v4dot5prover.cmx : proverapi.cmx linux/Perf.cmx
 Fonts_mac.cmo :
 Fonts_mac.cmx :
 z3v4prover.cmo : proverapi.cmx linux/Perf.cmx
@@ -22,12 +18,16 @@ verify_expr.cmx : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx parser.cmx ast.cmx assertions.cmx
 Mynum_slow.cmo :
 Mynum_slow.cmx :
-verifastPluginZ3v4dot5Smtlib.cmo : z3v4dot5prover.cmx verifast.cmx \
-    smtlibprover.cmx smtlib.cmx proverapi.cmx combineprovers.cmx
-verifastPluginZ3v4dot5Smtlib.cmx : z3v4dot5prover.cmx verifast.cmx \
-    smtlibprover.cmx smtlib.cmx proverapi.cmx combineprovers.cmx
+verifastPluginCvc4.cmo : verifast.cmx smtlibprover.cmx smtlib.cmx \
+    proverapi.cmx
+verifastPluginCvc4.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
+    proverapi.cmx
 util.cmo : proverapi.cmx
 util.cmx : proverapi.cmx
+verifastPluginExternalZ3.cmo : verifast.cmx smtlibprover.cmx smtlib.cmx \
+    proverapi.cmx
+verifastPluginExternalZ3.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
+    proverapi.cmx
 parser.cmo : util.cmx linux/Stopwatch.cmi stats.cmx linux/Perf.cmx lexer.cmx \
     ast.cmx
 parser.cmx : util.cmx linux/Stopwatch.cmx stats.cmx linux/Perf.cmx lexer.cmx \
@@ -36,22 +36,24 @@ tabhunter.cmo :
 tabhunter.cmx :
 smtlibprover.cmo : util.cmx smtlib.cmx proverapi.cmx
 smtlibprover.cmx : util.cmx smtlib.cmx proverapi.cmx
+stopwatch_test.cmo : linux/Stopwatch.cmi
+stopwatch_test.cmx : linux/Stopwatch.cmx
 branchleft_png.cmo :
 branchleft_png.cmx :
+DynType.cmo : DynType.cmi
+DynType.cmx : DynType.cmi
 main_class.cmo :
 main_class.cmx :
-Fonts_default.cmo :
-Fonts_default.cmx :
 combineprovers.cmo : proverapi.cmx
 combineprovers.cmx : proverapi.cmx
 assertions.cmo : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx linux/Perf.cmx parser.cmx ast.cmx
 assertions.cmx : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx linux/Perf.cmx parser.cmx ast.cmx
-verifastPluginCvc4.cmo : verifast.cmx smtlibprover.cmx smtlib.cmx \
-    proverapi.cmx
-verifastPluginCvc4.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
-    proverapi.cmx
+smtlib.cmo :
+smtlib.cmx :
+mysh.cmo : vfconfig.cmx Fonts.cmx
+mysh.cmx : vfconfig.cmx Fonts.cmx
 vfide.cmo : vfversion.cmi verifast0.cmx verifast.cmx util.cmx \
     shape_analysis/shape_analysis_frontend.cmx Printexc_proxy.cmx parser.cmx \
     lexer.cmx java_frontend/java_frontend_bridge.cmx Fonts.cmx \
@@ -62,8 +64,8 @@ vfide.cmx : vfversion.cmx verifast0.cmx verifast.cmx util.cmx \
     branchright_png.cmx branchleft_png.cmx ast.cmx
 Printexc_proxy.cmo :
 Printexc_proxy.cmx :
-stopwatch_test.cmo : linux/Stopwatch.cmi
-stopwatch_test.cmx : linux/Stopwatch.cmx
+plugins2.cmo : plugins_private.cmx plugins2.cmi
+plugins2.cmx : plugins_private.cmx plugins2.cmi
 SExpressionEmitter.cmo : util.cmx SExpressions.cmi ast.cmx \
     SExpressionEmitter.cmi
 SExpressionEmitter.cmx : util.cmx SExpressions.cmx ast.cmx \
@@ -78,18 +80,22 @@ verifastPluginReduxZ3v4dot5.cmx : z3v4dot5prover.cmx verifast.cmx redux.cmx \
     proverapi.cmx combineprovers.cmx
 z3v2prover.cmo : proverapi.cmx linux/Perf.cmx
 z3v2prover.cmx : proverapi.cmx linux/Perf.cmx
-verifast1.cmo : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
-    linux/Perf.cmx parser.cmx lexer.cmx \
-    java_frontend/java_frontend_bridge.cmx ast.cmx
-verifast1.cmx : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
-    linux/Perf.cmx parser.cmx lexer.cmx \
-    java_frontend/java_frontend_bridge.cmx ast.cmx
 lexer.cmo : util.cmx stats.cmx linux/Perf.cmx ast.cmx
 lexer.cmx : util.cmx stats.cmx linux/Perf.cmx ast.cmx
 verifastPluginZ3.cmo : z3prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3.cmx : z3prover.cmx verifast.cmx proverapi.cmx
 ast.cmo : util.cmx
 ast.cmx : util.cmx
+verifastPluginZ3v4dot5Smtlib.cmo : z3v4dot5prover.cmx verifast.cmx \
+    smtlibprover.cmx smtlib.cmx proverapi.cmx combineprovers.cmx
+verifastPluginZ3v4dot5Smtlib.cmx : z3v4dot5prover.cmx verifast.cmx \
+    smtlibprover.cmx smtlib.cmx proverapi.cmx combineprovers.cmx
+verifast1.cmo : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
+    linux/Perf.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx ast.cmx
+verifast1.cmx : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
+    linux/Perf.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx ast.cmx
 z3prover.cmo : proverapi.cmx linux/Perf.cmx
 z3prover.cmx : proverapi.cmx linux/Perf.cmx
 verifastPluginReduxSmtlib.cmo : verifast.cmx smtlibprover.cmx smtlib.cmx \
@@ -98,8 +104,20 @@ verifastPluginReduxSmtlib.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
     redux.cmx proverapi.cmx combineprovers.cmx
 vfstrip.cmo :
 vfstrip.cmx :
+Fonts_default.cmo :
+Fonts_default.cmx :
 verifast0.cmo : util.cmx ast.cmx
 verifast0.cmx : util.cmx ast.cmx
+z3v4dot5prover.cmo : proverapi.cmx linux/Perf.cmx
+z3v4dot5prover.cmx : proverapi.cmx linux/Perf.cmx
+stats.cmo : util.cmx linux/Stopwatch.cmi linux/Perf.cmx ast.cmx
+stats.cmx : util.cmx linux/Stopwatch.cmx linux/Perf.cmx ast.cmx
+vfconsole.cmo : verifast0.cmx verifast.cmx util.cmx SExpressionEmitter.cmi \
+    linux/Perf.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx ast.cmx
+vfconsole.cmx : verifast0.cmx verifast.cmx util.cmx SExpressionEmitter.cmx \
+    linux/Perf.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx ast.cmx
 verifast.cmo : vfversion.cmi verify_expr.cmx verifast1.cmx verifast0.cmx \
     util.cmx linux/Stopwatch.cmi stats.cmx proverapi.cmx linux/Perf.cmx \
     parser.cmx lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx \
@@ -110,14 +128,10 @@ verifast.cmx : vfversion.cmx verify_expr.cmx verifast1.cmx verifast0.cmx \
     assertions.cmx
 verifastPluginZ3v2.cmo : z3v2prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3v2.cmx : z3v2prover.cmx verifast.cmx proverapi.cmx
-stats.cmo : util.cmx linux/Stopwatch.cmi linux/Perf.cmx ast.cmx
-stats.cmx : util.cmx linux/Stopwatch.cmx linux/Perf.cmx ast.cmx
-mysh.cmo : vfconfig.cmx Fonts.cmx
-mysh.cmx : vfconfig.cmx Fonts.cmx
+plugins.cmo : DynType.cmi plugins.cmi
+plugins.cmx : DynType.cmx plugins.cmi
 verifastPluginZ3v4.cmo : z3v4prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3v4.cmx : z3v4prover.cmx verifast.cmx proverapi.cmx
-smtlib.cmo :
-smtlib.cmx :
 record_backtrace.cmo :
 record_backtrace.cmx :
 SExpressions.cmo : SExpressions.cmi
@@ -128,15 +142,13 @@ branchright_png.cmo :
 branchright_png.cmx :
 mynum.cmo :
 mynum.cmx :
-proverapi.cmo :
-proverapi.cmx :
 verifastPluginZ3v4dot5.cmo : z3v4dot5prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3v4dot5.cmx : z3v4dot5prover.cmx verifast.cmx proverapi.cmx
-SExpressionEmitter.cmi : SExpressions.cmi ast.cmx
 DynType.cmi :
 plugins2.cmi : plugins.cmi
-SExpressions.cmi :
+SExpressionEmitter.cmi : SExpressions.cmi ast.cmx
 plugins.cmi : DynType.cmi
+SExpressions.cmi :
 simplex.cmi :
 vfversion.cmi :
 linux/Stopwatch.cmo : linux/Stopwatch.cmi

--- a/src/.depend
+++ b/src/.depend
@@ -50,8 +50,8 @@ assertions.cmo : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx linux/Perf.cmx parser.cmx ast.cmx
 assertions.cmx : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx linux/Perf.cmx parser.cmx ast.cmx
-smtlib.cmo :
-smtlib.cmx :
+smtlib.cmo : util.cmx
+smtlib.cmx : util.cmx
 mysh.cmo : vfconfig.cmx Fonts.cmx
 mysh.cmx : vfconfig.cmx Fonts.cmx
 vfide.cmo : vfversion.cmi verifast0.cmx verifast.cmx util.cmx \
@@ -64,8 +64,6 @@ vfide.cmx : vfversion.cmx verifast0.cmx verifast.cmx util.cmx \
     branchright_png.cmx branchleft_png.cmx ast.cmx
 Printexc_proxy.cmo :
 Printexc_proxy.cmx :
-plugins2.cmo : plugins_private.cmx plugins2.cmi
-plugins2.cmx : plugins_private.cmx plugins2.cmi
 SExpressionEmitter.cmo : util.cmx SExpressions.cmi ast.cmx \
     SExpressionEmitter.cmi
 SExpressionEmitter.cmx : util.cmx SExpressions.cmx ast.cmx \
@@ -74,12 +72,22 @@ verifastPluginRedux.cmo : verifast.cmx redux.cmx proverapi.cmx
 verifastPluginRedux.cmx : verifast.cmx redux.cmx proverapi.cmx
 java_card_applet.cmo :
 java_card_applet.cmx :
+mynum.cmo :
+mynum.cmx :
 verifastPluginReduxZ3v4dot5.cmo : z3v4dot5prover.cmx verifast.cmx redux.cmx \
     proverapi.cmx combineprovers.cmx
 verifastPluginReduxZ3v4dot5.cmx : z3v4dot5prover.cmx verifast.cmx redux.cmx \
     proverapi.cmx combineprovers.cmx
 z3v2prover.cmo : proverapi.cmx linux/Perf.cmx
 z3v2prover.cmx : proverapi.cmx linux/Perf.cmx
+plugins2.cmo : plugins_private.cmx plugins2.cmi
+plugins2.cmx : plugins_private.cmx plugins2.cmi
+verifast1.cmo : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
+    linux/Perf.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx ast.cmx
+verifast1.cmx : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
+    linux/Perf.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx ast.cmx
 lexer.cmo : util.cmx stats.cmx linux/Perf.cmx ast.cmx
 lexer.cmx : util.cmx stats.cmx linux/Perf.cmx ast.cmx
 verifastPluginZ3.cmo : z3prover.cmx verifast.cmx proverapi.cmx
@@ -90,12 +98,6 @@ verifastPluginZ3v4dot5Smtlib.cmo : z3v4dot5prover.cmx verifast.cmx \
     smtlibprover.cmx smtlib.cmx proverapi.cmx combineprovers.cmx
 verifastPluginZ3v4dot5Smtlib.cmx : z3v4dot5prover.cmx verifast.cmx \
     smtlibprover.cmx smtlib.cmx proverapi.cmx combineprovers.cmx
-verifast1.cmo : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
-    linux/Perf.cmx parser.cmx lexer.cmx \
-    java_frontend/java_frontend_bridge.cmx ast.cmx
-verifast1.cmx : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
-    linux/Perf.cmx parser.cmx lexer.cmx \
-    java_frontend/java_frontend_bridge.cmx ast.cmx
 z3prover.cmo : proverapi.cmx linux/Perf.cmx
 z3prover.cmx : proverapi.cmx linux/Perf.cmx
 verifastPluginReduxSmtlib.cmo : verifast.cmx smtlibprover.cmx smtlib.cmx \
@@ -140,8 +142,6 @@ dlsymtool.cmo :
 dlsymtool.cmx :
 branchright_png.cmo :
 branchright_png.cmx :
-mynum.cmo :
-mynum.cmx :
 verifastPluginZ3v4dot5.cmo : z3v4dot5prover.cmx verifast.cmx proverapi.cmx
 verifastPluginZ3v4dot5.cmx : z3v4dot5prover.cmx verifast.cmx proverapi.cmx
 DynType.cmi :

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -273,7 +273,7 @@ $(STDLIB): $(STDLIB_FILES)
 	@echo "  VERIFAST " $@
 	${VERIFAST} -shared $(STDLIB_FILES) -emit_dll_vfmanifest \
 	  -emit_dll_vfmanifest_as $@  || (rm -f $(STDLIB) ; false)
-	
+
 ../bin/%.vfmanifest: ../bin/%.c ../bin/%.gh ../bin/verifast$(DOTEXE)
 	$(SET_ENV); ../bin/verifast -c -emit_vfmanifest ../bin/$*.c
 clean::

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -388,7 +388,7 @@ endif
 	  parser.cmx ${JAVA_FE_INCLS} verifast0.cmx verifast1.cmx assertions.cmx \
 	  verify_expr.cmx verifast.cmx combineprovers.cmx \
           simplex.cmx redux.cmx verifastPluginRedux.ml \
-          smtlib.cmx smtlibprover.cmx verifastPluginReduxSmtlib.ml \
+          smtlib.cmx smtlibprover.cmx verifastPluginCvc4.ml verifastPluginReduxSmtlib.ml \
           $(Z3ARGS_EARLY) \
 	  shape_analysis/shape_analysis_backend.cmx \
 	  shape_analysis/changelog.cmx shape_analysis/shape_analysis_frontend.cmx \
@@ -408,7 +408,7 @@ vfide: ../bin/vfide$(DOTEXE) $(STDLIB)
 	  util.cmx ast.cmx stats.cmx lexer.cmx parser.cmx \
 	  ${JAVA_FE_INCLS} verifast0.cmx verifast1.cmx assertions.cmx \
 	  verify_expr.cmx verifast.cmx simplex.cmx redux.cmx combineprovers.cmx \
-          smtlib.cmx smtlibprover.cmx verifastPluginReduxSmtlib.ml \
+          smtlib.cmx smtlibprover.cmx verifastPluginCvc4.ml verifastPluginReduxSmtlib.ml \
           $(Z3ARGS_EARLY) \
 	  verifastPluginRedux.ml $(Z3ARGS) vfconsole.cmx
 

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -388,7 +388,7 @@ endif
 	  parser.cmx ${JAVA_FE_INCLS} verifast0.cmx verifast1.cmx assertions.cmx \
 	  verify_expr.cmx verifast.cmx combineprovers.cmx \
           simplex.cmx redux.cmx verifastPluginRedux.ml \
-          smtlib.cmx smtlibprover.cmx verifastPluginCvc4.ml verifastPluginReduxSmtlib.ml \
+          smtlib.cmx smtlibprover.cmx verifastPluginCvc4.ml verifastPluginExternalZ3.ml verifastPluginReduxSmtlib.ml \
           $(Z3ARGS_EARLY) \
 	  shape_analysis/shape_analysis_backend.cmx \
 	  shape_analysis/changelog.cmx shape_analysis/shape_analysis_frontend.cmx \
@@ -408,7 +408,7 @@ vfide: ../bin/vfide$(DOTEXE) $(STDLIB)
 	  util.cmx ast.cmx stats.cmx lexer.cmx parser.cmx \
 	  ${JAVA_FE_INCLS} verifast0.cmx verifast1.cmx assertions.cmx \
 	  verify_expr.cmx verifast.cmx simplex.cmx redux.cmx combineprovers.cmx \
-          smtlib.cmx smtlibprover.cmx verifastPluginCvc4.ml verifastPluginReduxSmtlib.ml \
+          smtlib.cmx smtlibprover.cmx verifastPluginCvc4.ml verifastPluginExternalZ3.ml verifastPluginReduxSmtlib.ml \
           $(Z3ARGS_EARLY) \
 	  verifastPluginRedux.ml $(Z3ARGS) vfconsole.cmx
 

--- a/src/verifastPluginCvc4.ml
+++ b/src/verifastPluginCvc4.ml
@@ -1,0 +1,13 @@
+module Sp = Smtlibprover
+module S = Smtlib
+module P = Proverapi
+
+let _ =
+  Verifast.register_prover "cvc4"
+    "\brun CVC4."
+    (
+      fun client ->
+      let cvc4_ctxt =
+        Sp.external_smtlib_ctxt "cvc4 --incremental --lang smt" in
+      client#run cvc4_ctxt
+    )

--- a/src/verifastPluginCvc4.ml
+++ b/src/verifastPluginCvc4.ml
@@ -8,6 +8,9 @@ let _ =
     (
       fun client ->
       let cvc4_ctxt =
-        Sp.external_smtlib_ctxt "cvc4 --incremental --lang smt" in
+        Sp.external_smtlib_ctxt
+          "cvc4 --incremental --lang smt"
+          ["cvc4"; "I"; "Q"; "NDT"; "LIA"; "LRA"]
+      in
       client#run cvc4_ctxt
     )

--- a/src/verifastPluginExternalZ3.ml
+++ b/src/verifastPluginExternalZ3.ml
@@ -1,0 +1,14 @@
+module Sp = Smtlibprover
+module S = Smtlib
+module P = Proverapi
+
+let _ =
+  Verifast.register_prover "ext_z3"
+    "\brun Z3 as an external prover. This is to measure the impact of communicating with Z3 using a pipe instead of the API. This is also more portable."
+    (
+      fun client ->
+      let z3_ctxt =
+        Sp.external_smtlib_ctxt "z3 -in -smt2 smt.auto_config=false smt.mbqi=false auto_config=false model=false type_check=true well_sorted_check=true"
+      in
+      client#run z3_ctxt
+    )

--- a/src/verifastPluginExternalZ3.ml
+++ b/src/verifastPluginExternalZ3.ml
@@ -8,7 +8,9 @@ let _ =
     (
       fun client ->
       let z3_ctxt =
-        Sp.external_smtlib_ctxt "z3 -in -smt2 smt.auto_config=false smt.mbqi=false auto_config=false model=false type_check=true well_sorted_check=true"
+        Sp.external_smtlib_ctxt
+          "z3 -in -smt2 smt.auto_config=false smt.mbqi=false auto_config=false model=false type_check=true well_sorted_check=true"
+          ["z3"; "I"; "Q"; "NDT"; "LIA"; "LRA"]
       in
       client#run z3_ctxt
     )

--- a/src/verifastPluginReduxSmtlib.ml
+++ b/src/verifastPluginReduxSmtlib.ml
@@ -13,9 +13,6 @@ let _ =
         (new R.context ():
            R.context :> (unit, R.symbol, (R.symbol, R.termnode) R.term) P.context)
       in
-      let smtlib_ctxt =
-        (new Sp.smtlib_context():
-           Sp.smtlib_context :> (S.sort, S.symbol, S.term) P.context)
-      in
+      let smtlib_ctxt = Sp.dump_smtlib_ctxt "redux_dump.smt2" in
       client#run (C.combine redux_ctxt smtlib_ctxt C.Sync)
     )

--- a/src/verifastPluginReduxSmtlib.ml
+++ b/src/verifastPluginReduxSmtlib.ml
@@ -13,6 +13,10 @@ let _ =
         (new R.context ():
            R.context :> (unit, R.symbol, (R.symbol, R.termnode) R.term) P.context)
       in
-      let smtlib_ctxt = Sp.dump_smtlib_ctxt "redux_dump.smt2" in
+      let smtlib_ctxt =
+        Sp.dump_smtlib_ctxt
+          "redux_dump.smt2"
+          ["dump"; "I"; "Q"; "NDT"; "LIA"; "LRA"]
+      in
       client#run (C.combine redux_ctxt smtlib_ctxt C.Sync)
     )

--- a/src/verifastPluginZ3v4dot5Smtlib.ml
+++ b/src/verifastPluginZ3v4dot5Smtlib.ml
@@ -14,6 +14,10 @@ let _ =
         (new Z.z3_context():
            Z.z3_context :> (Zn.sort, Zn.func_decl, Zn.ast) P.context)
       in
-      let smtlib_ctxt = Sp.dump_smtlib_ctxt "z3_v4dot5_dump.smt2" in
+      let smtlib_ctxt =
+        Sp.dump_smtlib_ctxt
+          "z3_v4dot5_dump.smt2"
+          ["dump"; "I"; "Q"; "NDT"; "LIA"; "LRA"]
+      in
       client#run (C.combine z3_ctxt smtlib_ctxt C.Sync)
     )

--- a/src/verifastPluginZ3v4dot5Smtlib.ml
+++ b/src/verifastPluginZ3v4dot5Smtlib.ml
@@ -14,9 +14,6 @@ let _ =
         (new Z.z3_context():
            Z.z3_context :> (Zn.sort, Zn.func_decl, Zn.ast) P.context)
       in
-      let smtlib_ctxt =
-        (new Sp.smtlib_context():
-           Sp.smtlib_context :> (S.sort, S.symbol, S.term) P.context)
-      in
+      let smtlib_ctxt = Sp.dump_smtlib_ctxt "z3_v4dot5_dump.smt2" in
       client#run (C.combine z3_ctxt smtlib_ctxt C.Sync)
     )


### PR DESCRIPTION
This adds support for the CVC4 SMT solver (option `-prover cvc4`)
using the SMTLib interface.