### PR TITLE
Introduce predicate_nonempty

### DIFF
--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -18,19 +18,19 @@ lemma void div_rem(int D, int d);
     requires d != 0;
     ensures D == D / d * d + D % d &*& abs(D % d) < abs(d) &*& abs(D / d * d) <= abs(D);
 
-predicate character(char *p; char c);
-predicate u_character(unsigned char *p; unsigned char c);
+predicate_nonempty character(char *p; char c);
+predicate_nonempty u_character(unsigned char *p; unsigned char c);
 
-predicate integer(int *p; int v);
-predicate u_integer(unsigned int *p; unsigned int v);
+predicate_nonempty integer(int *p; int v);
+predicate_nonempty u_integer(unsigned int *p; unsigned int v);
 
-predicate llong_integer(long long *p; long long l);
-predicate u_llong_integer(unsigned long long *p; unsigned long long l);
+predicate_nonempty llong_integer(long long *p; long long l);
+predicate_nonempty u_llong_integer(unsigned long long *p; unsigned long long l);
 
-predicate short_integer(short *p; short s);
-predicate u_short_integer(unsigned short *p; unsigned short v);
+predicate_nonempty short_integer(short *p; short s);
+predicate_nonempty u_short_integer(unsigned short *p; unsigned short v);
 
-predicate pointer(void **pp; void *p);
+predicate_nonempty pointer(void **pp; void *p);
 
 lemma void character_limits(char *pc);
     requires [?f]character(pc, ?c);
@@ -368,6 +368,7 @@ predicate malloc_block_ullongs(unsigned long long *p; int count) = malloc_block(
 
 /*@
 
+// TODO: could be marked predicate_nonempty if bodies were accepted
 predicate string(char *s; list<char> cs) =
     character(s, ?c) &*&
     c == 0 ?

--- a/examples/linking/simple_pred/prelude_redef.c
+++ b/examples/linking/simple_pred/prelude_redef.c
@@ -1,4 +1,4 @@
-//@ predicate integer(int *p; int v) = false &*& v == 0;
+//@ predicate malloc_block(void *p; int size) = false &*& size == 0;
 
 int main() //@ : main
     //@ requires true;

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -636,13 +636,15 @@ and sexpr_of_decl (decl : decl) : sexpression =
                       index_count,
                       params,
                       precise,
-                      inductiveness) ->
+                      inductiveness,
+                      nonemptiness) ->
       build_list [ Symbol "declare-predicate-family"
                  ; Symbol name ]
                  [ "type-parameters", List (List.map symbol tparams)
                  ; "parameters", List (List.map sexpr_of_type_expr params)
                  ; "index-count", sexpr_of_int index_count
-                 ; "coinductive", sexpr_of_bool (inductiveness = Inductiveness_CoInductive)]
+                 ; "coinductive", sexpr_of_bool (inductiveness = Inductiveness_CoInductive)
+                 ; "non-empty", sexpr_of_bool nonemptiness ]
     | PredFamilyInstanceDecl (loc,
                               name,
                               tparams,

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -120,7 +120,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       ((g1, literal1), (g2, literal2)) -> if literal1 && literal2 then g1 == g2 else definitely_equal g1 g2
   
   let assume_field h0 fparent fname frange fghost tp tv tcoef cont =
-    let (_, (_, _, _, _, symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+    let (_, (_, _, _, _, symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
     if fghost = Real then begin
       match frange with
         Int (_, _) | PtrType _ ->
@@ -219,7 +219,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     match p with
     | WPointsTo (l, WRead (lr, e, fparent, fname, frange, fstatic, fvalue, fghost), tp, rhs) ->
       if fstatic then
-        let (_, (_, _, _, _, symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+        let (_, (_, _, _, _, symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
         evalpat (fghost = Ghost) ghostenv env rhs tp tp $. fun ghostenv env t ->
         produce_chunk h (symb, true) [] coef (Some 0) [t] None $. fun h ->
         cont h ghostenv env
@@ -260,7 +260,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let Some term = try_assoc g#name env in ((term, false), pats0, pats, g#domain, None)
        else
           begin match try_assoc g#name predfammap with
-            Some (_, _, _, declared_paramtypes, symb, _, _) -> ((symb, true), pats0, pats, g#domain, Some (g#name, declared_paramtypes))
+            Some (_, _, _, declared_paramtypes, symb, _, _, _) -> ((symb, true), pats0, pats, g#domain, Some (g#name, declared_paramtypes))
           | None ->
             let PredCtorInfo (_, ps1, ps2, inputParamCount, body, funcsym) = List.assoc g#name predctormap in
             let ctorargs = List.map (function LitPat e -> ev e | _ -> static_error l "Patterns are not supported in predicate constructor argument positions." None) pats0 in
@@ -584,11 +584,11 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | Some v -> v
 
   let read_field h env l t fparent fname =
-    let (_, (_, _, _, _, f_symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+    let (_, (_, _, _, _, f_symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
     lookup_points_to_chunk h env l f_symb t
   
   let read_static_field h env l fparent fname =
-    let (_, (_, _, _, _, f_symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+    let (_, (_, _, _, _, f_symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
     match extract (function Chunk (g, targs, coef, arg0::args, size) when predname_eq (f_symb, true) g -> Some arg0 | _ -> None) h with
       None -> assert_false h env l ("No matching heap chunk: " ^ ctxt#pprint f_symb) None
     | Some (v, _) -> v
@@ -743,8 +743,8 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let (g, inputParamCount) = match inputParamCount with 
             Some (n) -> (g, inputParamCount)
           | None when not (snd g) ->
-            begin match try_find (fun (_, (_, _, _, _, symb, _, _)) -> symb == fst(g)) predfammap with
-              Some (_, (_, _, _, _, symb, inputParamCount, _)) -> ((symb, true), inputParamCount)
+            begin match try_find (fun (_, (_, _, _, _, symb, _, _, _)) -> symb == fst(g)) predfammap with
+              Some (_, (_, _, _, _, symb, inputParamCount, _, _)) -> ((symb, true), inputParamCount)
             | None -> begin match try_assq (fst g) !pred_ctor_applications with
                 None -> (g, None)
               | Some (funsym, funterm, args, inputParamCount) -> (g, inputParamCount)
@@ -863,7 +863,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let points_to l coefpat e tp rhs =
       match e with
         WRead (lr, e, fparent, fname, frange, fstatic, fvalue, fghost) ->
-        let (_, (_, _, _, _, symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+        let (_, (_, _, _, _, symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
         let (inputParamCount, pats) =
           if fstatic then
             (Some 0, [rhs])
@@ -902,8 +902,8 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let (g_symb, pats0, pats, types) =
         if is_global_predref then
            match try_assoc g#name predfammap with
-            Some (_, _, _, _, symb, _, _) -> ((symb, true), pats0, pats, g#domain)
-          | None -> 
+            Some (_, _, _, _, symb, _, _, _) -> ((symb, true), pats0, pats, g#domain)
+          | None ->
             let PredCtorInfo (_, ps1, ps2, inputParamCount, body, funcsym) = List.assoc g#name predctormap in
             let ctorargs = List.map (function SrcPat (LitPat e) -> ev e | _ -> static_error l "Patterns are not supported in predicate constructor argument positions." None) pats0 in
             let g_symb = mk_app funcsym ctorargs in
@@ -1132,7 +1132,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match wbody with
         WPointsTo(_, WRead(lr, e, fparent, fname, frange, fstatic, fvalue, fghost), tp, v) ->
         if expr_is_fixed inputParameters e || fstatic then
-          let (_, (_, _, _, _, qsymb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+          let (_, (_, _, _, _, qsymb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
           construct_edge qsymb coef None [] [] (if fstatic then [] else [e]) conds
         else
           []
@@ -1141,7 +1141,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           Some _ -> []
         | None ->
           begin match try_assoc q#name predfammap with
-            Some (_, qtparams, _, qtps, qsymb, _, _) ->
+            Some (_, qtparams, _, qtps, qsymb, _, _, _) ->
             begin match q#inputParamCount with
               None -> assert false;
             | Some qInputParamCount ->
@@ -1231,8 +1231,8 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           find_edges construct_edge inputParameters xs wbody0
       )
       predinstmap
-  
-  let predicate_ctor_contains_edges = 
+
+  let predicate_ctor_contains_edges =
     predctormap |> flatmap
       (fun (g, PredCtorInfo (l, ps1, ps2, inputParamCount, wbody0, (psymbol, psymbol_term))) ->
         match inputParamCount with

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -646,7 +646,8 @@ and
       int (* number of indices *) *
       type_expr list *
       int option (* (Some n) means the predicate is precise and the first n parameters are input parameters *) *
-      inductiveness
+      inductiveness *
+      bool (* non-emptiness *)
   | PredFamilyInstanceDecl of
       loc *
       string *

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -22,7 +22,7 @@ let common_keywords = [
 let ghost_keywords = [
   "predicate"; "copredicate"; "requires"; "|->"; "&*&"; "inductive"; "fixpoint";
   "ensures"; "close"; "lemma"; "open"; "emp"; "invariant"; "lemma_auto";
-  "_"; "@*/"; "predicate_family"; "predicate_family_instance"; "predicate_ctor"; "leak"; "@";
+  "_"; "@*/"; "predicate_family"; "predicate_family_instance"; "predicate_ctor"; "predicate_nonempty"; "leak"; "@";
   "box_class"; "action"; "handle_predicate"; "preserved_by"; "consuming_box_predicate"; "consuming_handle_predicate"; "perform_action"; "nonghost_callers_only";
   "create_box"; "above"; "below"; "and_handle"; "and_fresh_handle"; "create_handle"; "create_fresh_handle"; "dispose_box"; 
   "produce_lemma_function_pointer_chunk"; "duplicate_lemma_function_pointer_chunk"; "produce_function_pointer_chunk";
@@ -510,22 +510,28 @@ and
       (ps, inputParamCount) = (parser [< '(_, Kwd ";"); ps' = rep_comma parse_param >] -> (ps @ ps', Some (List.length ps)) | [< >] -> (ps, None)); '(_, Kwd ")")
     >] -> (ps, inputParamCount)
 and
-  parse_predicate_decl l (inductiveness: inductiveness) = parser 
-    [< '(li, Ident g); tparams = parse_type_params li; 
+  parse_predicate_decl l (inductiveness: inductiveness) nonempty = parser
+    [< '(li, Ident g); tparams = parse_type_params li;
      (ps, inputParamCount) = parse_pred_paramlist;
      body = opt parse_pred_body;
      '(_, Kwd ";");
     >] ->
-    [PredFamilyDecl (l, g, tparams, 0, List.map (fun (t, p) -> t) ps, inputParamCount, inductiveness)] @
-    (match body with None -> [] | Some body -> [PredFamilyInstanceDecl (l, g, tparams, [], ps, body)])
+    [PredFamilyDecl (l, g, tparams, 0, List.map (fun (t, p) -> t) ps, inputParamCount, inductiveness, nonempty)] @
+    (match body with
+     | None -> []
+     | Some body ->
+       if nonempty then
+         static_error l "nonempty not allowed when a body is provided (TODO)" None;
+       [PredFamilyInstanceDecl (l, g, tparams, [], ps, body)])
 and
   parse_pure_decl = parser
     [< '(l, Kwd "inductive"); '(li, Ident i); tparams = parse_type_params li; '(_, Kwd "="); cs = (parser [< cs = parse_ctors >] -> cs | [< cs = parse_ctors_suffix >] -> cs); '(_, Kwd ";") >] -> [Inductive (l, i, tparams, cs)]
   | [< '(l, Kwd "fixpoint"); t = parse_return_type; d = parse_func_rest Fixpoint t Public>] -> [d]
-  | [< '(l, Kwd "predicate"); result = parse_predicate_decl l Inductiveness_Inductive >] -> result
-  | [< '(l, Kwd "copredicate"); result = parse_predicate_decl l Inductiveness_CoInductive >] -> result
+  | [< '(l, Kwd "predicate"); result = parse_predicate_decl l Inductiveness_Inductive false >] -> result
+  | [< '(l, Kwd "predicate_nonempty"); result = parse_predicate_decl l Inductiveness_Inductive true >] -> result
+  | [< '(l, Kwd "copredicate"); result = parse_predicate_decl l Inductiveness_CoInductive false >] -> result
   | [< '(l, Kwd "predicate_family"); '(_, Ident g); is = parse_paramlist; (ps, inputParamCount) = parse_pred_paramlist; '(_, Kwd ";") >]
-  -> [PredFamilyDecl (l, g, [], List.length is, List.map (fun (t, p) -> t) ps, inputParamCount, Inductiveness_Inductive)]
+  -> [PredFamilyDecl (l, g, [], List.length is, List.map (fun (t, p) -> t) ps, inputParamCount, Inductiveness_Inductive, false)]
   | [< '(l, Kwd "predicate_family_instance"); '(_, Ident g); is = parse_index_list; ps = parse_paramlist;
      p = parse_pred_body; '(_, Kwd ";"); >] -> [PredFamilyInstanceDecl (l, g, [], is, ps, p)]
   | [< '(l, Kwd "predicate_ctor"); '(_, Ident g); ps1 = parse_paramlist; (ps2, inputParamCount) = parse_pred_paramlist;

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -570,6 +570,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * termnode
       * int option (* number of input parameters; None if not precise *)
       * inductiveness
+      * bool (* non empty *)
     type malloc_block_pred_info =
         string (* predicate name *)
       * pred_fam_info
@@ -2060,13 +2061,13 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   (* Region: predicate families *)
   
-  let mk_predfam p l tparams arity ts inputParamCount inductiveness =
-    (p, (l, tparams, arity, ts, get_unique_var_symb p (PredType (tparams, ts, inputParamCount, inductiveness)), inputParamCount, inductiveness))
+  let mk_predfam p l tparams arity ts inputParamCount inductiveness nonempty =
+    (p, (l, tparams, arity, ts, get_unique_var_symb p (PredType (tparams, ts, inputParamCount, inductiveness)), inputParamCount, inductiveness, nonempty))
 
   let struct_padding_predfams1 =
     flatmap
       (function
-         (sn, (l, fds, Some padding_predsymb, size)) -> [("struct_" ^ sn ^ "_padding", (l, [], 0, [PtrType (StructType sn)], padding_predsymb, Some 1, Inductiveness_Inductive))]
+         (sn, (l, fds, Some padding_predsymb, size)) -> [("struct_" ^ sn ^ "_padding", (l, [], 0, [PtrType (StructType sn)], padding_predsymb, Some 1, Inductiveness_Inductive, false))]
        | _ -> [])
       structmap1
   
@@ -2076,7 +2077,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let predfammaps =
           if gh = Ghost || ftxmap <> [] || tparams <> [] then
             let paramtypes = [PtrType (FuncType g)] @ List.map snd ftxmap in
-            [mk_predfam (full_name pn ("is_" ^ g0)) l tparams 0 paramtypes (Some (List.length paramtypes)) Inductiveness_Inductive]
+            [mk_predfam (full_name pn ("is_" ^ g0)) l tparams 0 paramtypes (Some (List.length paramtypes)) Inductiveness_Inductive false]
           else
             []
         in
@@ -2088,7 +2089,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let malloc_block_pred_map1: malloc_block_pred_info map = 
     structmap1 |> flatmap begin function
-      (sn, (l, Some _, _, _)) -> [(sn, mk_predfam ("malloc_block_" ^ sn) l [] 0 [PtrType (StructType sn)] (Some 1) Inductiveness_Inductive)]
+      (sn, (l, Some _, _, _)) -> [(sn, mk_predfam ("malloc_block_" ^ sn) l [] 0 [PtrType (StructType sn)] (Some 1) Inductiveness_Inductive false)]
     | _ -> []
     end
   
@@ -2101,8 +2102,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         fds |> List.map begin fun (fn, {fl; ft; fbinding}) ->
           let predfam =
             match fbinding with
-              Static -> mk_predfam (cn ^ "_" ^ fn) fl [] 0 [ft] (Some 0) Inductiveness_Inductive
-            | Instance -> mk_predfam (cn ^ "_" ^ fn) fl [] 0 [ObjType cn; ft] (Some 1) Inductiveness_Inductive
+              Static -> mk_predfam (cn ^ "_" ^ fn) fl [] 0 [ft] (Some 0) Inductiveness_Inductive false
+            | Instance -> mk_predfam (cn ^ "_" ^ fn) fl [] 0 [ObjType cn; ft] (Some 1) Inductiveness_Inductive false
           in
           ((cn, fn), predfam)
         end
@@ -2115,35 +2116,35 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
          | Some fds ->
            List.map
              (fun (fn, (l, gh, t, offset)) ->
-              ((sn, fn), mk_predfam (sn ^ "_" ^ fn) l [] 0 [PtrType (StructType sn); t] (Some 1) Inductiveness_Inductive)
+              ((sn, fn), mk_predfam (sn ^ "_" ^ fn) l [] 0 [PtrType (StructType sn); t] (Some 1) Inductiveness_Inductive false)
              )
              fds
       )
       structmap1
-  
+
   let field_pred_map = field_pred_map1 @ field_pred_map0
-  
+
   let structpreds1: pred_fam_info map = List.map (fun (_, p) -> p) malloc_block_pred_map1 @ List.map (fun (_, p) -> p) field_pred_map1 @ struct_padding_predfams1
-  
+
   let predfammap1 =
     let rec iter (pn,ilist) pm ds =
       match ds with
-        PredFamilyDecl (l, p, tparams, arity, tes, inputParamCount, inductiveness)::ds -> let p=full_name pn p in
+        PredFamilyDecl (l, p, tparams, arity, tes, inputParamCount, inductiveness, nonempty)::ds -> let p=full_name pn p in
         let ts = List.map (check_pure_type (pn,ilist) tparams) tes in
         begin
           match try_assoc2' Ghost (pn,ilist) p pm predfammap0 with
-            Some (l0, tparams0, arity0, ts0, symb0, inputParamCount0, inductiveness0) ->
+          | Some (l0, tparams0, arity0, ts0, symb0, inputParamCount0, inductiveness0, nonempty0) ->
             let tpenv =
               match zip tparams0 (List.map (fun x -> TypeParam x) tparams) with
                 None -> static_error l "Predicate family redeclarations declares a different number of type parameters." None
               | Some bs -> bs
             in
             let ts0' = List.map (instantiate_type tpenv) ts0 in
-            if arity <> arity0 || ts <> ts0' || inputParamCount <> inputParamCount0 || inductiveness <> inductiveness0 then
+            if arity <> arity0 || ts <> ts0' || inputParamCount <> inputParamCount0 || inductiveness <> inductiveness0 || nonempty <> nonempty0 then
               static_error l ("Predicate family redeclaration does not match original declaration at '" ^ string_of_loc l0 ^ "'.") None;
             iter (pn,ilist) pm ds
           | None ->
-            iter (pn,ilist) (mk_predfam p l tparams arity ts inputParamCount inductiveness::pm) ds
+            iter (pn,ilist) (mk_predfam p l tparams arity ts inputParamCount inductiveness nonempty::pm) ds
         end
       | _::ds -> iter (pn,ilist) pm ds
       | [] -> List.rev pm
@@ -2175,8 +2176,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           in
           iter [] ps
         in
-        let pfm = mk_predfam bcn l [] 0 (BoxIdType::List.map (fun (x, t) -> t) boxpmap) (Some 1) Inductiveness_Inductive::pfm  in
-        let pfm = mk_predfam default_hpn l [] 0 (HandleIdType::BoxIdType::[]) (Some 1) Inductiveness_Inductive::pfm in
+        let pfm = mk_predfam bcn l [] 0 (BoxIdType::List.map (fun (x, t) -> t) boxpmap) (Some 1) Inductiveness_Inductive false::pfm  in
+        let pfm = mk_predfam default_hpn l [] 0 (HandleIdType::BoxIdType::[]) (Some 1) Inductiveness_Inductive false::pfm in
         let (pfm, amap) =
           let rec iter pfm amap ads =
             match ads with
@@ -2206,8 +2207,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   if List.mem_assoc action_permission_pred_name pfm || List.mem_assoc action_permission_pred_name purefuncmap0 then static_error l "Action permission name clashes with existing predicate name." None;
                   let action_permission_pred_param_types = BoxIdType :: (List.map (fun (x, t) -> t) pmap) in
                   let action_permission_pred_inputParamCount = Some (1 + nb_action_parameters) in
-                  let action_permission_pred = (mk_predfam action_permission_pred_name l [] 0 action_permission_pred_param_types action_permission_pred_inputParamCount) Inductiveness_Inductive in
-                  let  (_, (_, _, _, _, action_permission_pred_symb, _, Inductiveness_Inductive)) = action_permission_pred in
+                  let action_permission_pred = (mk_predfam action_permission_pred_name l [] 0 action_permission_pred_param_types action_permission_pred_inputParamCount) Inductiveness_Inductive false in
+                  let  (_, (_, _, _, _, action_permission_pred_symb, _, Inductiveness_Inductive, _)) = action_permission_pred in
                   let (_, _, _, _, is_action_permissionx_symb) = List.assoc ("is_action_permission" ^ (string_of_int nb_action_parameters)) purefuncmap0 in
                   ctxt#assert_term (mk_app is_action_permissionx_symb [action_permission_pred_symb]);
                   if ps = [] then
@@ -2216,11 +2217,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                     assert (List.length ps = 1);
                     let action_permission_dispenser_pred_name = action_permission_pred_name ^ "_dispenser" in
                     if List.mem_assoc action_permission_dispenser_pred_name pfm || List.mem_assoc action_permission_dispenser_pred_name purefuncmap0 then static_error l "Action permission name clashes with existing predicate name." None;
-                    let [(_, action_param_type)] = pmap in 
+                    let [(_, action_param_type)] = pmap in
                     let action_permission_dispenser_pred_param_types = [BoxIdType; InductiveType("list", [action_param_type])] in
                     let action_permission_dispenser_pred_inputParamCount = Some 2 in
-                    let action_permission_dispenser_pred = (mk_predfam action_permission_dispenser_pred_name l [] 0  action_permission_dispenser_pred_param_types action_permission_dispenser_pred_inputParamCount Inductiveness_Inductive) in
-                    let  (_, (_, _, _, _, action_permission_dispenser_pred_symb, _, _)) = action_permission_dispenser_pred in
+                    let action_permission_dispenser_pred = (mk_predfam action_permission_dispenser_pred_name l [] 0  action_permission_dispenser_pred_param_types action_permission_dispenser_pred_inputParamCount Inductiveness_Inductive false) in
+                    let  (_, (_, _, _, _, action_permission_dispenser_pred_symb, _, _, _)) = action_permission_dispenser_pred in
                     (* assuming is_action_permission1_dispenser(action_permission_dispenser_pred_symb) *)
                     let (_, _, _, _, is_action_permission1_dispenser_symb) = List.assoc "is_action_permission1_dispenser" purefuncmap0 in
                     ctxt#assert_term (mk_app is_action_permission1_dispenser_symb [action_permission_dispenser_pred_symb]);
@@ -2255,20 +2256,20 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 in
                 iter [] ps
               in
-              (match extends with 
+              (match extends with
                 None -> ()
-              | Some(ehn) -> 
+              | Some(ehn) ->
                 if not (List.mem_assoc ehn hpm) then static_error l "Extended handle must appear earlier in same box class." None;
                 let (el, epmap, extendedInv, einv, epbcs) = List.assoc ehn hpm in
-                (match einv with ExprAsn(_, _) -> () | _ -> static_error l "Extended handle's invariant must be pure assertion." None); 
+                (match einv with ExprAsn(_, _) -> () | _ -> static_error l "Extended handle's invariant must be pure assertion." None);
                 if (List.length pmap) < (List.length epmap) then static_error l "Extended handle's parameter list must be prefix of extending handle's parameter list." None;
                 if not
                 (List.for_all2
                   (fun (name1, tp1) (name2, tp2) -> name1 = name2 && tp1 = tp2)
-                  (take (List.length epmap) pmap) epmap) 
+                  (take (List.length epmap) pmap) epmap)
                 then static_error l "Extended handle's parameter list must be prefix of extending handle's parameter list." None;
               );
-              iter (mk_predfam hpn l [] 0 (HandleIdType::BoxIdType::List.map (fun (x, t) -> t) pmap) (Some 1) Inductiveness_Inductive::pfm) ((hpn, (l, pmap, extends, inv, pbcs))::hpm) hpds
+              iter (mk_predfam hpn l [] 0 (HandleIdType::BoxIdType::List.map (fun (x, t) -> t) pmap) (Some 1) Inductiveness_Inductive false::pfm) ((hpn, (l, pmap, extends, inv, pbcs))::hpm) hpds
           in
           iter pfm [] hpds
         in
@@ -2820,7 +2821,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         (WVar (l, x, FuncName), PtrType Void, None)
       | None ->
       match resolve Ghost (pn,ilist) l x predfammap with
-      | Some (x, (_, tparams, arity, ts, _, inputParamCount, inductiveness)) ->
+      | Some (x, (_, tparams, arity, ts, _, inputParamCount, inductiveness, _)) ->
         if arity <> 0 then static_error l "Using a predicate family as a value is not supported." None;
         if tparams <> [] then static_error l "Using a predicate with type parameters as a value is not supported." None;
         (WVar (l, x, PredFamName), PredType (tparams, ts, inputParamCount, inductiveness), None)
@@ -2855,7 +2856,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | PredNameExpr (l, g) ->
       begin
         match resolve Ghost (pn,ilist) l g predfammap with
-          Some (g, (_, tparams, arity, ts, _, inputParamCount, inductiveness)) ->
+          Some (g, (_, tparams, arity, ts, _, inputParamCount, inductiveness, _)) ->
           if arity <> 0 then static_error l "Using a predicate family as a value is not supported." None;
           if tparams <> [] then static_error l "Using a predicate with type parameters as a value is not supported." None;
           (PredNameExpr (l, g), PredType (tparams, ts, inputParamCount, inductiveness), None)
@@ -3894,7 +3895,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | _ -> static_error l (Printf.sprintf "Ambiguous instance predicate assertion: multiple predicates named '%s' in scope" g) None
     end
   
-  let get_pred_symb p = let (_, _, _, _, symb, _, _) = List.assoc p predfammap in symb
+  let get_pred_symb p = let (_, _, _, _, symb, _, _, _) = List.assoc p predfammap in symb
   let get_pure_func_symb g = let (_, _, _, _, symb) = List.assoc g purefuncmap in symb
   
   let lazy_value f =
@@ -4032,7 +4033,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
            Some (PredType (callee_tparams, ts, inputParamCount, inductiveness)) -> cont (new predref (p#name), false, callee_tparams, [], ts, inputParamCount)
          | None | Some _ ->
           begin match resolve Ghost (pn,ilist) l p#name predfammap with
-            Some (pname, (_, callee_tparams, arity, xs, _, inputParamCount, inductiveness)) ->
+            Some (pname, (_, callee_tparams, arity, xs, _, inputParamCount, inductiveness, _)) ->
             let ts0 = match file_type path with
               Java-> list_make arity (ObjType "java.lang.Class")
             | _   -> list_make arity (PtrType Void)
@@ -4050,10 +4051,10 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               Some (ps1, ps2, inputParamCount) ->
               cont (new predref (p#name), true, [], List.map snd ps1, List.map snd ps2, inputParamCount)
             | None ->
-              let error () = 
+              let error () =
                 begin match try_assoc p#name tenv with
-                  None ->  static_error l ("No such predicate: " ^ p#name) None 
-                | Some _ -> static_error l ("Variable " ^ p#name ^ " is not of predicate type.") None 
+                  None ->  static_error l ("No such predicate: " ^ p#name) None
+                | Some _ -> static_error l ("Variable " ^ p#name ^ " is not of predicate type.") None
                 end
               in
               begin match try_assoc "this" tenv with
@@ -4389,7 +4390,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               function
                 (f, (l, Real, t, offset)) ->
                 begin
-                let (g, (_, _, _, _, symb, _, inductiveness)) = List.assoc (sn, f) field_pred_map in (* TODO WILLEM: we moeten die inductiveness ergens gebruiken *)
+                let (g, (_, _, _, _, symb, _, inductiveness, _)) = List.assoc (sn, f) field_pred_map in (* TODO WILLEM: we moeten die inductiveness ergens gebruiken *)
                 let predinst p =
                   p#set_inputParamCount (Some 1);
                   ((g, []),
@@ -4492,7 +4493,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let (p, predfam_tparams, arity, ps, psymb, inputParamCount) =
       match resolve Ghost (pn,ilist) l p predfammap with
         None -> static_error l ("No such predicate family: "^p) None
-      | Some (p, (lfam, predfam_tparams, arity, ps, psymb, inputParamCount, inductiveness)) ->
+      | Some (p, (lfam, predfam_tparams, arity, ps, psymb, inputParamCount, inductiveness, _)) ->
         if fns = [] && language = CLang && l != lfam then begin
           nonabstract_predicates := (p, lfam, l)::!nonabstract_predicates
         end;
@@ -5173,7 +5174,7 @@ let check_if_list_is_defined () =
           LocalVar -> (try List.assoc x env with Not_found -> assert_false [] env l (Printf.sprintf "Unbound variable '%s'" x) None)
         | PureCtor -> let Some (lg, tparams, t, [], s) = try_assoc x purefuncmap in mk_app s []
         | FuncName -> List.assoc x all_funcnameterms
-        | PredFamName -> let Some (_, _, _, _, symb, _, _) = try_assoc x predfammap in symb
+        | PredFamName -> let Some (_, _, _, _, symb, _, _, _) = try_assoc x predfammap in symb
         | EnumElemName n -> ctxt#mk_intlit_of_string (string_of_big_int n)
         | GlobalName ->
           let Some((_, tp, symbol, init)) = try_assoc x globalmap in 
@@ -5190,7 +5191,7 @@ let check_if_list_is_defined () =
         | ModuleName -> List.assoc x modulemap
         | PureFuncName -> let (lg, tparams, t, tps, (fsymb, vsymb)) = List.assoc x purefuncmap in vsymb
       end
-    | PredNameExpr (l, g) -> let Some (_, _, _, _, symb, _, _) = try_assoc g predfammap in cont state symb
+    | PredNameExpr (l, g) -> let Some (_, _, _, _, symb, _, _, _) = try_assoc g predfammap in cont state symb
     | TruncatingExpr (l, CastExpr (lc, ManifestTypeExpr (_, t), e)) ->
       begin
         match (e, t) with

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -105,7 +105,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       cont h coef t)
     
   let get_field h t fparent fname l cont =
-    let (_, (_, _, _, _, f_symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+    let (_, (_, _, _, _, f_symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
     get_points_to h t f_symb l cont
   
   let current_thread_name = "currentThread"
@@ -1173,9 +1173,14 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | BlockStmt(_, decls, ss, _, _) -> (List.flatten (List.map (fun s -> stmt_address_taken s) ss))
     | LabelStmt _ | GotoStmt _ | NoopStmt _ | Break _ | Throw _ | TryFinally _ | TryCatch _ -> []
     | _ -> []
-  
-  let nonempty_pred_symbs = List.map (fun (_, (_, (_, _, _, _, symb, _, _))) -> symb) field_pred_map
-  
+
+  let nonempty_pred_symbs =
+    let prj (_, (_, _, _, _, symb, _, _, _)) = symb in
+    let is_nonempty (_, (_, _, _, _, _, _, _, nonempty)) = nonempty in
+    List.map (fun (_,pred) -> prj pred) field_pred_map @
+    List.map prj (List.filter is_nonempty predfammap)
+
+
   let eval_non_pure_cps ev is_ghost_expr ((h, env) as state) env e cont =
     let assert_term = if is_ghost_expr then None else Some (fun l t msg url -> assert_term t h env l msg url) in
     let read_field =
@@ -1359,7 +1364,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             consume_c_object l (field_address l addr sn f) t h true $. fun h ->
             iter h fields
           | _ ->
-             let (_, (_, _, _, _, f_symb, _, _)) = List.assoc (sn, f) field_pred_map in
+             let (_, (_, _, _, _, f_symb, _, _, _)) = List.assoc (sn, f) field_pred_map in
              consume_chunk rules h [] [] [] l (f_symb, true) [] real_unit (TermPat(real_unit)) (Some 1) [TermPat addr; dummypat] $.
              (fun chunk h coef [_; t] size ghostenv env env' -> iter h fields)
       in
@@ -1435,21 +1440,21 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * string  (* Current lemma *)
       * (string * int * (termnode) list) option  (* Inductive parameter name, its index and paramter list*)
       * bool  (* nonghost_callers_only *)
-  
+
   let leminfo_is_lemma leminfo =
     match leminfo with
       RealFuncInfo (_, _, _) -> false
     | RealMethodInfo _ -> false
     | LemInfo (_, _, _, _) -> true
-  
+
   let should_terminate leminfo =
     match leminfo with
       RealFuncInfo (gs, g, terminates) -> terminates
     | RealMethodInfo rank -> rank <> None
     | LemInfo (lems, g, indinfo, nonghost_callers_only) -> true
-  
+
   let consume_class_call_perm l t h cont =
-    let (_, _, _, _, call_perm__symb, _, _) = List.assoc "java.lang.call_perm_" predfammap in
+    let (_, _, _, _, call_perm__symb, _, _, _) = List.assoc "java.lang.call_perm_" predfammap in
     consume_chunk rules h [] [] [] l (call_perm__symb, true) [] real_unit dummypat (Some 1) [TermPat t] $. fun _ h _ _ _ _ _ _ ->
     cont h
 
@@ -1737,7 +1742,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     in
     let new_array h env l elem_tp length elems =
       let at = get_unique_var_symb (match xo with None -> "array" | Some x -> x) (ArrayType elem_tp) in
-      let (_, _, _, _, array_slice_symb, _, _) = List.assoc "java.lang.array_slice" predfammap in
+      let (_, _, _, _, array_slice_symb, _, _, _) = List.assoc "java.lang.array_slice" predfammap in
       assume (ctxt#mk_not (ctxt#mk_eq at (ctxt#mk_intlit 0))) $. fun () ->
       assume (ctxt#mk_eq (ctxt#mk_app arraylength_symbol [at]) length) $. fun () ->
       cont (Chunk ((array_slice_symb, true), [elem_tp], real_unit, [at; ctxt#mk_intlit 0; length; elems], None)::h) env at
@@ -1746,7 +1751,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match lhs with
         WVar (l, x, scope) -> cont h env (LValues.Var (l, x, scope))
       | WRead (l, w, fparent, fname, tp, fstatic, fvalue, fghost) ->
-        let (_, (_, _, _, _, f_symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+        let (_, (_, _, _, _, f_symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
         begin fun cont ->
           if fstatic then
             cont h env None
@@ -1909,7 +1914,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           produce_c_object l real_unit result t None true false h $. fun h ->
           match t with
             StructType sn ->
-            let (_, (_, _, _, _, malloc_block_symb, _, _)) = List.assoc sn malloc_block_pred_map in
+            let (_, (_, _, _, _, malloc_block_symb, _, _, _)) = List.assoc sn malloc_block_pred_map in
             cont (Chunk ((malloc_block_symb, true), [], real_unit, [result], None)::h)
           | _ ->
             match try_pointee_pred_symb0 t with
@@ -1929,7 +1934,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       in
       let consume_call_perm h cont =
         if should_terminate leminfo then begin
-          let (_, _, _, _, call_perm__symb, _, _) = List.assoc "call_perm_" predfammap in
+          let (_, _, _, _, call_perm__symb, _, _, _) = List.assoc "call_perm_" predfammap in
           consume_chunk rules h [] [] [] l (call_perm__symb, true) [] real_unit dummypat (Some 1) [TermPat fterm] $. fun _ h _ _ _ _ _ _ ->
           cont h
         end else
@@ -1944,7 +1949,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           consume_call_perm h $. fun h ->
           check_call [] h [] cont
         | Real ->
-          let [(_, (_, _, _, _, predsymb, inputParamCount, _))] = ft_predfammaps in
+          let [(_, (_, _, _, _, predsymb, inputParamCount, _, _))] = ft_predfammaps in
           let pats = TermPat fterm::List.map (fun _ -> SrcPat DummyPat) ftxmap in
           let targs = List.map (fun _ -> InferredType (object end, ref None)) fttparams in
           consume_chunk rules h [] [] [] l (predsymb, true) targs real_unit dummypat inputParamCount pats $. fun (Chunk (_, targs, _, _, _) as c) h coef (_::args) _ _ _ _ ->
@@ -1952,7 +1957,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           check_call targs h args $. fun h env retval ->
           cont (c::h) env retval
         | Ghost ->
-          let [(_, (_, _, _, _, predsymb, inputParamCount, _))] = ft_predfammaps in
+          let [(_, (_, _, _, _, predsymb, inputParamCount, _, _))] = ft_predfammaps in
           let targs = List.map (fun _ -> InferredType (object end, ref None)) fttparams in
           let pats = TermPat fterm::List.map (fun _ -> SrcPat DummyPat) ftxmap in
           consume_chunk rules h [] [] [] l (predsymb, true) targs real_unit dummypat inputParamCount pats $. fun chunk h coef (_::args) _ _ _ _ ->
@@ -1987,7 +1992,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         match try_assoc tn classmap with
           Some {cfinal; cmeths} ->
           let MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract) = List.assoc (m, pts) cmeths in
-          let can_be_overridden = fb = Instance && cfinal = ExtensibleClass && v <> Private in 
+          let can_be_overridden = fb = Instance && cfinal = ExtensibleClass && v <> Private in
           let is_upcall =
             not can_be_overridden &&
             match ss, leminfo with
@@ -2061,7 +2066,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         cont h env value
       | _ ->
         if unloadable then static_error l "The use of string literals as expressions in unloadable modules is not supported. Put the string literal in a named global array variable instead." None;
-        let (_, _, _, _, string_symb, _, _) = List.assoc "string" predfammap in
+        let (_, _, _, _, string_symb, _, _, _) = List.assoc "string" predfammap in
         let cs = get_unique_var_symb "stringLiteralChars" (InductiveType ("list", [Int (Signed, 0)])) in
         let value = get_unique_var_symb "stringLiteral" (PtrType (Int (Signed, 0))) in
         let coef = get_dummy_frac_term () in
@@ -2081,7 +2086,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         StaticArrayType (elemTp, elemCount) ->
         cont h env (field_address l t fparent fname)
       | _ ->
-      let (_, (_, _, _, _, f_symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+      let (_, (_, _, _, _, f_symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
       begin match lookup_points_to_chunk_core h f_symb t with
         None -> (* Try the heavyweight approach; this might trigger a rule (i.e. an auto-open or auto-close) and rewrite the heap. *)
         get_points_to h t f_symb l $. fun h coef v ->
@@ -2090,7 +2095,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       end
       end
     | WRead (l, _, fparent, fname, frange, true (* is static? *), fvalue, fghost) when ! fvalue = None || ! fvalue = Some None->
-      let (_, (_, _, _, _, f_symb, _, _)) = List.assoc (fparent, fname) field_pred_map in
+      let (_, (_, _, _, _, f_symb, _, _, _)) = List.assoc (fparent, fname) field_pred_map in
       consume_chunk rules h [] [] [] l (f_symb, true) [] real_unit dummypat (Some 0) [dummypat] (fun chunk h coef [field_value] size ghostenv _ _ ->
         cont (chunk :: h) env field_value)
     | WReadArray (l, arr, elem_tp, i) when language = Java ->


### PR DESCRIPTION
This implements the `predicate_nonempty` construct which was discussed on the mailing-list.
It asserts that a predicate maintains some parts of the heap alive, making it easier to pass the recursion termination check.

Note:
- the patch rewrites a lot of parts because it adds one field to the predicate tuple definition, so all deconstructions of the tuple are touched... would you accept a patch rewriting this tuple as a record?
- I remove trailing spaces from files before committing, however there are a lot of trailing ones in verifast codebase, would you accept a patch that remove all trailing spaces (not doing any other change)?