### PR TITLE
Allow hardtab in string literals

### DIFF
--- a/src/lexer.ml
+++ b/src/lexer.ml
@@ -662,7 +662,7 @@ let make_lexer_core keywords ghostKeywords startpos text reportRange inComment i
             Stream.Failure -> error "Bad string literal."
         in
         store c; string ()
-    | c when c < ' ' -> raise Stream.Failure
+    | c when c = '\n' -> raise Stream.Failure
     | c -> text_junk (); store c; string ()
   and char () =
     match text_peek () with

--- a/src/lexer.ml
+++ b/src/lexer.ml
@@ -214,10 +214,10 @@ let compare_tokens t1 t2 =
   | _ -> false
 end
 
-let rec print_tokens tokens =
+let rec print_tokens_list tokens =
   match tokens with
     [(_, tok)] -> Printf.printf "%s\n" (string_of_token tok)
-  | (_, tok) :: xs -> Printf.printf "%s, " (string_of_token tok); print_tokens xs
+  | (_, tok) :: xs -> Printf.printf "%s, " (string_of_token tok); print_tokens_list xs
   | [] -> Printf.printf "\n"
 
 exception ParseException of loc * string
@@ -275,6 +275,11 @@ module Stream = struct
     in
     iter ()
 end
+
+let rec print_tokens_stream tokens =
+  Printf.printf "[\n";
+  Stream.iter (fun (_, tok) -> Printf.printf " %s\n" (string_of_token tok)) tokens;
+  Printf.printf "]\n"
 
 (* The lexer *)
 

--- a/tests/string_literals/run.mysh
+++ b/tests/string_literals/run.mysh
@@ -1,0 +1,1 @@
+verifast -c use_tab.c

--- a/tests/string_literals/use_tab.c
+++ b/tests/string_literals/use_tab.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+        printf("Use hard	tab\n");
+        return 0;
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -398,6 +398,9 @@ cd tests
   cd preprocessor_if
     mysh < run.mysh
   cd ..
+  cd string_literals
+    mysh < run.mysh
+  cd ..
   verifast_both -c test-pattern-match-constructor-subtyping.c
   verifast_both -c test-octal-number.c
   verifast_both -c integral-ghost-types.c


### PR DESCRIPTION
Allow hard tab in string literals.

"6.4.5 String literals" at C99 puts following

```
Syntax
  string-literal:
    " s-char-sequence opt "
    L" s-char-sequence opt "
  s-char-sequence:
    s-char
    s-char-sequence s-char
  s-char:
    any member of the source character set except
      the double-quote ", backslash \, or new-line character
    escape-sequence
```

Above means that we should only maintain new-line character in string literals at lexer.ml.
