### PR TITLE
Parse semicolon without any declarations

### DIFF
--- a/src/parser.ml
+++ b/src/parser.ml
@@ -228,6 +228,7 @@ and
        -> type_params_pop();
           Interface (l, cn, il, fields mem, methods cn mem, instance_preds mem)::ds
      | [< d = parse_decl; ds = parse_decls_core >] -> d@ds
+     | [< '(_, Kwd ";"); ds = parse_decls_core >] -> ds
      | [< >] -> []
      end
   >] -> ds

--- a/tests/nodecl_and_semicolon.c
+++ b/tests/nodecl_and_semicolon.c
@@ -1,0 +1,1 @@
+/* No declarations */;

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -398,6 +398,7 @@ cd tests
   cd preprocessor_if
     mysh < run.mysh
   cd ..
+  verifast -c nodecl_and_semicolon.c
   verifast_both -c test-pattern-match-constructor-subtyping.c
   verifast_both -c test-octal-number.c
   verifast_both -c integral-ghost-types.c


### PR DESCRIPTION
In C language, following code is available:

```
$ cat main.c
/* No declarations */;
$ gcc -c main.c
$ echo $?
0
```