### PR TITLE
Support z3 with opam

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -100,8 +100,15 @@ ifndef NOZ3
 endif
 Z3V4DOT5PRESENT=false
 ifdef Z3V4DOT5
-  Z3_OCAML ?= $(shell ocamlfind query -qe Z3 || ocamlfind query z3)# It's Z3 when installed using `make install` and z3 when installed using OPAM
-  Z3_DLL_DIR ?= $(Z3_OCAML)/../..
+  # It's Z3 when installed using `make install` and z3 when installed using OPAM
+  Z3_OCAML = $(shell ocamlfind query -qe Z3)
+  ifneq ($(Z3_OCAML), "")
+    Z3_DLL_DIR = $(Z3_OCAML)/../..
+  endif
+  Z3_OCAML = $(shell ocamlfind query z3)
+  ifneq ($(Z3_OCAML), "")
+    Z3_DLL_DIR = $(Z3_OCAML)
+  endif
   Z3DEPS := z3$(Z3VERSION)prover.cmx verifastPluginZ3$(Z3VERSION).ml verifastPluginReduxZ3$(Z3VERSION).ml verifastPluginZ3$(Z3VERSION)Smtlib.ml
   ifeq ($(OS), Darwin)
     Z3DEPS := $(Z3DEPS) ../lib/libz3.dylib


### PR DESCRIPTION
You will see following error, if you use opam to install z3.

```
$ make
--snip--
  OCAMLOPT  z3v4dot5prover.cmx
cp: cannot stat '/home/kiwamu/.opam/system/lib/z3/../../libz3.so': No such file or directory
make: *** [GNUmakefile:159: ../bin/libz3.so] Error 1
```

But the `libz3.so` file is located at following:

```
$ ocamlfind query -qe Z3 || ocamlfind query z3
/home/kiwamu/.opam/system/lib/z3
$ ls -l /home/kiwamu/.opam/system/lib/z3/libz3.so
-rwxr-xr-x 1 kiwamu kiwamu 23283608 Jan 19 11:58 /home/kiwamu/.opam/system/lib/z3/libz3.so*
```