### PR TITLE
Fix misc to verify FreeRTOS

### DIFF
--- a/src/lexer.ml
+++ b/src/lexer.ml
@@ -921,6 +921,7 @@ and
   parse_expr_primary = parser
   [< '(l, Ident _) >] -> IntLit (l, zero_big_int, false, false, NoLSuffix)
 | [< '(l, Int (n, dec, usuffix, lsuffix)) >] -> IntLit (l, n, dec, usuffix, lsuffix)
+| [< '(l, Kwd "-"); '(l, Int (n, dec, usuffix, lsuffix)) >] -> IntLit (l, minus_big_int n, dec, usuffix, lsuffix)
 | [< '(l, Kwd "("); e0 = parse_operators; '(_, Kwd ")"); e = parse_operators_rest e0 >] -> e
 | [< '(l, Kwd "!"); e = parse_expr_suffix >] -> Operation(l, Not, [e])
 | [< '(l, Kwd "INT_MIN") >] -> IntLit (l, min_signed_big_int int_rank, true, false, NoLSuffix)


### PR DESCRIPTION
This patch includes some misc to verify FreeRTOS, which is located at following:
https://github.com/metasepi/amazon-freertos

But... On my laptop PC, verifying the `problem4.java` doesn't finish...

```
SLOW: examples/vstte2010$ verifast -prover z3v4.5 -c -disable_overflow_check problem4.java has been running for 645s
```