### PR TITLE
Basic generics for java

### DIFF
--- a/bin/rt/java.util.javaspec
+++ b/bin/rt/java.util.javaspec
@@ -151,8 +151,7 @@ fixpoint list<t> remove_nths<t>(list<int> ns, list<t> xs) {
 
 public interface List<E> extends Collection<E> {
     
-    //@ predicate List(list<Object> elements);
-    		
+    //@ predicate List(list<Object> elements);   		
     /*@
     
     lemma void listToIterable();

--- a/bin/rt/java.util.javaspec
+++ b/bin/rt/java.util.javaspec
@@ -122,7 +122,7 @@ public interface Iterator<E>{
         //@ requires Iterator(?es, ?c, ?n);
         //@ ensures Iterator(es, c, n) &*& result ? es(n) != none : es(n) == none; // Force case split.
     
-    public E next();
+    E next();
         //@ requires Iterator(?es, ?c, ?n) &*& es(n) != none;
         //@ ensures Iterator(es, some(n), n + 1) &*& result == the(es(n));
     
@@ -151,7 +151,8 @@ fixpoint list<t> remove_nths<t>(list<int> ns, list<t> xs) {
 
 public interface List<E> extends Collection<E> {
     
-    //@ predicate List(list<Object> elements);   		
+    //@ predicate List(list<Object> elements);
+
     /*@
     
     lemma void listToIterable();

--- a/bin/rt/java.util.javaspec
+++ b/bin/rt/java.util.javaspec
@@ -152,7 +152,7 @@ fixpoint list<t> remove_nths<t>(list<int> ns, list<t> xs) {
 public interface List<E> extends Collection<E> {
     
     //@ predicate List(list<Object> elements);
-
+    
     /*@
     
     lemma void listToIterable();

--- a/bin/rt/java.util.javaspec
+++ b/bin/rt/java.util.javaspec
@@ -216,7 +216,8 @@ public class ArrayList<E> implements List<E> {
 
 public class Arrays {
     
-    public static <E> List<E> asList(E[] a);
+    // No support for generic methods yet.
+    public static List asList(Object[] a);
         //@ requires [?f]a[..] |-> ?es;
         //@ ensures [f]a[..] |-> es &*& result.List(es);
    

--- a/bin/rt/java.util.javaspec
+++ b/bin/rt/java.util.javaspec
@@ -122,7 +122,7 @@ public interface Iterator<E>{
         //@ requires Iterator(?es, ?c, ?n);
         //@ ensures Iterator(es, c, n) &*& result ? es(n) != none : es(n) == none; // Force case split.
     
-    E next();
+    public E next();
         //@ requires Iterator(?es, ?c, ?n) &*& es(n) != none;
         //@ ensures Iterator(es, some(n), n + 1) &*& result == the(es(n));
     
@@ -152,7 +152,7 @@ fixpoint list<t> remove_nths<t>(list<int> ns, list<t> xs) {
 public interface List<E> extends Collection<E> {
     
     //@ predicate List(list<Object> elements);
-    
+    		
     /*@
     
     lemma void listToIterable();
@@ -173,7 +173,7 @@ public interface List<E> extends Collection<E> {
         //@ requires [?f]List(?es) &*& 0 <= index &*& index < length(es); 
         //@ ensures [f]List(es) &*& result == nth(index, es);
     
-    Iterator iterator();
+    Iterator<E> iterator();
         //@ requires [?f]Iterable(?es);
         /*@
         ensures
@@ -194,7 +194,7 @@ public interface List<E> extends Collection<E> {
         //@ requires List(?es);
         //@ ensures List(append(es, cons(e, nil))) &*& result;
 
-    boolean addAll(Collection other);
+    boolean addAll(Collection<E> other);
         //@ requires List(?es) &*& listIsCollection(?l, other) &*& l.List(?other_es);
         //@ ensures List(append(es, other_es)) &*& l.List(other_es);
     
@@ -245,7 +245,7 @@ public interface Set<E> extends Collection<E> {
         
     @*/
     
-    Iterator iterator();
+    Iterator<E> iterator();
         //@ requires [?f]Iterable(?es);
         /*@
         ensures

--- a/examples/java/ArrayList.java
+++ b/examples/java/ArrayList.java
@@ -130,9 +130,9 @@ lemma void remove_nth_remove_nths(int i, list<int> rs, list<Object> es)
 
 @*/
     
-final class ArrayListIterator implements Iterator {
+final class ArrayListIterator<T> implements Iterator<T> {
     
-    ArrayList list;
+    ArrayList<T> list;
     //@ real frac;
     //@ list<Object> oldElements;
     //@ list<int> removals;
@@ -161,7 +161,7 @@ final class ArrayListIterator implements Iterator {
     
     @*/
     
-    ArrayListIterator(ArrayList list)
+    ArrayListIterator(ArrayList<T> list)
         //@ requires [?f]list.List(?es);
         /*@ ensures Iterator((seq_of_list)(es), none, 0) &*& (f == 1 ? Iterator_removals(nil) : true) &*& 
                     [_]this.list |-> list &*& [_]oldElements |-> es &*& [_]frac |-> f &*&
@@ -186,7 +186,7 @@ final class ArrayListIterator implements Iterator {
         
     }
     
-    public Object next()
+    public T next()
         //@ requires Iterator(?es, ?c, ?n) &*& es(n) != none;
         //@ ensures Iterator(es, some(n), n + 1) &*& result == the(es(n));
     {
@@ -247,7 +247,7 @@ predicate_family_instance Iterable_iterating(ArrayList.class)(ArrayList list, li
 
 @*/
 
-final class ArrayList implements List {
+final class ArrayList<T> implements List<T> {
 
     Object[] elements;
     int size;
@@ -295,14 +295,14 @@ final class ArrayList implements List {
         //@ iterableToList();
     }
     
-    public Object get(int index)
+    public T get(int index)
         //@ requires [?f]List(?es) &*& 0 <= index &*& index < length(es);
         //@ ensures [f]List(es) &*& result == nth(index, es);
     {
         return elements[index];
     }
     
-    public Iterator iterator()
+    public Iterator<T> iterator()
         //@ requires [?f]Iterable(?es);
         /*@
         ensures
@@ -312,7 +312,7 @@ final class ArrayList implements List {
         @*/
     {
         //@ this.iterableToList();
-        ArrayListIterator i = new ArrayListIterator(this);
+        ArrayListIterator<T> i = new ArrayListIterator<T>(this);
         //@ close Iterable_iterating(ArrayList.class)(this, es, f, i);
         return i;
     }
@@ -339,7 +339,7 @@ final class ArrayList implements List {
     
     @*/
 
-    boolean add(Object e)
+    boolean add(T e)
         //@ requires List(?es);
         //@ ensures List(append(es, cons(e, nil))) &*& result;
     {
@@ -357,12 +357,12 @@ final class ArrayList implements List {
         return true;
     }
     
-    boolean addAll(Collection other)
+    boolean addAll(Collection<T> other)
         //@ requires List(?es) &*& listIsCollection(?li, other) &*& li.List(?other_es);
         //@ ensures List(append(es, other_es)) &*& li.List(other_es);
     {
         //@ open listIsCollection(li, other);
-        List l = (List) other;
+        List<T> l = (List) other;
         int n = l.size();
         //@ list<Object> ys = nil;
         //@ list<Object> zs = other_es;
@@ -380,11 +380,11 @@ final class ArrayList implements List {
         return true;
     }
     
-    Object remove(int index)
+    T remove(int index)
         //@ requires List(?es) &*& 0 <= index &*& index < length(es);
         //@ ensures List(remove_nth(index, es)) &*& result == nth(index, es);
     {
-        Object result = elements[index];
+        T result = elements[index];
         //@ close array_slice_dynamic(array_slice_Object, elements, index, index + 1, _);
         //@ assert elements |-> ?e &*& size |-> ?s &*& array_slice(e, index + 1, s, ?elems);
         //@ close array_slice_dynamic(array_slice_Object, elements, index + 1, size - 1, _);

--- a/examples/java/GenericClass.java
+++ b/examples/java/GenericClass.java
@@ -1,6 +1,8 @@
 import java.util.ArrayList;
 import java.util.List;
 
+// Contains examples on how to work with generics in VeriFast.
+
 public class GenericClass<T>{
 	public T field;
 	public GenericClass(T f)
@@ -10,11 +12,12 @@ public class GenericClass<T>{
 		field = f;
 	}
 	
-	public void add(T arg)
+	public T add(T arg)
 	//@ requires this.field |-> ?f;
 	//@ ensures this.field |-> arg;
 	{
 		field = arg;
+		return field;
 	}
 	
 	public T get()
@@ -72,10 +75,9 @@ public class HelloWorld
   {
     System.out.println("Hello, World");
     Foo<String> foo = new Foo<String>("test");
-    GenericClass<GenericClass<String> > list = new GenericClass<GenericClass<String> >(new GenericClass<String>("foo"));
-    list.add(new GenericClass<String>("hello"));
-    GenericClass<String> s = list.get();   // no cast
-    genericFunction<GenericClass<String>,String >(list, "Foo");
-    genericFunction< >(list, "Foo");
+    GenericClass<String> simple = new GenericClass<String>("Example");
+    GenericClass<GenericClass<String> > nested = new GenericClass<GenericClass<String> >(new GenericClass<String>("foo"));
+    nested.add(new GenericClass<String>("hello"));
+    GenericClass<String> s = nested.get();   // no cast
   }
 }

--- a/examples/java/GenericClass.java
+++ b/examples/java/GenericClass.java
@@ -25,7 +25,15 @@ public class GenericClass<T>{
 	}
 }
 
-public class Foo {}
+public class Foo<T> {
+	public Foo(T arg)
+	//@ requires true;
+	//@ ensures true;
+	{
+		GenericClass<T> b = new GenericClass<T>(arg);
+	}
+}
+
 
 /*
 	Proper method overrides
@@ -56,10 +64,6 @@ public class ChildClassInheritance<C,D> extends AbstractParentClass<C,D>{
 
 public class HelloWorld 
 {
-  public static <T,V> void genericFunction(T argument, V other)
-  //@ requires true;
-  //@ ensures true;
-  {}
   public static GenericClass<GenericClass<Foo> > genericInstance;
   
   public static void main(String[] args) 
@@ -67,6 +71,7 @@ public class HelloWorld
     //@ ensures true; 
   {
     System.out.println("Hello, World");
+    Foo<String> foo = new Foo<String>("test");
     GenericClass<GenericClass<String> > list = new GenericClass<GenericClass<String> >(new GenericClass<String>("foo"));
     list.add(new GenericClass<String>("hello"));
     GenericClass<String> s = list.get();   // no cast

--- a/examples/java/GenericClass.java
+++ b/examples/java/GenericClass.java
@@ -1,0 +1,76 @@
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenericClass<T>{
+	public T field;
+	public GenericClass(T f)
+	//@ requires true;
+	//@ ensures this.field |-> f;
+	{
+		field = f;
+	}
+	
+	public void add(T arg)
+	//@ requires this.field |-> ?f;
+	//@ ensures this.field |-> arg;
+	{
+		field = arg;
+	}
+	
+	public T get()
+	//@ requires this.field |-> ?f;
+	//@ ensures this.field |-> f;
+	{
+		return field;
+	}
+}
+
+public class Foo {}
+
+/*
+	Proper method overrides
+*/
+// Case A: Interface implements interface
+public interface Parent<A,B>{
+	public A get1(A arg1);
+	public B get2();
+}
+
+public interface Child<C,D> extends Parent<D,C>{
+	public D get1(D arg1);
+	public C get2();
+}
+// Case B: Class implements interface
+public class ChildClass<C,D> implements Parent<D,C>{
+	public D get1(D arg1) {return null;}
+	public C get2() {return null;}
+}
+
+// Case C: Class extends class
+public abstract class AbstractParentClass<A,B> {
+	public abstract A get1(A arg1);
+}
+public class ChildClassInheritance<C,D> extends AbstractParentClass<C,D>{
+	public C get1(C arg1){return null;}
+}
+
+public class HelloWorld 
+{
+  public static <T,V> void genericFunction(T argument, V other)
+  //@ requires true;
+  //@ ensures true;
+  {}
+  public static GenericClass<GenericClass<Foo> > genericInstance;
+  
+  public static void main(String[] args) 
+    //@ requires System_out(?o) &*& o != null;
+    //@ ensures true; 
+  {
+    System.out.println("Hello, World");
+    GenericClass<GenericClass<String> > list = new GenericClass<GenericClass<String> >(new GenericClass<String>("foo"));
+    list.add(new GenericClass<String>("hello"));
+    GenericClass<String> s = list.get();   // no cast
+    genericFunction<GenericClass<String>,String >(list, "Foo");
+    genericFunction< >(list, "Foo");
+  }
+}

--- a/examples/java/channels/Channel.java
+++ b/examples/java/channels/Channel.java
@@ -8,7 +8,8 @@ import java.util.*;
 /*@
 
 predicate_ctor channel_sema_inv(Channel channel)() =
-    channel.itemList |-> ?itemList &*& itemList.List(?items) &*& [1/2]channel.items_ |-> items &*&
+    channel.itemList |-> ?itemList &*& itemList.List(?items) 
+    &*& [1/2]channel.items_ |-> items &*&
     [1/2]channel.queueMaxSize |-> ?qms &*& length(items) <= qms;
 
 @*/
@@ -16,7 +17,7 @@ predicate_ctor channel_sema_inv(Channel channel)() =
 public final class Channel {
 
     //@ list<Object> items_;
-    List itemList;
+    List<String> itemList;
     Semaphore sema;
     int queueMaxSize;
     
@@ -27,7 +28,7 @@ public final class Channel {
         //@ requires 0 <= queueMaxSize;
         //@ ensures Channel() &*& ChannelState(nil, queueMaxSize);
     {
-        itemList = new ArrayList();
+        itemList = new ArrayList<String>();
         this.queueMaxSize = queueMaxSize;
         //@ items_ = nil;
         //@ close channel_sema_inv(this)();
@@ -80,7 +81,7 @@ public final class Channel {
                 sepPred() &*& pre() &*&
                 [1/2]items_ |-> items;
             predicate Q() =
-                [1/2]items_ |-> (length(items) < qms ? append(items, cons(msg, nil)) : items) &*&
+                [1/2]items_ |-> (length(items) < qms ? append<Object>(items, cons(msg, nil)) : items) &*&
                 sepPred() &*&
                 post(length(items) < qms);
             
@@ -93,8 +94,8 @@ public final class Channel {
                 open ChannelState(_, _);
                 if (length(items) < qms)
                 {
-                  items_ = append(items, cons(msg, nil));
-                  close ChannelState(append(items, cons(msg, nil)), _);
+                  items_ = append<Object>(items, cons(msg, nil));
+                  close ChannelState(append<Object>(items, cons(msg, nil)), _);
                   send_(true);
                 }
                 else
@@ -113,7 +114,7 @@ public final class Channel {
             //@ perform_atomic_space_ghost_operation();
             //@ open Q();
         }
-        //@ length_append(items, cons(msg, nil));
+        //@ length_append<Object>(items, cons(msg, nil));
         //@ close channel_sema_inv(this)();
         sema.release();
         //@ close [fc]Channel();

--- a/examples/java/channels/Channel.java
+++ b/examples/java/channels/Channel.java
@@ -8,8 +8,7 @@ import java.util.*;
 /*@
 
 predicate_ctor channel_sema_inv(Channel channel)() =
-    channel.itemList |-> ?itemList &*& itemList.List(?items) 
-    &*& [1/2]channel.items_ |-> items &*&
+    channel.itemList |-> ?itemList &*& itemList.List(?items) &*& [1/2]channel.items_ |-> items &*&
     [1/2]channel.queueMaxSize |-> ?qms &*& length(items) <= qms;
 
 @*/

--- a/examples/java/channels_raw/Channel.java
+++ b/examples/java/channels_raw/Channel.java
@@ -1,0 +1,190 @@
+// Work done in collaboration with Sybren Roede and Ruurd Kuiper
+
+package channels;
+
+import java.util.concurrent.*;
+import java.util.*;
+
+/*@
+
+predicate_ctor channel_sema_inv(Channel channel)() =
+    channel.itemList |-> ?itemList &*& itemList.List(?items) 
+    &*& [1/2]channel.items_ |-> items &*&
+    [1/2]channel.queueMaxSize |-> ?qms &*& length(items) <= qms;
+
+@*/
+
+public final class Channel {
+
+    //@ list<Object> items_;
+    List itemList;
+    Semaphore sema;
+    int queueMaxSize;
+    
+    //@ predicate Channel() = sema |-> ?sema &*& [_]sema.Semaphore(channel_sema_inv(this));
+    //@ predicate ChannelState(list<Object> items, int qms) = [1/2]items_ |-> items &*& [1/2]queueMaxSize |-> qms;
+    
+    public Channel(int queueMaxSize)
+        //@ requires 0 <= queueMaxSize;
+        //@ ensures Channel() &*& ChannelState(nil, queueMaxSize);
+    {
+        itemList = new ArrayList();
+        this.queueMaxSize = queueMaxSize;
+        //@ items_ = nil;
+        //@ close channel_sema_inv(this)();
+        //@ one_time(channel_sema_inv(this));
+        sema = new Semaphore(1);
+        //@ sema.leakHandle();
+        //@ close Channel();
+        //@ close ChannelState(nil, queueMaxSize);
+    }
+    
+    boolean send(String msg)
+        /*@
+        requires 
+            [?fc]Channel() &*&
+            [?fa]atomic_space(?inv) &*&
+            is_channel_sep(?sep, inv, this, ?sepPred, ?unsepPred) &*&
+            is_channel_unsep(?unsep, inv, this, sepPred, unsepPred) &*&
+            sepPred() &*&
+            is_channel_send(?send_, inv, this, unsepPred, msg, ?pre, ?post) &*& pre();
+        @*/
+        /*@
+        ensures
+            [fc]Channel() &*&
+            [fa]atomic_space(inv) &*&
+            sepPred() &*&
+            post(result);
+        @*/
+    {
+        //@ open [fc]Channel();
+        //@ sema.makeHandle();
+        sema.acquire();
+        //@ open channel_sema_inv(this)();
+        //@ assert itemList |-> ?l &*& l.List(?items);
+        //@ assert [1/2]queueMaxSize |-> ?qms;
+
+        boolean result;
+        if (itemList.size() < queueMaxSize) {
+            itemList.add(msg);
+            result = true;
+        } else {
+            result = false;
+        }
+        
+        {
+            /*@
+            predicate P() =
+                is_channel_sep(sep, inv, this, sepPred, unsepPred) &*&
+                is_channel_unsep(unsep, inv, this, sepPred, unsepPred) &*&
+                is_channel_send(send_, inv, this, unsepPred, msg, pre, post) &*&
+                sepPred() &*& pre() &*&
+                [1/2]items_ |-> items;
+            predicate Q() =
+                [1/2]items_ |-> (length(items) < qms ? append<Object>(items, cons(msg, nil)) : items) &*&
+                sepPred() &*&
+                post(length(items) < qms);
+            
+            lemma void my_ghost_op()
+                requires P() &*& inv();
+                ensures Q() &*& inv();
+            {
+                open P();
+                sep();
+                open ChannelState(_, _);
+                if (length(items) < qms)
+                {
+                  items_ = append<Object>(items, cons(msg, nil));
+                  close ChannelState(append<Object>(items, cons(msg, nil)), _);
+                  send_(true);
+                }
+                else
+                {
+                  items_ = items;
+                  close ChannelState(items, _);
+                  send_(false);
+                }
+
+                unsep();
+                close Q();
+            }
+            @*/
+            //@ close P();
+            //@ produce_lemma_function_pointer_chunk(my_ghost_op) : atomic_space_ghost_operation(inv, P, Q)() { call(); };
+            //@ perform_atomic_space_ghost_operation();
+            //@ open Q();
+        }
+        //@ length_append<Object>(items, cons(msg, nil));
+        //@ close channel_sema_inv(this)();
+        sema.release();
+        //@ close [fc]Channel();
+        return result;
+    }
+    
+    String receive()
+        /*@
+        requires
+            [?fc]Channel() &*&
+            [?fa]atomic_space(?inv) &*&
+            is_channel_sep(?sep, inv, this, ?sepPred, ?unsepPred) &*&
+            is_channel_unsep(?unsep, inv, this, sepPred, unsepPred) &*&
+            is_channel_receive(?receive_, inv, this, unsepPred, ?pre, ?post) &*&
+            sepPred() &*& pre();
+        @*/
+        /*@
+        ensures
+            [fc]Channel() &*&
+            [fa]atomic_space(inv) &*&
+            sepPred() &*&
+            post(result);
+        @*/
+    {
+        //@ sema.makeHandle();
+        sema.acquire();
+        //@ open channel_sema_inv(this)();
+        String result;
+        if (itemList.size() == 0) {
+            result = null;
+        } else {
+            result = (String)itemList.remove(0);
+        }
+        //@ list<Object> items = items_;
+        {
+            /*@
+            predicate P() =
+                is_channel_sep(sep, inv, this, sepPred, unsepPred) &*&
+                is_channel_unsep(unsep, inv, this, sepPred, unsepPred) &*&
+                is_channel_receive(receive_, inv, this, unsepPred, pre, post) &*&
+                sepPred() &*& pre() &*&
+                [1/2]items_ |-> items;
+            predicate Q() =
+                [1/2]items_ |-> tail(items) &*&
+                sepPred() &*&
+                post(items != nil ? head(items) : null);
+            
+            lemma void my_ghost_op()
+                requires P() &*& inv();
+                ensures Q() &*& inv();
+            {
+                open P();
+                sep();
+                open ChannelState(_, _);
+                items_ = tail(items);
+                close ChannelState(tail(items), _);
+                receive_();
+                unsep();
+                close Q();
+            }
+            @*/
+            //@ close P();
+            //@ produce_lemma_function_pointer_chunk(my_ghost_op) : atomic_space_ghost_operation(inv, P, Q)() { call(); };
+            //@ perform_atomic_space_ghost_operation();
+            //@ open Q();
+        }
+        //@ switch (items) { case nil: case cons(i0, is0): }
+        //@ close channel_sema_inv(this)();
+        sema.release();
+        return result;
+    }
+    
+}

--- a/examples/java/channels_raw/channels.jarspec
+++ b/examples/java/channels_raw/channels.jarspec
@@ -1,0 +1,1 @@
+channels.javaspec

--- a/examples/java/channels_raw/channels.jarsrc
+++ b/examples/java/channels_raw/channels.jarsrc
@@ -1,0 +1,1 @@
+Channel.java

--- a/examples/java/channels_raw/channels.javaspec
+++ b/examples/java/channels_raw/channels.javaspec
@@ -1,0 +1,68 @@
+package channels;
+
+/*@
+
+typedef lemma void channel_sep(predicate() inv, Channel c, predicate() sepPred, predicate(list<Object>, int) unsepPred)();
+    requires sepPred() &*& inv();
+    ensures c.ChannelState(?items, ?qms) &*& unsepPred(items, qms);
+
+typedef lemma void channel_unsep(predicate() inv, Channel c, predicate() sepPred, predicate(list<Object>, int) unsepPred)();
+    requires unsepPred(?items, ?qms) &*& c.ChannelState(items, qms);
+    ensures sepPred() &*& inv();
+
+typedef lemma void channel_send(predicate() inv, Channel c, predicate(list<Object>, int) unsepPred, String msg, predicate() pre, predicate(boolean) post)(boolean r);
+    requires pre() &*& unsepPred(?items, ?qms);
+    ensures post(r) &*& unsepPred(r ? append(items, cons(msg, nil)) : items, qms);
+
+typedef lemma void channel_receive(predicate() inv, Channel c, predicate(list<Object>,int) unsepPred, predicate() pre, predicate(Object) post)();
+    requires pre() &*& unsepPred(?items, ?qms);
+    ensures post(items != nil ? head(items) : null) &*& unsepPred(tail(items), qms);
+
+@*/
+
+public final class Channel {
+    
+    //@ predicate Channel();
+    //@ predicate ChannelState(list<Object> items, int queueSizeMax);
+    
+    public Channel(int queueMaxSize);
+        //@ requires 0 <= queueMaxSize;
+        //@ ensures Channel() &*& ChannelState(nil, queueMaxSize);
+    
+    public boolean send(String msg);
+        /*@
+        requires
+            [?fc]Channel() &*&
+            [?fa]atomic_space(?inv) &*&
+            is_channel_sep(?sep, inv, this, ?sepPred, ?unsepPred) &*&
+            is_channel_unsep(?unsep, inv, this, sepPred, unsepPred) &*&
+            is_channel_send(?send, inv, this, unsepPred, msg, ?pre, ?post) &*&
+            sepPred() &*& pre();
+        @*/
+        /*@
+        ensures
+            [fc]Channel() &*&
+            [fa]atomic_space(inv) &*&
+            sepPred() &*&
+            post(result);
+        @*/
+    
+    public String receive();
+        /*@
+        requires
+            [?fc]Channel() &*&
+            [?fa]atomic_space(?inv) &*&
+            is_channel_sep(?sep, inv, this, ?sepPred, ?unsepPred) &*&
+            is_channel_unsep(?unsep, inv, this, sepPred, unsepPred) &*&
+            is_channel_receive(?receive, inv, this, unsepPred, ?pre, ?post) &*&
+            sepPred() &*& pre();
+        @*/
+        /*@
+        ensures
+            [fc]Channel() &*&
+            [fa]atomic_space(inv) &*&
+            sepPred() &*&
+            post(result);
+        @*/
+    
+}

--- a/examples/java/channels_raw/client.jarsrc
+++ b/examples/java/channels_raw/client.jarsrc
@@ -1,0 +1,3 @@
+../verifast.jar
+channels.jar
+client.java

--- a/examples/java/channels_raw/client.java
+++ b/examples/java/channels_raw/client.java
@@ -1,0 +1,595 @@
+// Work done in collaboration with Sybren Roede and Ruurd Kuiper
+
+import channels.*;
+import verifast.*;
+
+/*@
+
+fixpoint boolean non_null(Object o) { return o != null; }
+
+predicate_ctor client_inv(Channel c)() =
+    c.ChannelState(?items, ?qms) &*& forall(items, non_null) == true &*&
+    [1/2]Program_sendMaxCount(?smc) &*& 0 < smc &*&
+    [1/2]Program_receiveMaxCount(?rmc) &*& 0 < rmc &*&
+    [_]Program_senders(?s) &*&
+    [_]Program_sendersCount(?sc) &*&
+    [1/3]array_slice_deep(s, 0, sc, senderWorkerInv, unit, _, ?lstSc)  &*&
+    [_]Program_receivers(?r) &*&
+    [_]Program_receiversCount(?rc) &*&
+    [1/3]array_slice_deep(r, 0, rc, receiverWorkerInv, unit, _, ?lstRc) &*&
+    length(items) == sum(lstSc) - sum(lstRc) &*&
+    sum(lstRc) <= sum(lstSc);
+
+predicate senderWorkerInv(unit u, SenderThread sw; int senderCount) =
+    [3/2]sw.senderSendCount |-> senderCount;
+
+predicate receiverWorkerInv(unit u, ReceiverThread rw; int receiverCount) =
+    [3/2]rw.receiverReceiveCount |-> receiverCount;
+
+fixpoint int sum(list<int> vs) {
+    switch(vs) {
+      case nil: return 0;
+      case cons(h, t): return h + sum(t);
+    }
+}
+
+lemma_auto void sum_all_eq(list<int> vs)
+    requires all_eq(vs, 0) == true;
+    ensures sum(vs) == 0;
+{
+    switch(vs) {
+        case nil :
+        case cons (x0, xs0): sum_all_eq(xs0);
+    }
+}
+
+lemma void sum_take_cons_drop(int k, list<int> xs, int x)
+    requires 0 <= k &*& k < length(xs);
+    ensures sum(xs) == sum(append(take(k, xs), cons(x, drop(k + 1, xs)))) - x + head(take(1, drop(k, xs)));
+{
+    switch (xs) {
+        case nil:
+        case cons(x0, xs0):
+            if (k == 0) {
+            } else {
+                sum_take_cons_drop(k - 1, xs0, x);
+            }
+    }
+}
+
+predicate my_sep_pred() = true;
+
+predicate_ctor my_unsep_pred(Channel c)(list<Object> items, int qms) =
+    forall(items, non_null) == true &*&
+    [1/2]Program_sendMaxCount(?smc) &*&  0 < smc &*&
+    [1/2]Program_receiveMaxCount(?rmc) &*& 0 < rmc &*&
+    [_]Program_senders(?s) &*&
+    [_]Program_sendersCount(?sc) &*&
+    [1/3]array_slice_deep(s, 0, sc, senderWorkerInv, unit, _, ?lstSc)  &*&
+    [_]Program_receivers(?r) &*&
+    [_]Program_receiversCount(?rc) &*&
+    [1/3]array_slice_deep(r, 0, rc, receiverWorkerInv, unit, _, ?lstRc) &*&
+    length(items) == sum(lstSc) - sum(lstRc) &*&
+    sum(lstRc) <= sum(lstSc);
+
+lemma void my_sep()
+    requires exists<Channel>(?c) &*& my_sep_pred() &*& client_inv(c)();
+    ensures c.ChannelState(?items, ?qms) &*& my_unsep_pred(c)(items, qms);
+{
+    open client_inv(c)();
+    assert c.ChannelState(?items, ?qms);
+    close my_unsep_pred(c)(items, qms);
+}
+
+lemma void my_unsep()
+    requires exists<Channel>(?c) &*& my_unsep_pred(c)(?items, ?qms) &*& c.ChannelState(items, qms);
+    ensures my_sep_pred() &*& client_inv(c)();
+{
+    open my_unsep_pred(c)(_, _);
+    close client_inv(c)();
+    close my_sep_pred();
+}
+
+predicate foreach_i<t>(int i, list<t> xs, predicate(int, t) p) =
+    switch (xs) {
+        case nil: return true;
+        case cons(x0, xs0): return p(i, x0) &*& foreach_i(i + 1, xs0, p);
+    };
+
+lemma void foreach_i_append<t>(int i, list<t> xs, list<t> ys)
+    requires foreach_i(i, xs, ?p) &*& foreach_i(i + length(xs), ys, p);
+    ensures foreach_i(i, append(xs, ys), p);
+{
+    switch (xs) {
+        case nil:
+        case cons(x0, xs0):
+            open foreach_i(i, xs, p);
+            foreach_i_append(i + 1, xs0, ys);
+            close foreach_i(i, append(xs, ys), p);
+    }
+}
+
+@*/
+
+/*@
+
+predicate senderWorker(unit u, SenderThread SenderWorker; unit u2) =
+    [3]SenderWorker.thread |-> ?t &*&  [3]SenderWorker.joinable |-> ?j &*&
+    [3]t.Thread(j, true) &*& [3]j.JoinableRunnable(SenderWorker, true) &*& SenderWorker.getClass() == SenderThread.class &*&
+    u2 == unit;
+
+predicate senderWorkerNull(unit u, SenderThread SenderWorker; unit u2) =
+    [3/2]SenderWorker.thread |-> _ &*&  [3/2]SenderWorker.joinable |-> _ &*&
+    [3/2]SenderWorker.myIndex |-> _ &*&
+    SenderWorker.getClass() == SenderThread.class &*& [3/4]SenderWorker.senderSendCount |-> 0 &*&
+    u2 == unit;
+
+predicate senderWorkerIndex(int i, SenderThread t) =
+    [_]t.myIndex |-> i;
+
+@*/
+
+public class SenderThread implements Runnable {
+    
+    //@ int senderSendCount;
+    //@ int myIndex;
+    Thread thread;
+    JoinableRunnable joinable;
+    
+    /*@
+    
+    predicate pre()  =
+        [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+        [_]Program_sendMaxCount(?smc) &*& 0 < smc &*&
+        [_]Program_senders(?s) &*& [_]this.myIndex |-> ?myIndex &*&
+        [_]Program_sendersCount(?sc) &*& myIndex < sc  &*&
+        [1/3]array_slice_deep(s, myIndex, myIndex + 1, senderWorkerInv, unit, cons(this, nil), cons(0, nil));
+    
+    predicate post() =
+        [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+        [_]Program_sendMaxCount(?smc) &*&
+        [_]Program_senders(?s) &*& [_]this.myIndex |-> ?myIndex &*&
+        [_]Program_sendersCount(?sc) &*& myIndex < sc  &*&
+        [1/3]array_slice_deep(s, myIndex, myIndex + 1, senderWorkerInv, unit, cons(this, nil), cons(smc, nil));
+    
+    @*/
+    
+    public void run()
+        //@ requires pre();
+        //@ ensures post();
+    {
+        String m = "Hello";
+        int i;
+        for(i = 0; i < Program.sendMaxCount; i++)
+            /*@
+            invariant
+                [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+                [_]Program_sendMaxCount(?smc) &*& i <= smc &*&
+                [_]Program_senders(?s) &*& [_]this.myIndex |-> ?myIndex &*&
+                [_]Program_sendersCount(?sc) &*& myIndex < sc &*&
+                [1/3]array_slice_deep(s, myIndex, myIndex + 1, senderWorkerInv, unit, cons(this, nil), cons(i, nil));
+            @*/
+        {
+            for (;;)
+                /*@
+                invariant
+                    [_]Program_channel(c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+                    [_]Program_sendMaxCount(smc) &*& i < smc &*&
+                    [_]Program_senders(s) &*& [_]this.myIndex |-> myIndex &*&
+                    [_]Program_sendersCount(sc) &*& myIndex < sc &*&
+                    [1/3]array_slice_deep(s, myIndex, myIndex + 1, senderWorkerInv, unit, cons(this, nil), cons(i, nil));
+                @*/
+            {
+                
+                /*@
+                predicate P() =
+                    [_]Program_sendMaxCount(smc) &*&
+                    [_]Program_senders(s) &*& [_]this.myIndex |-> myIndex &*&
+                    [_]Program_sendersCount(sc) &*& myIndex < sc &*&
+                    [1/3]array_slice_deep(s, myIndex, myIndex + 1, senderWorkerInv, unit, cons(this, nil), cons(i, nil));
+                predicate Q(boolean r) =
+                    [_]Program_sendMaxCount(smc) &*&
+                    [_]Program_senders(s) &*& [_]this.myIndex |-> myIndex &*&
+                    [_]Program_sendersCount(sc) &*& myIndex < sc &*&
+                    [1/3]array_slice_deep(s, myIndex, myIndex + 1, senderWorkerInv, unit, cons(this, nil), (r ? cons(i+1, nil) : cons(i, nil)));
+                
+                lemma void my_send(boolean r)
+                    requires i < smc &*& P() &*& my_unsep_pred(c)(?items, ?qms);
+                    ensures Q(r) &*& my_unsep_pred(c)(r ? append(items, cons(m, nil)) : items, qms);
+                {
+                    open P();
+                    open my_unsep_pred(c)(items, qms);
+                    SenderThread[] senders = Program.senders;
+                    int sendersCount = Program.sendersCount;
+                    int k = myIndex;
+                    assert [1/3]array_slice_deep(senders, 0, sendersCount, senderWorkerInv, unit, _, ?oldSenderCounts);
+                    array_slice_deep_split(Program.senders, 0, myIndex);
+                    array_slice_deep_split_precise(1/3, Program.senders, myIndex, Program.sendersCount, senderWorkerInv, unit, myIndex + 1);
+                    array_slice_deep_open_precise(2/3, Program.senders, myIndex);
+                    int myOldSendCount = senderSendCount;
+                    if (r) {
+                        senderSendCount++;
+                    }
+                    int myNewSendCount = senderSendCount;
+                    array_slice_deep_close(Program.senders, myIndex, senderWorkerInv, unit);
+                    array_slice_deep_join_precise(1/3, Program.senders, myIndex, myIndex + 1, senderWorkerInv, unit, Program.sendersCount);
+                    array_slice_deep_join_precise(1/3, Program.senders, 0, myIndex, senderWorkerInv, unit, Program.sendersCount);
+                    
+                    forall_append(items, cons(m, nil), non_null);
+                    length_append(items, cons(m, nil));
+                    assert [1/3]array_slice_deep(senders, 0, sendersCount, senderWorkerInv, unit, _, ?newSenderCounts);
+                    assert newSenderCounts == append(take(k, oldSenderCounts), cons(myNewSendCount, drop(1, drop(k, oldSenderCounts))));
+                    assert length(oldSenderCounts) == sendersCount;
+                    assert 0 <= 1 &*& 0 <= k &*& 1 + k <= length(oldSenderCounts);
+                    drop_drop(1, k, oldSenderCounts);
+                    assert newSenderCounts == append(take(k, oldSenderCounts), cons(myNewSendCount, drop(k + 1, oldSenderCounts)));
+                    sum_take_cons_drop(k, oldSenderCounts, myNewSendCount);
+                    assert sum(newSenderCounts) == sum(oldSenderCounts) + myNewSendCount - myOldSendCount;
+                    close my_unsep_pred(c)(r ? append(items, cons(m, nil)) : items, qms);
+                    close Q(r);
+                }
+                @*/
+                //@ produce_lemma_function_pointer_chunk(my_sep) : channel_sep(client_inv(c), c, my_sep_pred, my_unsep_pred(c))() { close exists(c); call(); };
+                //@ produce_lemma_function_pointer_chunk(my_unsep) : channel_unsep(client_inv(c), c, my_sep_pred, my_unsep_pred(c))() { close exists(c); call(); };
+                //@ close my_sep_pred();
+                //@ produce_lemma_function_pointer_chunk(my_send) : channel_send(client_inv(c), c, my_unsep_pred(c), m, P, Q)(r) { call(); };
+                //@ close P();
+                boolean success = Program.channel.send(m);
+                //@ open Q(success);
+                if (success) break;
+            }
+        }
+        //@ assert i == Program.sendMaxCount;
+        //@ close post();
+    }
+}
+
+/*@
+
+predicate receiverWorker(unit u, ReceiverThread ReceiverWorker; unit u2) =
+    [3]ReceiverWorker.thread |-> ?t &*& [3]ReceiverWorker.joinable |-> ?j &*&
+    [3]t.Thread(j, true) &*& [3]j.JoinableRunnable(ReceiverWorker, true) &*& ReceiverWorker.getClass() == ReceiverThread.class &*&
+    u2 == unit;
+
+predicate receiverWorkerNull(unit u, ReceiverThread ReceiverWorker; unit u2) =
+    [3/2]ReceiverWorker.thread |-> _ &*&  [3/2]ReceiverWorker.joinable |-> _ &*&
+    [3/2]ReceiverWorker.myIndex |-> _ &*&
+    ReceiverWorker.getClass() == ReceiverThread.class &*& [3/4]ReceiverWorker.receiverReceiveCount |-> 0 &*&
+    u2 == unit;
+
+predicate receiverWorkerIndex(int i, ReceiverThread t) =
+    [_]t.myIndex |-> i;
+
+@*/
+
+class ReceiverThread implements Runnable {
+    //@ int receiverReceiveCount;
+    //@ int myIndex;
+    Thread thread;
+    JoinableRunnable joinable;
+    
+    /*@
+    
+    predicate pre() =
+        [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+        [_]Program_receiveMaxCount(?rmc) &*& 0 < rmc &*&
+        [_]Program_receivers(?s) &*& [_]this.myIndex |-> ?myIndex &*&
+        [_]Program_receiversCount(?rc) &*& myIndex < rc  &*&
+        [1/3]array_slice_deep(s, myIndex, myIndex + 1, receiverWorkerInv, unit, cons(this, nil), cons(0, nil));
+    
+    predicate post() =
+        [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+        [_]Program_receiveMaxCount(?rmc) &*&
+        [_]Program_receivers(?s) &*& [_]this.myIndex |-> ?myIndex &*&
+        [_]Program_receiversCount(?rc) &*& myIndex < rc  &*&
+        [1/3]array_slice_deep(s, myIndex, myIndex + 1, receiverWorkerInv, unit, cons(this, nil), cons(rmc, nil));
+    
+    @*/
+    
+    public void run()
+        //@ requires pre();
+        //@ ensures post();
+    {
+        int i;
+        for (i=0; i < Program.receiveMaxCount; i++)
+            /*@
+            invariant
+                [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+                [_]Program_receiveMaxCount(?rmc) &*& i <= rmc &*&
+                [_]Program_receivers(?r) &*& [_]this.myIndex |-> ?myIndex &*&
+                [_]Program_receiversCount(?rc) &*& myIndex < rc &*&
+                [1/3]array_slice_deep(r, myIndex, myIndex + 1, receiverWorkerInv, unit, cons(this, nil), cons(i, nil));
+            @*/
+        {
+            for (;;)
+                /*@
+                invariant
+                    [_]Program_channel(c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+                    [_]Program_receiveMaxCount(rmc) &*& i < rmc &*&
+                    [_]Program_receivers(r) &*& [_]this.myIndex |-> myIndex &*&
+                    [_]Program_receiversCount(rc) &*& myIndex < rc &*&
+                    [1/3]array_slice_deep(r, myIndex, myIndex + 1, receiverWorkerInv, unit, cons(this, nil), cons(i, nil));
+                @*/
+            {
+                /*@
+                predicate P() =  
+                    [_]Program_receiveMaxCount(rmc) &*&
+                    [_]Program_receivers(r) &*& [_]this.myIndex |-> myIndex &*&
+                    [_]Program_receiversCount(rc) &*& myIndex < rc &*&
+                    [1/3]array_slice_deep(r, myIndex, myIndex + 1, receiverWorkerInv, unit, cons(this, nil), cons(i, nil));
+                predicate Q(Object result) = 
+                    [_]Program_receiveMaxCount(rmc) &*& 
+                    [_]Program_receivers(r) &*& [_]this.myIndex |-> myIndex &*& 
+                    [_]Program_receiversCount(rc) &*& myIndex < rc &*&
+                    [1/3]array_slice_deep(r, myIndex, myIndex + 1, receiverWorkerInv, unit, cons(this, nil), (result != null ? cons(i + 1, nil) : cons(i , nil)));
+                
+                lemma void my_channel_receive()
+                    requires i < rmc &*& P() &*& my_unsep_pred(c)(?items, ?qms);
+                    ensures Q(items != nil ? head(items) : null) &*& my_unsep_pred(c)(tail(items), qms);
+                {
+                    open P();
+                    open my_unsep_pred(c)(items, qms);
+                    ReceiverThread[] receivers = Program.receivers;
+                    int receiversCount = Program.receiversCount;
+                    int k = myIndex;
+                    assert [1/3]array_slice_deep(receivers, 0, receiversCount, receiverWorkerInv, unit, _, ?oldReceiverCounts);
+                    array_slice_deep_split(Program.receivers, 0, myIndex);
+                    array_slice_deep_split_precise(1/3, Program.receivers, myIndex, Program.receiversCount, receiverWorkerInv, unit, myIndex + 1);
+                    array_slice_deep_open_precise(2/3, Program.receivers, myIndex);
+                    int myOldReceiveCount = receiverReceiveCount;
+                    switch (items) {
+                    case nil:
+                    case cons(head, tail):
+                        receiverReceiveCount++;
+                    }
+                    int myNewReceiverCount = receiverReceiveCount;
+                    array_slice_deep_close(Program.receivers, myIndex, receiverWorkerInv, unit);
+                    array_slice_deep_join_precise(1/3, Program.receivers, myIndex, myIndex + 1, receiverWorkerInv, unit, Program.receiversCount);
+                    array_slice_deep_join_precise(1/3, Program.receivers, 0, myIndex, receiverWorkerInv, unit, Program.receiversCount);
+                    
+                    assert [1/3]array_slice_deep(receivers, 0, receiversCount, receiverWorkerInv, unit, _, ?newReceiverCounts);
+                    assert newReceiverCounts == append(take(k, oldReceiverCounts), cons(myNewReceiverCount, drop(1, drop(k, oldReceiverCounts))));
+                    assert length(oldReceiverCounts) == receiversCount;
+                    assert 0 <= 1 &*& 0 <= k &*& 1 + k <= length(oldReceiverCounts);
+                    drop_drop(1, k, oldReceiverCounts);
+                    assert newReceiverCounts == append(take(k, oldReceiverCounts), cons(myNewReceiverCount, drop(k + 1, oldReceiverCounts)));
+                    sum_take_cons_drop(k, oldReceiverCounts, myNewReceiverCount);
+                    assert sum(newReceiverCounts) == sum(oldReceiverCounts) + myNewReceiverCount - myOldReceiveCount;
+                    
+                    switch (items) {
+                    case nil:
+                        close my_unsep_pred(c)(items, qms);
+                        close Q(null);
+                    case cons(head, tail):
+                        close my_unsep_pred(c)(tail, qms);
+                        close Q(head);
+                    }
+                }
+                @*/
+                //@ produce_lemma_function_pointer_chunk(my_sep) : channel_sep(client_inv(c), c, my_sep_pred, my_unsep_pred(c))() { close exists(c); call(); };
+                //@ produce_lemma_function_pointer_chunk(my_unsep) : channel_unsep(client_inv(c), c, my_sep_pred, my_unsep_pred(c))() { close exists(c); call(); };
+                //@ close my_sep_pred();
+                //@ produce_lemma_function_pointer_chunk(my_channel_receive) : channel_receive(client_inv(c), c, my_unsep_pred(c), P, Q)() { call(); };
+                //@ close P();
+                String m = Program.channel.receive();
+                //@ open Q(m);
+                if (m != null) break;
+            }
+        }
+        //@ close post();
+    }
+}
+
+public class Program {
+    
+    //@ static int sendCount;
+    //@ static int receiveCount;
+    
+    public static int sendMaxCount;
+    public static int receiveMaxCount;
+    public static Channel channel;
+    public static int sendersCount;
+    public static int receiversCount;
+    public static SenderThread[] senders;
+    public static ReceiverThread[] receivers;
+    
+    public static void main(String[] args)
+        //@ requires class_init_token(Program.class);
+        //@ ensures true;
+    {
+        //@ init_class();
+        Program.sendersCount = 1000;
+        Program.receiversCount = 1000;
+        Program.sendMaxCount = 2000;
+        Program.receiveMaxCount = 2000;
+        Program.work();
+        //@assert Program.sendCount == 2000000;
+        //@assert Program.receiveCount == 2000000;
+    }
+    
+    public static void work()
+        /*@
+        requires
+            Program_channel(?channel) &*&
+            Program_senders(_) &*& Program_receivers(_) &*&
+            [_]Program_sendersCount(?sendersCount) &*& [_]Program_receiversCount(?receiversCount) &*&
+            0 < sendersCount &*& 0 < receiversCount &*&
+            Program_sendCount(?psc) &*& Program_receiveCount(?prc) &*& psc==0 &*& prc==0 &*&
+            Program_sendMaxCount(?smc) &*& 0 < smc  &*& Program_receiveMaxCount(?rmc) &*& 0 < rmc;
+        @*/
+        //@ ensures Program_sendCount(smc * sendersCount) &*& Program_receiveCount(rmc * receiversCount);
+     {
+        Program.senders = new SenderThread[Program.sendersCount];
+        //@ SenderThread[] s = Program.senders;
+        //@ leak Program_senders(s);
+        //@ array_slice_deep_empty_close(s, 0, senderWorker, unit);
+        for (int i = 0; i < Program.sendersCount; i++)
+            /*@
+            invariant
+                0 <= i &*& i <= sendersCount &*&
+                [_]Program_senders(s) &*& [_]Program_sendersCount(sendersCount) &*&
+                [1/3]Program_sendMaxCount(smc) &*& 0 < smc &*&
+                array_slice(s, i, sendersCount, ?elems) &*& all_eq(elems, null) == true &*&
+                [1/3]array_slice_deep(s, 0, i, senderWorkerInv, unit, _, ?v) &*& all_eq(v, 0) == true &*&
+                [2/3]array_slice_deep(s, 0, i, senderWorkerNull, unit, _, _);
+            @*/
+        {
+            Program.senders[i] = new SenderThread();
+            //@ Program.senders[i].myIndex = i;
+            //@ array_slice_split(senders, i, i + 1);
+            //@ close [2/3]senderWorkerNull(unit, senders[i], unit);
+            //@ close [1/3]senderWorkerInv(unit, senders[i], _);
+            //@ array_slice_deep_close_precise(2/3, senders, i, senderWorkerNull, unit);
+            //@ array_slice_deep_close_precise(1/3, senders, i, senderWorkerInv, unit);
+            
+        }
+        
+        Program.receivers = new ReceiverThread[Program.receiversCount];
+        //@ ReceiverThread[] r = Program.receivers;
+        //@ leak Program_receivers(r);
+        //@ array_slice_deep_empty_close(r, 0, receiverWorker, unit);
+        for (int i = 0; i < Program.receiversCount; i++)
+            /*@
+            invariant
+                0 <= i &*& i <= receiversCount &*&
+                [_]Program_receivers(r) &*& [_]Program_receiversCount(receiversCount) &*&
+                [1/3]Program_receiveMaxCount(rmc) &*& 0 < rmc &*&
+                array_slice(r, i, receiversCount, ?elems) &*& all_eq(elems, null) == true &*&
+                [1/3]array_slice_deep(r, 0, i, receiverWorkerInv, unit, _, ?v) &*& all_eq(v, 0) == true &*&
+                [2/3]array_slice_deep(r, 0, i, receiverWorkerNull, unit, _, _);
+            @*/
+        {
+            receivers[i] = new ReceiverThread();
+            //@ Program.receivers[i].myIndex = i;
+            //@ array_slice_split(receivers, i, i + 1);
+            //@ close [2/3]receiverWorkerNull(unit, receivers[i], unit);
+            //@ close [1/3]receiverWorkerInv(unit, receivers[i], _);
+            //@ array_slice_deep_close_precise(2/3, receivers, i, receiverWorkerNull, unit);
+            //@ array_slice_deep_close_precise(1/3, receivers, i, receiverWorkerInv, unit);
+        }
+        Program.channel = new Channel(2);
+        
+        //@ close client_inv(Program.channel)();
+        //@ create_atomic_space(client_inv(Program.channel));
+        //@ close foreach_i(0, nil, senderWorkerIndex);
+        
+        for (int i = 0; i < Program.sendersCount; i++)
+            /*@
+            invariant
+                0 <= i &*& i <= sendersCount &*&
+                [_]Program_sendersCount(sendersCount) &*& [_]Program_senders(s) &*&
+                [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*& [_]Program_sendMaxCount(smc) &*& 0 < smc &*&
+                [2/3]array_slice_deep(s, i, sendersCount, senderWorkerNull, unit, _, _) &*&
+                [1/3]array_slice_deep(s, 0, i, senderWorker, unit, ?elements, _) &*& foreach_i(0, elements, senderWorkerIndex);
+            @*/
+        {
+            //@ array_slice_deep_split(s, i, i + 1);
+            //@ array_slice_deep_open_precise(2/3, s, i);
+            SenderThread sender = senders[i];
+            //@ close [1/3]senderWorkerInv(unit, sender, _);
+            //@ array_slice_deep_close_precise(1/3, s, i, senderWorkerInv, unit);
+            JoinableRunnable j = ThreadingHelper.createJoinableRunnable(sender);
+            //@ sender.myIndex = i;
+            //@ leak sender.myIndex |-> i;
+            //@ close sender.pre();
+            //@ j.closeIt();
+            Thread t = new Thread(j);
+            t.start();
+            
+            sender.thread = t;
+            sender.joinable = j;
+            //@ close [1/3]senderWorker(unit, sender, unit);
+            //@ array_slice_deep_close_precise(1/3, senders, i, senderWorker, unit);
+            
+            //@ close foreach_i(i + 1, nil, senderWorkerIndex);
+            //@ close senderWorkerIndex(i, sender);
+            //@ close foreach_i(i, cons(sender, nil), senderWorkerIndex);
+            //@ foreach_i_append(0, elements, cons(sender, nil));
+        }
+        //@ close foreach_i(0, nil, receiverWorkerIndex);
+        for (int i = 0; i < Program.receiversCount; i++)
+            /*@
+            invariant
+                0 <= i &*& i <= receiversCount &*&
+                [_]Program_receiversCount(receiversCount) &*& [_]Program_receivers(r) &*&
+                [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*& [_]Program_receiveMaxCount(rmc) &*& 0 < rmc &*&
+                [2/3]array_slice_deep(r, i, receiversCount, receiverWorkerNull, unit, _, _) &*&
+                [1/3]array_slice_deep(r, 0, i, receiverWorker, unit, ?elements, _) &*& foreach_i(0, elements, receiverWorkerIndex);
+            @*/
+        {
+            //@ array_slice_deep_split(r, i, i + 1);
+            //@ array_slice_deep_open_precise(2/3, r, i);
+            ReceiverThread receiver = receivers[i];
+            //@ close [1/3]receiverWorkerInv(unit, receiver, _);
+            //@ array_slice_deep_close_precise(1/3, r, i, receiverWorkerInv, unit);
+            JoinableRunnable j = ThreadingHelper.createJoinableRunnable(receiver);
+            //@ receiver.myIndex = i;
+            //@ leak receiver.myIndex |-> i;
+            //@ close receiver.pre();
+            //@ j.closeIt();
+            Thread t = new Thread(j);
+            t.start();
+            
+            receiver.thread = t;
+            receiver.joinable = j;
+            //@ close [1/3]receiverWorker(unit, receiver, unit);
+            //@ array_slice_deep_close_precise(1/3, receivers, i, receiverWorker, unit);
+            
+            //@ close foreach_i(i + 1, nil, receiverWorkerIndex);
+            //@ close receiverWorkerIndex(i, receiver);
+            //@ close foreach_i(i, cons(receiver, nil), receiverWorkerIndex);
+            //@ foreach_i_append(0, elements, cons(receiver, nil));
+        }
+        
+        int j;
+        for (j = 0; j < Program.sendersCount; j++)
+            /*@
+            invariant
+                0 <= j &*& j <= sendersCount &*&
+                [_]Program_sendersCount(sendersCount) &*& [_]Program_senders(s) &*&
+                [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+                Program_sendCount(j * smc) &*& [_]Program_sendMaxCount(smc) &*&
+                [1/3]array_slice_deep(s, j, sendersCount, senderWorker, unit, ?elements, _) &*& foreach_i(j, elements, senderWorkerIndex);
+            @*/
+        {
+            SenderThread sw = senders[j];
+            ThreadingHelper.join(sw.thread, sw.joinable);
+            //@ open sw.post();
+            //@ open foreach_i(j, elements, senderWorkerIndex);
+            //@ open senderWorkerIndex(j, sw);
+            //@ int jj = sw.myIndex;
+            //@ assert j == jj;
+            //@ array_slice_deep_open_precise(1/3, s, j);
+            //@ open senderWorkerInv(unit, sw, _);
+            //@ Program.sendCount += sw.senderSendCount;
+        }
+        //@ assert Program.sendCount == Program.sendMaxCount * j;
+        //@ assert j == sendersCount;
+        //@ assert Program.sendCount == Program.sendMaxCount * sendersCount;
+        for (j = 0; j < Program.receiversCount; j++)
+            /*@
+            invariant
+                0 <= j &*& j <= receiversCount &*&
+                [_]Program_receiversCount(receiversCount) &*& [_]Program_receivers(r) &*&
+                [_]Program_channel(?c) &*& [_]c.Channel() &*& [_]atomic_space(client_inv(c)) &*&
+                Program_receiveCount(j * rmc) &*& [_]Program_receiveMaxCount(rmc) &*&
+                [1/3]array_slice_deep(r, j, receiversCount, receiverWorker, unit, ?elements, _) &*& foreach_i(j, elements, receiverWorkerIndex);
+            @*/
+        {
+            ReceiverThread rw = receivers[j];
+            ThreadingHelper.join(rw.thread, rw.joinable);
+            //@ open rw.post();
+            //@ open foreach_i(j, elements, receiverWorkerIndex);
+            //@ open receiverWorkerIndex(j, rw);
+            //@ int jj = rw.myIndex;
+            //@ assert j == jj;
+            //@ array_slice_deep_open_precise(1/3, r, j);
+            //@ open receiverWorkerInv(unit, rw, _);
+            //@ Program.receiveCount += rw.receiverReceiveCount;
+        }
+        //@ assert Program.receiveCount == Program.receiveMaxCount * j;
+        //@ assert j == receiversCount;
+        //@ assert Program.receiveCount == Program.receiveMaxCount * receiversCount;
+    }
+    
+}

--- a/examples/java/chat/Room.java
+++ b/examples/java/chat/Room.java
@@ -11,13 +11,13 @@ predicate room(Room room) =
 @*/
 
 public class Room {
-    List members;
+    List<Member> members;
 
     public Room()
         //@ requires emp;
         //@ ensures room(this);
     {
-        List a = new ArrayList();
+        List<Member> a = new ArrayList<Member>();
         this.members = a;
         //@ close foreach<Member>(nil, member);
         //@ close room(this);
@@ -29,9 +29,9 @@ public class Room {
     {
         //@ open room(this);
         //@ assert foreach(?members, _);
-        List membersList = this.members;
+        List<Member> membersList = this.members;
         //@ membersList.listToIterable();
-        Iterator iter = membersList.iterator();
+        Iterator<Member> iter = membersList.iterator();
         boolean hasMember = false;
         boolean hasNext = iter.hasNext();
         while (hasNext && !hasMember)
@@ -41,8 +41,7 @@ public class Room {
                 &*& hasNext == (i < length(members)) &*& 0 <= i &*& i <= length(members);
             @*/
         {
-            Object o = iter.next();
-            Member member = (Member)o;
+            Member member = iter.next();
             //@ foreach_remove<Member>(member, members);
             //@ open member(member);
             hasMember = nick.equals(member.nick);
@@ -62,9 +61,9 @@ public class Room {
     {
         //@ open room(this);
         //@ assert foreach(?members0, _);
-        List membersList = this.members;
+        List<Member> membersList = this.members;
         //@ membersList.listToIterable();
-        Iterator iter = membersList.iterator();
+        Iterator<Member> iter = membersList.iterator();
         boolean hasNext = iter.hasNext();
         //@ length_nonnegative(members0);
         while (hasNext)
@@ -74,8 +73,7 @@ public class Room {
                 &*& hasNext == (i < length(members)) &*& 0 <= i &*& i <= length(members);
             @*/
         {
-            Object o = iter.next();
-            Member member = (Member)o;
+            Member member = iter.next();
             //@ mem_nth(i, members);
             //@ foreach_remove<Member>(member, members);
             //@ open member(member);

--- a/examples/java/chat/Session.java
+++ b/examples/java/chat/Session.java
@@ -7,7 +7,7 @@ import java.util.concurrent.*;
 
 class ListUtil {
     
-    static void remove(List l, Object o) // Like l.remove(o), except uses identity comparison instead of .equals().
+    static <T> void remove(List<T> l, T o) // Like l.remove(o), except uses identity comparison instead of .equals().
         //@ requires l.List(?es);
         //@ ensures l.List(remove(o, es));
     {
@@ -74,7 +74,7 @@ public final class Session implements Runnable {
         {
             //@ open room(room);
             member = new Member(nick, writer);
-            List list = room.members;
+            List<Member> list = room.members;
             list.add(member);
             //@ open foreach<Member>(?members, @member);
             //@ close foreach(members, @member);
@@ -107,7 +107,7 @@ public final class Session implements Runnable {
         //@ open room_ctor(room)();
         //@ open room(room);
         {
-            List membersList = room.members;
+            List<Member> membersList = room.members;
             //@ assert foreach<Member>(?members, @member);
             //@ assume(mem<Member>(member, members)); // TODO: Eliminate using a ghost list.
             ListUtil.remove(membersList, member);
@@ -161,10 +161,10 @@ public final class Session implements Runnable {
         //@ open room_ctor(room)();
         //@ open room(room);
         {
-            List membersList = room.members;
+            List<Member> membersList = room.members;
             //@ assert foreach<Member>(?members, @member);
             //@ membersList.listToIterable();
-            Iterator iter = membersList.iterator();
+            Iterator<Member> iter = membersList.iterator();
             boolean hasNext = iter.hasNext();
             while (hasNext)
                 /*@
@@ -174,8 +174,7 @@ public final class Session implements Runnable {
                     &*& foreach(members, @member) &*& hasNext == (i < length(members)) &*& 0 <= i &*& i <= length(members);
                 @*/
             {
-                Object o = iter.next();
-                Member member = (Member)o;
+                Member member = iter.next();
                 //@ foreach_remove<Member>(member, members);
                 //@ open member(member);
                 writer.write(member.nick);

--- a/examples/java/chat/Session.java
+++ b/examples/java/chat/Session.java
@@ -7,7 +7,7 @@ import java.util.concurrent.*;
 
 class ListUtil {
     
-    static <T> void remove(List<T> l, T o) // Like l.remove(o), except uses identity comparison instead of .equals().
+    static void remove(List l, Object o) // Like l.remove(o), except uses identity comparison instead of .equals().
         //@ requires l.List(?es);
         //@ ensures l.List(remove(o, es));
     {

--- a/examples/java/chat_raw/Member.java
+++ b/examples/java/chat_raw/Member.java
@@ -1,0 +1,50 @@
+package chat;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+/*@
+
+predicate member(Member member) =
+    member.nick |-> ?nick &*& [1/2]member.writer |-> ?writer &*& writer != null &*& writer.Writer();
+
+lemma void member_distinct(Member m1,Member m2)
+    requires member(m1) &*& member(m2);
+    ensures member(m1) &*& member(m2) &*& m1 != m2;
+{
+    open member(m1);
+    open member(m2);
+    close member(m2);
+    close member(m1);
+}
+
+lemma void foreach_member_not_contains(list<Member> members, Member member)
+    requires foreach(members, @member) &*& member(member);
+    ensures foreach(members, @member) &*& member(member) &*& !mem<Object>(member, members);
+{
+    switch (members) {
+        case nil:
+        case cons(m, ms):
+            open foreach(members, @member);
+            member_distinct(m, member);
+            foreach_member_not_contains(ms, member);
+            close foreach(members, @member);
+    }
+}
+
+@*/
+
+class Member {
+    String nick;
+    Writer writer;
+    
+    public Member(String nick, Writer writer)
+        //@ requires writer != null &*& writer.Writer();
+        //@ ensures member(this) &*& [1/2]this.writer |-> writer;
+    {
+        this.nick = nick;
+        this.writer = writer;
+        //@ close member(this);
+    }
+}

--- a/examples/java/chat_raw/Program.java
+++ b/examples/java/chat_raw/Program.java
@@ -1,0 +1,30 @@
+package chat;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class Program {
+    public static void main(String[] args) throws IOException /*@ ensures true; @*/
+        //@ requires true;
+        //@ ensures true;
+    {
+        Room room = new Room();
+        //@ close room_ctor(room)();
+        //@ one_time(room_ctor(room));
+        Semaphore roomLock = new Semaphore(1);
+        //@ roomLock.leakHandle();
+        ServerSocket serverSocket = new ServerSocket(12345);
+
+        while (true)
+            //@ invariant [_]roomLock.Semaphore(room_ctor(room)) &*& serverSocket.ServerSocket();
+        {
+            Socket socket = serverSocket.accept();
+            Session session = new Session(room, roomLock, socket);
+            //@ close session.pre();
+            Thread t = new Thread(session);
+            t.start();
+        }
+    }
+}

--- a/examples/java/chat_raw/Room.java
+++ b/examples/java/chat_raw/Room.java
@@ -1,0 +1,92 @@
+package chat;
+
+import java.io.*;
+import java.util.*;
+
+/*@
+
+predicate room(Room room) =
+    room.members |-> ?membersList &*& membersList != null &*& foreach<Member>(?members, member) &*& membersList.List(members);
+
+@*/
+
+public class Room {
+    List members;
+
+    public Room()
+        //@ requires emp;
+        //@ ensures room(this);
+    {
+        List a = new ArrayList();
+        this.members = a;
+        //@ close foreach<Member>(nil, member);
+        //@ close room(this);
+    }
+    
+    public boolean has_member(String nick)
+        //@ requires room(this) &*& nick != null;
+        //@ ensures room(this);
+    {
+        //@ open room(this);
+        //@ assert foreach(?members, _);
+        List membersList = this.members;
+        //@ membersList.listToIterable();
+        Iterator iter = membersList.iterator();
+        boolean hasMember = false;
+        boolean hasNext = iter.hasNext();
+        while (hasNext && !hasMember)
+            /*@
+            invariant
+                iter.Iterator((seq_of_list)(members), _, ?i) &*& Iterable_iterating(membersList.getClass())(membersList, members, 1, iter) &*& foreach(members, @member)
+                &*& hasNext == (i < length(members)) &*& 0 <= i &*& i <= length(members);
+            @*/
+        {
+            Member member = (Member) iter.next();
+            //@ foreach_remove<Member>(member, members);
+            //@ open member(member);
+            hasMember = nick.equals(member.nick);
+            //@ close member(member);
+            //@ foreach_unremove<Member>(member, members);
+            hasNext = iter.hasNext();
+        }
+        //@ membersList.destroyIterator();
+        //@ membersList.iterableToList();
+        //@ close room(this);
+        return hasMember;
+    }
+    
+    public void broadcast_message(String message) throws IOException /*@ ensures true; @*/
+        //@ requires room(this) &*& message != null;
+        //@ ensures room(this);
+    {
+        //@ open room(this);
+        //@ assert foreach(?members0, _);
+        List membersList = this.members;
+        //@ membersList.listToIterable();
+        Iterator iter = membersList.iterator();
+        boolean hasNext = iter.hasNext();
+        //@ length_nonnegative(members0);
+        while (hasNext)
+            /*@
+            invariant
+                foreach<Member>(?members, @member) &*& iter.Iterator((seq_of_list)(members), _, ?i) &*& Iterable_iterating(membersList.getClass())(membersList, members, 1, iter)
+                &*& hasNext == (i < length(members)) &*& 0 <= i &*& i <= length(members);
+            @*/
+        {
+            Member member = (Member) iter.next();
+            //@ mem_nth(i, members);
+            //@ foreach_remove<Member>(member, members);
+            //@ open member(member);
+            Writer writer = member.writer;
+            writer.write(message);
+            writer.write("\r\n");
+            writer.flush();
+            //@ close member(member);
+            //@ foreach_unremove<Member>(member, members);
+            hasNext = iter.hasNext();
+        }
+        //@ membersList.destroyIterator();
+        //@ membersList.iterableToList();
+        //@ close room(this);
+    }
+}

--- a/examples/java/chat_raw/Session.java
+++ b/examples/java/chat_raw/Session.java
@@ -1,0 +1,234 @@
+package chat;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+class ListUtil {
+    
+    static void remove(List l, Object o) // Like l.remove(o), except uses identity comparison instead of .equals().
+        //@ requires l.List(?es);
+        //@ ensures l.List(remove(o, es));
+    {
+        for (int i = 0; i < l.size(); i++)
+            //@ invariant l.List(es) &*& 0 <= i &*& i <= index_of(o, es);
+        {
+            if (l.get(i) == o) {
+                l.remove(i);
+                //@ remove_remove_nth(o, es);
+                //@ index_of_nth(i, es);
+                break;
+            }
+            //@ if (index_of(o, es) == i) { nth_index_of(o, es); }
+        }
+        //@ if (mem(o, es)) { mem_index_of(o, es); } else { mem_remove_eq(o, es); }
+    }
+    
+}
+
+/*@
+
+predicate_ctor room_ctor(Room room)() = room(room);
+
+predicate session(Session session;) =
+    session.room |-> ?room &*& session.room_lock |-> ?roomLock &*& session.socket |-> ?socket &*& socket != null &*& socket.Socket(?i, ?o)
+    &*& roomLock != null &*& [_]roomLock.Semaphore(room_ctor(room)) &*& i.InputStream() &*& o.OutputStream();
+
+@*/
+
+public final class Session implements Runnable {
+    Room room;
+    Semaphore room_lock;
+    Socket socket;
+    
+    //@ predicate pre() = session(this);
+    //@ predicate post() = true;
+    
+    public Session(Room room, Semaphore roomLock, Socket socket)
+        /*@
+        requires
+            roomLock != null &*& [_]roomLock.Semaphore(room_ctor(room)) &*&
+            socket != null &*& socket.Socket(?i, ?o) &*& i.InputStream() &*& o.OutputStream();
+        @*/
+        //@ ensures session(this);
+    {
+        this.room = room;
+        this.room_lock = roomLock;
+        this.socket = socket;
+        //@ close session(this);
+    }
+    
+    public void run_with_nick(Room room, Semaphore roomLock, BufferedReader reader, Writer writer, String nick) throws InterruptedException /*@ ensures true; @*/, IOException /*@ ensures true; @*/
+        /*@
+        requires
+            roomLock != null &*& [_]roomLock.Semaphore(room_ctor(room)) &*& room != null &*& room(room) &*&
+            reader != null &*& reader.Reader() &*&
+            writer != null &*& writer.Writer();
+        @*/
+        //@ ensures [_]roomLock.Semaphore(room_ctor(room)) &*& reader.Reader() &*& writer.Writer();
+    {
+        Member member = null;
+        String joinMessage = nick + " has joined the room.";
+        room.broadcast_message(joinMessage);
+        {
+            //@ open room(room);
+            member = new Member(nick, writer);
+            List list = room.members;
+            list.add(member);
+            //@ open foreach<Member>(?members, @member);
+            //@ close foreach(members, @member);
+            //@ foreach_member_not_contains(members, member);
+            //@ close foreach<Member>(nil, @member);
+            //@ close foreach<Member>(cons<Member>(member, nil), @member);
+            //@ foreach_append<Member>(members, cons<Member>(member, nil));
+            //@ close room(room);
+        }
+        //@ close room_ctor(room)();
+        //@ roomLock.makeHandle();
+        roomLock.release();
+        
+        {
+            String message = reader.readLine();
+            while (message != null)
+                //@ invariant reader.Reader() &*& [_]roomLock.Semaphore(room_ctor(room));
+            {
+                //@ roomLock.makeHandle();
+                roomLock.acquire();
+                //@ open room_ctor(room)();
+                room.broadcast_message(nick + " says: " + message);
+                //@ close room_ctor(room)();
+                roomLock.release();
+                message = reader.readLine();
+            }
+        }
+        
+        roomLock.acquire();
+        //@ open room_ctor(room)();
+        //@ open room(room);
+        {
+            List membersList = room.members;
+            //@ assert foreach<Member>(?members, @member);
+            //@ assume(mem<Member>(member, members)); // TODO: Eliminate using a ghost list.
+            ListUtil.remove(membersList, member);
+            //@ foreach_remove<Member>(member, members);
+        }
+        //@ close room(room);
+        {
+            room.broadcast_message(nick + " left the room.");
+        }
+        //@ close room_ctor(room)();
+        roomLock.release();
+        
+        //@ open member(member);
+    }
+    
+    public void run()
+        //@ requires pre();
+        //@ ensures post();
+    {
+        try {
+            this.runCore();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public void runCore() throws InterruptedException /*@ ensures true; @*/, IOException /*@ ensures true; @*/
+        //@ requires pre();
+        //@ ensures post();
+    {
+        //@ open pre();
+        //@ open session(this);
+        Room room = this.room;
+        Semaphore roomLock = this.room_lock;
+        Socket socket = this.socket;
+        InputStream in = socket.getInputStream();
+        InputStreamReader reader0 = new InputStreamReader(in);
+        BufferedReader reader = new BufferedReader(reader0);
+        OutputStream out = socket.getOutputStream();
+        OutputStreamWriter writer0 = new OutputStreamWriter(out);
+        BufferedWriter writer1 = new BufferedWriter(writer0);
+        Writer writer = writer1;
+        
+        writer.write("Welcome to the chat room.\r\n");
+        writer.write("The following members are present: ");
+        
+        //@ roomLock.makeHandle();
+        roomLock.acquire();
+        //@ open room_ctor(room)();
+        //@ open room(room);
+        {
+            List membersList = room.members;
+            //@ assert foreach<Member>(?members, @member);
+            //@ membersList.listToIterable();
+            Iterator iter = membersList.iterator();
+            boolean hasNext = iter.hasNext();
+            while (hasNext)
+                /*@
+                invariant
+                    writer.Writer() &*&
+                    iter.Iterator((seq_of_list)(members), _, ?i) &*& Iterable_iterating(membersList.getClass())(membersList, members, 1, iter)
+                    &*& foreach(members, @member) &*& hasNext == (i < length(members)) &*& 0 <= i &*& i <= length(members);
+                @*/
+            {
+                Member member = (Member) iter.next();
+                //@ foreach_remove<Member>(member, members);
+                //@ open member(member);
+                writer.write(member.nick);
+                writer.write("  ");
+                //@ close member(member);
+                //@ foreach_unremove<Member>(member, members);
+                hasNext = iter.hasNext();
+            }
+            writer.write("\r\n");
+            writer.flush();
+            //@ membersList.destroyIterator();
+            //@ membersList.iterableToList();
+        }
+        
+        //@ close room(room);
+        //@ close room_ctor(room)();
+        roomLock.release();
+
+        {
+            boolean done = false;
+            while (!done)
+                //@ invariant writer.Writer() &*& reader.Reader() &*& [_]roomLock.Semaphore(room_ctor(room));
+            {
+                writer.write("Please enter your nick: \r\n");
+                writer.flush();
+                {
+                    String nick = reader.readLine();
+                    if (nick == null) {
+                        done = true;
+                    } else {
+                        //@ roomLock.makeHandle();
+                        roomLock.acquire();
+                        //@ open room_ctor(room)();
+                        {
+                            if (room.has_member(nick)) {
+                                //@ close room_ctor(room)();
+                                roomLock.release();
+                                writer.write("Error: This nick is already in use.\r\n");
+                                writer.flush();
+                            } else {
+                                this.run_with_nick(room, roomLock, reader, writer, nick);
+                                done = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        //@ reader.destroy();
+        //@ reader0.destroy();
+        //@ writer1.destroy();
+        //@ writer0.destroy();
+        socket.close();
+        //@ close post();
+    }
+}

--- a/examples/java/chat_raw/chat.bat
+++ b/examples/java/chat_raw/chat.bat
@@ -1,0 +1,4 @@
+javac *.java
+if errorlevel 1 goto end
+java -cp .. chat.Program
+:end

--- a/examples/java/chat_raw/chat.jarsrc
+++ b/examples/java/chat_raw/chat.jarsrc
@@ -1,0 +1,5 @@
+Session.java
+Room.java
+Member.java
+Program.java
+main-class chat.Program

--- a/examples/java/frontend/big_example/Java7Program_desugared.java
+++ b/examples/java/frontend/big_example/Java7Program_desugared.java
@@ -43,13 +43,13 @@ predicate_family_instance FoldFunc(Java7Program_desugared$1.class)(FoldFunc f, l
 
 public class Java7Program_desugared 
 {
-  public static <T> void addAll(List<T> l, T[] xs) throws EmptyException /*@ ensures xs.length == 0; @*/
+  public static void addAll(List l, Object[] xs) throws EmptyException /*@ ensures xs.length == 0; @*/
     //@ requires l.List(?l_es) &*& [?f]xs[..] |-> ?xs_es;
     //@ ensures l.List(append(l_es, xs_es)) &*& [f]xs[..] |-> xs_es &*& xs.length > 0;
   {
     if (xs.length > 0)
     {
-      List<T> temp = Arrays.asList(xs);
+      List temp = Arrays.asList(xs);
       //@ close listIsCollection(temp, temp);
       l.addAll(temp);
     }
@@ -59,20 +59,20 @@ public class Java7Program_desugared
     }
   }
 
-  public static <T> T fold(FoldFunc f, List<T> xs, T acc0)
+  public static Object fold(FoldFunc f, List xs, Object acc0)
     //@ requires xs.List(?es) &*& FoldFunc(f.getClass())(f, es, acc0, ?info) &*& f != null;
     //@ ensures xs.List(es) &*& FoldFunc(f.getClass())(f, nil, result, info);
   {
-    T acc = acc0;
+    Object acc = acc0;
     
     //@ xs.listToIterable();
     {
-      Iterator<T> iSSS = xs.iterator();
+      Iterator iSSS = xs.iterator();
       while (iSSS.hasNext())
         //@ requires iSSS.Iterator((seq_of_list)(es), _, ?n) &*& FoldFunc(f.getClass())(f, drop(n, es), acc, info) &*& f != null &*& n >= 0 &*& n <= length(es);
         //@ ensures FoldFunc(f.getClass())(f, nil, acc, info) &*& iSSS.Iterator((seq_of_list)(es), _, length(es));
       {
-        T x = iSSS.next();
+        Object x = iSSS.next();
         {
           //@ drop_n_plus_one(n, es);
           acc = f.fold(acc, x);
@@ -89,7 +89,7 @@ public class Java7Program_desugared
     //@ requires true;
     //@ ensures true;
   {
-    List<Integer> xs = new ArrayList<Integer>(); 
+    List xs = new ArrayList(); 
     Integer i1 = Integer.valueOf(3);
     Integer i2 = Integer.valueOf(5);
     Integer i3 = Integer.valueOf(7);
@@ -107,7 +107,7 @@ public class Java7Program_desugared
     FoldFunc func = new Java7Program_desugared$1();
     Integer acc = Integer.valueOf(2);
     //@ close FoldFunc(Java7Program_desugared$1.class)(func, exs, acc, cons(acc, exs));
-    Integer vo = fold(func, xs, acc);
+    Object vo = fold(func, xs, acc);
     Integer vi = (Integer) vo;
     //@ open FoldFunc(Java7Program_desugared$1.class)(_, _, _, _);
     int v = vi.intValue();

--- a/examples/java/frontend/big_example/Java7Program_desugared.java
+++ b/examples/java/frontend/big_example/Java7Program_desugared.java
@@ -43,13 +43,13 @@ predicate_family_instance FoldFunc(Java7Program_desugared$1.class)(FoldFunc f, l
 
 public class Java7Program_desugared 
 {
-  public static void addAll(List l, Object[] xs) throws EmptyException /*@ ensures xs.length == 0; @*/
+  public static <T> void addAll(List<T> l, T[] xs) throws EmptyException /*@ ensures xs.length == 0; @*/
     //@ requires l.List(?l_es) &*& [?f]xs[..] |-> ?xs_es;
     //@ ensures l.List(append(l_es, xs_es)) &*& [f]xs[..] |-> xs_es &*& xs.length > 0;
   {
     if (xs.length > 0)
     {
-      List temp = Arrays.asList(xs);
+      List<T> temp = Arrays.asList(xs);
       //@ close listIsCollection(temp, temp);
       l.addAll(temp);
     }
@@ -59,20 +59,20 @@ public class Java7Program_desugared
     }
   }
 
-  public static Object fold(FoldFunc f, List xs, Object acc0)
+  public static <T> T fold(FoldFunc f, List<T> xs, T acc0)
     //@ requires xs.List(?es) &*& FoldFunc(f.getClass())(f, es, acc0, ?info) &*& f != null;
     //@ ensures xs.List(es) &*& FoldFunc(f.getClass())(f, nil, result, info);
   {
-    Object acc = acc0;
+    T acc = acc0;
     
     //@ xs.listToIterable();
     {
-      Iterator iSSS = xs.iterator();
+      Iterator<T> iSSS = xs.iterator();
       while (iSSS.hasNext())
         //@ requires iSSS.Iterator((seq_of_list)(es), _, ?n) &*& FoldFunc(f.getClass())(f, drop(n, es), acc, info) &*& f != null &*& n >= 0 &*& n <= length(es);
         //@ ensures FoldFunc(f.getClass())(f, nil, acc, info) &*& iSSS.Iterator((seq_of_list)(es), _, length(es));
       {
-        Object x = (Object) iSSS.next();
+        T x = iSSS.next();
         {
           //@ drop_n_plus_one(n, es);
           acc = f.fold(acc, x);
@@ -89,7 +89,7 @@ public class Java7Program_desugared
     //@ requires true;
     //@ ensures true;
   {
-    List xs = new ArrayList(); 
+    List<Integer> xs = new ArrayList<Integer>(); 
     Integer i1 = Integer.valueOf(3);
     Integer i2 = Integer.valueOf(5);
     Integer i3 = Integer.valueOf(7);
@@ -107,7 +107,7 @@ public class Java7Program_desugared
     FoldFunc func = new Java7Program_desugared$1();
     Integer acc = Integer.valueOf(2);
     //@ close FoldFunc(Java7Program_desugared$1.class)(func, exs, acc, cons(acc, exs));
-    Object vo = fold(func, xs, acc);
+    Integer vo = fold(func, xs, acc);
     Integer vi = (Integer) vo;
     //@ open FoldFunc(Java7Program_desugared$1.class)(_, _, _, _);
     int v = vi.intValue();

--- a/setup-build.sh
+++ b/setup-build.sh
@@ -22,7 +22,7 @@ elif [ $(uname -s) = "Darwin" ]; then
   brew update
 
   if [ $TRAVIS = "true" ]; then
-      brew unlink python # See https://github.com/verifast/verifast/issues/127
+      brew unlink python@2 # See https://github.com/verifast/verifast/issues/191
   fi
 
   function brewinstall {

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -633,7 +633,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
                                 ; "postcondition", sexpr_of_pred post ]
       in
       let kw = List.concat [ [ "kind", sexpr_of_func_kind kind
-                             ; "type-parameters", List (List.map sexpr_of_tparam tparams )
+                             ; "type-parameters", List (List.map symbol tparams )
                              ; "return-type", sexpr_of_type_expr_option rtype
                              ; "parameters", List (List.map sexpr_of_arg params) ]
                            ; body
@@ -649,7 +649,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
                       inductiveness) ->
       build_list [ Symbol "declare-predicate-family"
                  ; Symbol name ]
-                 [ "type-parameters", List (List.map sexpr_of_tparam tparams)
+                 [ "type-parameters", List (List.map symbol tparams)
                  ; "parameters", List (List.map sexpr_of_type_expr params)
                  ; "index-count", sexpr_of_int index_count
                  ; "coinductive", sexpr_of_bool (inductiveness = Inductiveness_CoInductive)]
@@ -665,7 +665,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
       in
       build_list [ Symbol "declare-predicate-family-instance"
                  ; Symbol name ]
-                 [ "type-parameters", List (List.map sexpr_of_tparam tparams) 
+                 [ "type-parameters", List (List.map symbol tparams) 
                  ; "parameters", List (List.map arg_pair params)
                  ; "predicate", sexpr_of_pred predicate ]
     | ImportModuleDecl (loc, name) ->
@@ -674,7 +674,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
     | Inductive (_, name, tparams, cons) ->
       build_list [ Symbol "declare-inductive"
                  ; Symbol name]
-                 [ "tparams", List (List.map sexpr_of_tparam tparams)
+                 [ "tparams", List (List.map symbol tparams)
                  ; "constructors", sexpr_of_list sexpr_of_inductive_constructor cons ]
     | Interface (_, id, inters, fields, meths, tparams, preds) ->
       build_list [ Symbol "declare-interface"

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -591,8 +591,8 @@ let rec sexpr_of_stmt (stmt : stmt) : sexpression =
                  [ "arguments", List (List.map sexpr_of_expr args) ]
 
 and sexpr_of_decl (decl : decl) : sexpression =
-  let sexpr_of_tparam tparam =
-        Symbol tparam in
+  let symbol s = Symbol s
+  in
   match decl with
     | Struct (loc,
               name,

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -747,10 +747,8 @@ and sexpr_of_meths (meth : meth) : sexpression =
       build_list [ Symbol "declare-method"; Symbol name ] kw
 
 and sexpr_of_constructor (name : string) (cons : cons) : sexpression =
-  let sexpr_of_tparam tparam =
-    Symbol tparam in
   match cons with
-  | Cons (loc, params, contract, body, vis, tparams) ->
+  | Cons (loc, params, contract, body, vis) ->
     let sexpr_of_arg (t, id) =
       List [ Symbol id; sexpr_of_type_expr t ]
     in
@@ -765,8 +763,7 @@ and sexpr_of_constructor (name : string) (cons : cons) : sexpression =
         | Some (pre, post, _, _) -> [ "precondition", sexpr_of_pred pre
                                     ; "postcondition", sexpr_of_pred post ] 
     in        
-    let kw = List.concat [ [ "parameters", List (List.map sexpr_of_arg params)
-                            ; "type-parameters", List (List.map sexpr_of_tparam tparams) ]
+    let kw = List.concat [ [ "parameters", List (List.map sexpr_of_arg params) ]
                           ; body
                           ; contract ]
     in

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -87,7 +87,7 @@ let rec sexpr_of_type_ (t : type_) : sexpression =
                                         sexpr_of_type_ t2]
     | ObjType (s, targs)             -> List [ Symbol "type-obj-type";
                                         Symbol s ;
-                                        Symbol "type-arguments: " ;
+                                        Symbol "type-arguments:" ;
                                         sexpr_of_list sexpr_of_type_ targs]
     | ArrayType (t)           -> List [ Symbol "type-array-type";
                                         sexpr_of_type_ t ]
@@ -331,9 +331,11 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
       build_list [ Symbol "expr-new-array" ]
                  [ "texpr", sexpr_of_type_expr texpr
                  ; "expr", sexpr_of_expr expr]
-    | NewObject (l, cn, args) ->
+    | NewObject (l, cn, args, targs) ->
       build_list [ Symbol "expr-new-obj"; Symbol cn ]
-                 [ "args", sexpr_of_list sexpr_of_expr args]
+                 [ "args", sexpr_of_list sexpr_of_expr args ;
+                  "targs", sexpr_of_option (fun targs -> sexpr_of_list sexpr_of_type_expr targs) targs ]
+
     | NewArrayWithInitializer (l, texpr, args) -> 
       build_list [ Symbol "expr-array-init" ]
                  [ "type", sexpr_of_type_expr texpr
@@ -619,6 +621,9 @@ and sexpr_of_decl (decl : decl) : sexpression =
       let sexpr_of_arg (t, id) =
         List [ Symbol id; sexpr_of_type_expr t ]
       in
+      let sexpr_of_tparam tparam =
+        Symbol tparam
+      in
       let body =
         match body with
           | None           -> [ ]
@@ -631,7 +636,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
                                 ; "postcondition", sexpr_of_pred post ]
       in
       let kw = List.concat [ [ "kind", sexpr_of_func_kind kind
-                             ; "type-parameters", Symbol (String.concat ", " tparams)
+                             ; "type-parameters", List (List.map sexpr_of_tparam tparams )
                              ; "return-type", sexpr_of_type_expr_option rtype
                              ; "parameters", List (List.map sexpr_of_arg params) ]
                            ; body

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -208,6 +208,7 @@ let sexpr_of_method_binding (binding : method_binding) : sexpression =
     | Instance -> Symbol "instance-method"
 
 let rec sexpr_of_expr (expr : expr) : sexpression =
+  let sexpr_of_tparam t = Symbol t in
   match expr with
     | Operation (loc, op, exprs) -> 
       build_list [ Symbol "expr-op"
@@ -325,7 +326,9 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
                  ; "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs 
-                 ; "stat", sexpr_of_method_binding bind ]
+                 ; "stat", sexpr_of_method_binding bind 
+                 ; "tparams", sexpr_of_list sexpr_of_tparam (List.map (fun (tparam,targ) -> tparam) tparamEnv)
+                 ; "targs", sexpr_of_list sexpr_of_type_ (List.map (fun (_,targ) -> targ) tparamEnv) ]
     | NewArray (_, texpr, expr) ->
       build_list [ Symbol "expr-new-array" ]
                  [ "texpr", sexpr_of_type_expr texpr

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -87,7 +87,7 @@ let rec sexpr_of_type_ (t : type_) : sexpression =
                                         sexpr_of_type_ t2]
     | ObjType (s, targs)             -> List [ Symbol "type-obj-type";
                                         Symbol s ;
-                                        Symbol "type-arguments:" ;
+                                        Symbol "type-arguments" ;
                                         sexpr_of_list sexpr_of_type_ targs]
     | ArrayType (t)           -> List [ Symbol "type-array-type";
                                         sexpr_of_type_ t ]
@@ -594,6 +594,8 @@ let rec sexpr_of_stmt (stmt : stmt) : sexpression =
                  [ "arguments", List (List.map sexpr_of_expr args) ]
 
 and sexpr_of_decl (decl : decl) : sexpression =
+  let sexpr_of_tparam tparam =
+        Symbol tparam in
   match decl with
     | Struct (loc,
               name,
@@ -621,9 +623,6 @@ and sexpr_of_decl (decl : decl) : sexpression =
             visibility) ->
       let sexpr_of_arg (t, id) =
         List [ Symbol id; sexpr_of_type_expr t ]
-      in
-      let sexpr_of_tparam tparam =
-        Symbol tparam
       in
       let body =
         match body with
@@ -653,7 +652,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
                       inductiveness) ->
       build_list [ Symbol "declare-predicate-family"
                  ; Symbol name ]
-                 [ "type-parameters", Symbol (String.concat ", " tparams)
+                 [ "type-parameters", List (List.map sexpr_of_tparam tparams)
                  ; "parameters", List (List.map sexpr_of_type_expr params)
                  ; "index-count", sexpr_of_int index_count
                  ; "coinductive", sexpr_of_bool (inductiveness = Inductiveness_CoInductive)]
@@ -669,7 +668,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
       in
       build_list [ Symbol "declare-predicate-family-instance"
                  ; Symbol name ]
-                 [ "type-parameters", Symbol (String.concat ", " tparams) 
+                 [ "type-parameters", List (List.map sexpr_of_tparam tparams) 
                  ; "parameters", List (List.map arg_pair params)
                  ; "predicate", sexpr_of_pred predicate ]
     | ImportModuleDecl (loc, name) ->
@@ -678,7 +677,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
     | Inductive (_, name, tparams, cons) ->
       build_list [ Symbol "declare-inductive"
                  ; Symbol name]
-                 [ "tparams", Symbol (String.concat ", "  tparams)
+                 [ "tparams", List (List.map sexpr_of_tparam tparams)
                  ; "constructors", sexpr_of_list sexpr_of_inductive_constructor cons ]
     | Interface (_, id, inters, fields, meths, tparams, preds) ->
       build_list [ Symbol "declare-interface"
@@ -726,6 +725,8 @@ and sexpr_of_super (name, targs) : sexpression =
   List [ Symbol name; sexpr_of_list sexpr_of_type_expr targs ]
 
 and sexpr_of_meths (meth : meth) : sexpression =
+  let sexpr_of_tparam tparam =
+        Symbol tparam in
   match meth with
   | Meth (loc, ghost, rtype, name, params, contract, body, bind, vis, abs, tparams) ->
     let sexpr_of_arg (t, id) =
@@ -745,7 +746,7 @@ and sexpr_of_meths (meth : meth) : sexpression =
     let kw = List.concat [ [ "ghos", sexpr_of_ghostness ghost
                             ; "return-type", sexpr_of_type_expr_option rtype
                             ; "parameters", List (List.map sexpr_of_arg params)
-                            ; "type-parameters", Symbol (String.concat ", " tparams) ]
+                            ; "type-parameters", List (List.map sexpr_of_tparam tparams) ]
                           ; body
                           ; contract ]
     in

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -319,7 +319,7 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
                  [ "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs ]
-    | WMethodCall (_, clss, name, typs, exprs, bind) ->
+    | WMethodCall (_, clss, name, typs, exprs, bind, tparamEnv) ->
       build_list [ Symbol "expr-w-method-call" ]
                  [ "class", Symbol clss
                  ; "name", Symbol name

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -319,14 +319,15 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
                  [ "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs ]
-    | WMethodCall (_, clss, name, typs, exprs, bind, targs) ->
+    | WMethodCall (_, clss, name, typs, exprs, bind, targs, ctargs) ->
       build_list [ Symbol "expr-w-method-call" ]
                  [ "class", Symbol clss
                  ; "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs 
                  ; "stat", sexpr_of_method_binding bind 
-                 ; "targs ", sexpr_of_list sexpr_of_type_ targs ]
+                 ; "targs", sexpr_of_list sexpr_of_type_ targs
+                 ; "classTargs", sexpr_of_list sexpr_of_type_ ctargs ]
     | NewArray (_, texpr, expr) ->
       build_list [ Symbol "expr-new-array" ]
                  [ "texpr", sexpr_of_type_expr texpr

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -86,8 +86,8 @@ let rec sexpr_of_type_ (t : type_) : sexpression =
                                         sexpr_of_type_ t1; 
                                         sexpr_of_type_ t2]
     | ObjType (s, targs)             -> List [ Symbol "type-obj-type";
-                                        Symbol s ;
-                                        Symbol "type-arguments" ;
+                                        Symbol s;
+                                        Symbol "type-arguments";
                                         sexpr_of_list sexpr_of_type_ targs]
     | ArrayType (t)           -> List [ Symbol "type-array-type";
                                         sexpr_of_type_ t ]

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -334,7 +334,6 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
       build_list [ Symbol "expr-new-obj"; Symbol cn ]
                  [ "args", sexpr_of_list sexpr_of_expr args ;
                   "targs", sexpr_of_option (fun targs -> sexpr_of_list sexpr_of_type_expr targs) targs ]
-
     | NewArrayWithInitializer (l, texpr, args) -> 
       build_list [ Symbol "expr-array-init" ]
                  [ "type", sexpr_of_type_expr texpr
@@ -748,6 +747,8 @@ and sexpr_of_meths (meth : meth) : sexpression =
       build_list [ Symbol "declare-method"; Symbol name ] kw
 
 and sexpr_of_constructor (name : string) (cons : cons) : sexpression =
+  let sexpr_of_tparam tparam =
+    Symbol tparam in
   match cons with
   | Cons (loc, params, contract, body, vis, tparams) ->
     let sexpr_of_arg (t, id) =
@@ -765,7 +766,7 @@ and sexpr_of_constructor (name : string) (cons : cons) : sexpression =
                                     ; "postcondition", sexpr_of_pred post ] 
     in        
     let kw = List.concat [ [ "parameters", List (List.map sexpr_of_arg params)
-                            ; "type-parameters", Symbol (String.concat ", " tparams) ]
+                            ; "type-parameters", List (List.map sexpr_of_tparam tparams) ]
                           ; body
                           ; contract ]
     in

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -85,8 +85,10 @@ let rec sexpr_of_type_ (t : type_) : sexpression =
     | PureFuncType (t1, t2)   -> List [ Symbol "type-pred-func-type";
                                         sexpr_of_type_ t1; 
                                         sexpr_of_type_ t2]
-    | ObjType (s)             -> List [ Symbol "type-obj-type";
-                                        Symbol s ]
+    | ObjType (s, targs)             -> List [ Symbol "type-obj-type";
+                                        Symbol s ;
+                                        Symbol "type-arguments: " ;
+                                        sexpr_of_list sexpr_of_type_ targs]
     | ArrayType (t)           -> List [ Symbol "type-array-type";
                                         sexpr_of_type_ t ]
     | StaticArrayType (t, n)  -> List [ Symbol "type-static-array-type";
@@ -95,8 +97,10 @@ let rec sexpr_of_type_ (t : type_) : sexpression =
     | BoxIdType               -> aux2 "type-box-id"
     | HandleIdType            -> aux2 "type-handle-id-type"
     | AnyType                 -> aux2 "AnyType"
-    | TypeParam (s)           -> List [ Symbol "type-param";
-                                        Symbol s ]
+    | RealTypeParam s           -> List [ Symbol "real-type-param";
+                                      Symbol s ]
+    | GhostTypeParam s           -> List [ Symbol "ghost-type-param";
+                                      Symbol s ]
     | InferredType (_, i)     -> List [ Symbol "type-inferred";
                                         sexpr_of_inferred_type_state !i]
     | ClassOrInterfaceName (s)-> List [ Symbol "type-class-or-interface-name";
@@ -315,20 +319,21 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
                  [ "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs ]
-    | WMethodCall (_, clss, name, typs, exprs, bind) ->
+    | WMethodCall (_, clss, name, typs, exprs, bind, targs) ->
       build_list [ Symbol "expr-w-method-call" ]
                  [ "class", Symbol clss
                  ; "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs 
-                 ; "stat", sexpr_of_method_binding bind ]
+                 ; "stat", sexpr_of_method_binding bind 
+                 ; "targs ", sexpr_of_list sexpr_of_type_ targs ]
     | NewArray (_, texpr, expr) ->
       build_list [ Symbol "expr-new-array" ]
                  [ "texpr", sexpr_of_type_expr texpr
                  ; "expr", sexpr_of_expr expr]
     | NewObject (l, cn, args) ->
       build_list [ Symbol "expr-new-obj"; Symbol cn ]
-                 [ "args", sexpr_of_list sexpr_of_expr args ]
+                 [ "args", sexpr_of_list sexpr_of_expr args]
     | NewArrayWithInitializer (l, texpr, args) -> 
       build_list [ Symbol "expr-array-init" ]
                  [ "type", sexpr_of_type_expr texpr
@@ -586,8 +591,6 @@ let rec sexpr_of_stmt (stmt : stmt) : sexpression =
                  [ "arguments", List (List.map sexpr_of_expr args) ]
 
 and sexpr_of_decl (decl : decl) : sexpression =
-  let symbol s = Symbol s
-  in
   match decl with
     | Struct (loc,
               name,
@@ -628,7 +631,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
                                 ; "postcondition", sexpr_of_pred post ]
       in
       let kw = List.concat [ [ "kind", sexpr_of_func_kind kind
-                             ; "type-parameters", List (List.map symbol tparams)
+                             ; "type-parameters", Symbol (String.concat ", " tparams)
                              ; "return-type", sexpr_of_type_expr_option rtype
                              ; "parameters", List (List.map sexpr_of_arg params) ]
                            ; body
@@ -644,7 +647,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
                       inductiveness) ->
       build_list [ Symbol "declare-predicate-family"
                  ; Symbol name ]
-                 [ "type-parameters", List (List.map symbol tparams)
+                 [ "type-parameters", Symbol (String.concat ", " tparams)
                  ; "parameters", List (List.map sexpr_of_type_expr params)
                  ; "index-count", sexpr_of_int index_count
                  ; "coinductive", sexpr_of_bool (inductiveness = Inductiveness_CoInductive)]
@@ -660,7 +663,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
       in
       build_list [ Symbol "declare-predicate-family-instance"
                  ; Symbol name ]
-                 [ "type-parameters", List (List.map symbol tparams)
+                 [ "type-parameters", Symbol (String.concat ", " tparams) 
                  ; "parameters", List (List.map arg_pair params)
                  ; "predicate", sexpr_of_pred predicate ]
     | ImportModuleDecl (loc, name) ->
@@ -669,20 +672,20 @@ and sexpr_of_decl (decl : decl) : sexpression =
     | Inductive (_, name, tparams, cons) ->
       build_list [ Symbol "declare-inductive"
                  ; Symbol name]
-                 [ "tparams", List (List.map symbol tparams)
+                 [ "tparams", Symbol (String.concat ", "  tparams)
                  ; "constructors", sexpr_of_list sexpr_of_inductive_constructor cons ]
-    | Interface (_, id, inters, fields, meths, preds) ->
+    | Interface (_, id, inters, fields, meths, tparams, preds) ->
       build_list [ Symbol "declare-interface"
                  ; Symbol id ]
-                 [ "super-interfaces", List (List.map symbol inters)
+                 [ "super-interfaces", sexpr_of_list sexpr_of_super inters
                  ; "fields", sexpr_of_list sexpr_of_field fields
                  ; "methods", sexpr_of_list sexpr_of_meths meths 
                  ; "instance-preds", sexpr_of_list sexpr_of_instance_pred preds ]
-    | Class (_, abs, final, id, meths, fields, cons, super, inters, preds) ->
+    | Class (_, abs, final, id, meths, fields, cons, super, tparams, inters, preds) ->
       build_list [ Symbol "declare-class"
                  ; Symbol id ]
-                 [ "super-class", symbol super
-                 ; "super-interfaces", List (List.map symbol inters)
+                 [ "super-class", sexpr_of_super super
+                 ; "super-interfaces", sexpr_of_list sexpr_of_super inters
                  ; "methods", sexpr_of_list sexpr_of_meths meths 
                  ; "fields", sexpr_of_list sexpr_of_field fields
                  ; "construcors", sexpr_of_list (sexpr_of_constructor id) cons 
@@ -713,9 +716,12 @@ and sexpr_of_inductive_constructor (c : ctor) : sexpression =
                ; Symbol name ]
                [ "arguments", List (List.map aux args)]
 
+and sexpr_of_super (name, targs) : sexpression =
+  List [ Symbol name; sexpr_of_list sexpr_of_type_expr targs ]
+
 and sexpr_of_meths (meth : meth) : sexpression =
   match meth with
-  | Meth (loc, ghost, rtype, name, params, contract, body, bind, vis, abs) ->
+  | Meth (loc, ghost, rtype, name, params, contract, body, bind, vis, abs, tparams) ->
     let sexpr_of_arg (t, id) =
       List [ Symbol id; sexpr_of_type_expr t ]
     in
@@ -732,7 +738,8 @@ and sexpr_of_meths (meth : meth) : sexpression =
     in        
     let kw = List.concat [ [ "ghos", sexpr_of_ghostness ghost
                             ; "return-type", sexpr_of_type_expr_option rtype
-                            ; "parameters", List (List.map sexpr_of_arg params) ]
+                            ; "parameters", List (List.map sexpr_of_arg params)
+                            ; "type-parameters", Symbol (String.concat ", " tparams) ]
                           ; body
                           ; contract ]
     in
@@ -740,7 +747,7 @@ and sexpr_of_meths (meth : meth) : sexpression =
 
 and sexpr_of_constructor (name : string) (cons : cons) : sexpression =
   match cons with
-  | Cons (loc, params, contract, body, vis) ->
+  | Cons (loc, params, contract, body, vis, tparams) ->
     let sexpr_of_arg (t, id) =
       List [ Symbol id; sexpr_of_type_expr t ]
     in
@@ -755,7 +762,8 @@ and sexpr_of_constructor (name : string) (cons : cons) : sexpression =
         | Some (pre, post, _, _) -> [ "precondition", sexpr_of_pred pre
                                     ; "postcondition", sexpr_of_pred post ] 
     in        
-    let kw = List.concat [ [ "parameters", List (List.map sexpr_of_arg params) ]
+    let kw = List.concat [ [ "parameters", List (List.map sexpr_of_arg params)
+                            ; "type-parameters", Symbol (String.concat ", " tparams) ]
                           ; body
                           ; contract ]
     in

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -319,14 +319,13 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
                  [ "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs ]
-    | WMethodCall (_, clss, name, typs, exprs, bind, targs, ctargs) ->
+    | WMethodCall (_, clss, name, typs, exprs, bind, ctargs) ->
       build_list [ Symbol "expr-w-method-call" ]
                  [ "class", Symbol clss
                  ; "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs 
                  ; "stat", sexpr_of_method_binding bind 
-                 ; "targs", sexpr_of_list sexpr_of_type_ targs
                  ; "classTargs", sexpr_of_list sexpr_of_type_ ctargs ]
     | NewArray (_, texpr, expr) ->
       build_list [ Symbol "expr-new-array" ]
@@ -725,10 +724,8 @@ and sexpr_of_super (name, targs) : sexpression =
   List [ Symbol name; sexpr_of_list sexpr_of_type_expr targs ]
 
 and sexpr_of_meths (meth : meth) : sexpression =
-  let sexpr_of_tparam tparam =
-        Symbol tparam in
   match meth with
-  | Meth (loc, ghost, rtype, name, params, contract, body, bind, vis, abs, tparams) ->
+  | Meth (loc, ghost, rtype, name, params, contract, body, bind, vis, abs) ->
     let sexpr_of_arg (t, id) =
       List [ Symbol id; sexpr_of_type_expr t ]
     in
@@ -745,8 +742,7 @@ and sexpr_of_meths (meth : meth) : sexpression =
     in        
     let kw = List.concat [ [ "ghos", sexpr_of_ghostness ghost
                             ; "return-type", sexpr_of_type_expr_option rtype
-                            ; "parameters", List (List.map sexpr_of_arg params)
-                            ; "type-parameters", List (List.map sexpr_of_tparam tparams) ]
+                            ; "parameters", List (List.map sexpr_of_arg params) ]
                           ; body
                           ; contract ]
     in

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -319,14 +319,13 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
                  [ "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs ]
-    | WMethodCall (_, clss, name, typs, exprs, bind, ctargs) ->
+    | WMethodCall (_, clss, name, typs, exprs, bind) ->
       build_list [ Symbol "expr-w-method-call" ]
                  [ "class", Symbol clss
                  ; "name", Symbol name
                  ; "typs", sexpr_of_list sexpr_of_type_ typs
                  ; "exprs", sexpr_of_list sexpr_of_expr exprs 
-                 ; "stat", sexpr_of_method_binding bind 
-                 ; "classTargs", sexpr_of_list sexpr_of_type_ ctargs ]
+                 ; "stat", sexpr_of_method_binding bind ]
     | NewArray (_, texpr, expr) ->
       build_list [ Symbol "expr-new-array" ]
                  [ "texpr", sexpr_of_type_expr texpr

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -979,7 +979,9 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             register_pred_ctor_application g_symb symbol symbol_term ctorargs inputParamCount;
             ((g_symb, false), [], pats, List.map snd ps2)
         else
-          let Some term = try_assoc (g#name) env in ((term, false), pats0, pats, g#domain)
+          match try_assoc g#name env with
+            None -> assert_false [] env l (Printf.sprintf "Unbound variable '%s'" g#name) None
+          | Some term -> ((term, false), pats0, pats, g#domain)
       in
       let targs = instantiate_types tpenv targs in
       let domain = instantiate_types tpenv types in

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -1010,7 +1010,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       in
       let target = match e_opt with None -> List.assoc "this" env | Some e -> ev e in
       let index = ev index in
-      let types = ObjType (tn,[])::ObjType ("java.lang.Class", [])::List.map snd pmap in
+      let types = ObjType (tn, [])::ObjType ("java.lang.Class", [])::List.map snd pmap in
       let pats = TermPat target::TermPat index::srcpats pats in
       consume_chunk_core rules h ghostenv env env' l (pred_symb, true) [] coef coefpat (Some 2) pats types types $. fun chunk h coef ts size ghostenv env env' ->
       check_dummy_coefpat l coefpat coef;

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -305,7 +305,6 @@ and
       type_ list (* parameter types (not including receiver) *) *
       expr list (* args, including receiver if instance method *) *
       method_binding *
-      type_ list * (* method Type arguments *)
       type_ list (* class type arguments *)
   | NewArray of loc * type_expr * expr
   (* If type arguments are None -> regular object creation or raw objects. [] -> type inference required and if the list is populated: parameterised type creation *)
@@ -643,8 +642,7 @@ and
       ((stmt list * loc (* Close brace *)) * int (*rank*)) option * 
       method_binding * 
       visibility *
-      bool * (* is declared abstract? *)
-      string list (*method specific type parameters*)
+      bool (* is declared abstract? *)
 and
   cons = (* ?cons *)
   | Cons of
@@ -845,7 +843,7 @@ let rec expr_loc e =
   | WPureFunValueCall (l, e, es) -> l
   | WFunPtrCall (l, g, args) -> l
   | WFunCall (l, g, targs, args) -> l
-  | WMethodCall (l, tn, m, pts, args, fb, targs, ctargs) -> l
+  | WMethodCall (l, tn, m, pts, args, fb, ctargs) -> l
   | NewObject (l, cn, args, targs) -> l
   | NewArray(l, _, _) -> l
   | NewArrayWithInitializer (l, _, _) -> l
@@ -1027,7 +1025,7 @@ let expr_fold_open iter state e =
   | WPureFunValueCall (l, e, args) -> iters state (e::args)
   | WFunCall (l, g, targs, args) -> iters state args
   | WFunPtrCall (l, g, args) -> iters state args
-  | WMethodCall (l, cn, m, pts, args, mb, targs, ctargs) -> iters state args
+  | WMethodCall (l, cn, m, pts, args, mb, ctargs) -> iters state args
   | NewObject (l, cn, args, targs) -> iters state args
   | NewArray (l, te, e0) -> iter state e0
   | NewArrayWithInitializer (l, te, es) -> iters state es

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -977,17 +977,6 @@ let type_expr_loc t =
   | PredTypeExpr(l, te, _) -> l
   | PureFuncTypeExpr (l, tes) -> l
 
-let rec string_of_type_expr t = 
-  match t with 
-    ManifestTypeExpr (l, t) -> "ManifestTypeExpr"
-  | StructTypeExpr (l, sn, _) -> "StructtypeExpr"
-  | IdentTypeExpr (l, _, x) -> "IdentTypeExpr " ^ x 
-  | ConstructedTypeExpr (l, x, targs) -> "ConstructedTypeExpr <" ^ (String.concat ", " (List.map string_of_type_expr targs)) ^ ">"
-  | PtrTypeExpr (l, te) -> "PtrTypeExpr"
-  | ArrayTypeExpr(l, te) -> "ArrayTypeExpr"
-  | PredTypeExpr(l, te, _) -> "PredTypeExpr"
-  | PureFuncTypeExpr (l, tes) -> "PureFuncTypeExpr"
-
 let expr_fold_open iter state e =
   let rec iters state es =
     match es with

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -304,7 +304,8 @@ and
       string (* method name *) *
       type_ list (* parameter types (not including receiver) *) *
       expr list (* args, including receiver if instance method *) *
-      method_binding
+      method_binding *
+      (string * type_ ) list (* type param environment *)
   | NewArray of loc * type_expr * expr
   (* If type arguments are None -> regular object creation or raw objects. [] -> type inference required and if the list is populated: parameterised type creation *)
   | NewObject of loc * string * expr list * type_expr list option
@@ -836,7 +837,7 @@ let rec expr_loc e =
   | WPureFunValueCall (l, e, es) -> l
   | WFunPtrCall (l, g, args) -> l
   | WFunCall (l, g, targs, args) -> l
-  | WMethodCall (l, tn, m, pts, args, fb) -> l
+  | WMethodCall (l, tn, m, pts, args, fb, tparamEnv) -> l
   | NewObject (l, cn, args, targs) -> l
   | NewArray(l, _, _) -> l
   | NewArrayWithInitializer (l, _, _) -> l
@@ -1018,7 +1019,7 @@ let expr_fold_open iter state e =
   | WPureFunValueCall (l, e, args) -> iters state (e::args)
   | WFunCall (l, g, targs, args) -> iters state args
   | WFunPtrCall (l, g, args) -> iters state args
-  | WMethodCall (l, cn, m, pts, args, mb) -> iters state args
+  | WMethodCall (l, cn, m, pts, args, mb, tparamEnv) -> iters state args
   | NewObject (l, cn, args, targs) -> iters state args
   | NewArray (l, te, e0) -> iter state e0
   | NewArrayWithInitializer (l, te, es) -> iters state es

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -230,7 +230,6 @@ and
   | False of loc
   | Null of loc
   | Var of loc * string
-  | VarWithTargs of loc * string * type_expr list
   | WVar of loc * string * ident_scope
   | TruncatingExpr of loc * expr
   | Operation of (* voor operaties met bovenstaande operators*)
@@ -822,7 +821,7 @@ let rec expr_loc e =
     True l -> l
   | False l -> l
   | Null l -> l
-  | Var (l, x) | VarWithTargs (l, x, _) | WVar (l, x, _) -> l
+  | Var (l, x) | WVar (l, x, _) -> l
   | IntLit (l, n, _, _, _) -> l
   | WIntLit (l, n) -> l
   | RealLit (l, n) -> l
@@ -1015,7 +1014,7 @@ let expr_fold_open iter state e =
     True l -> state
   | False l -> state
   | Null l -> state
-  | Var (l, x) | VarWithTargs (l,x,_) | WVar (l, x, _) -> state
+  | Var (l, x) | WVar (l, x, _) -> state
   | TruncatingExpr (l, e) -> iter state e
   | Operation (l, op, es) -> iters state es
   | WOperation (l, op, es, t) -> iters state es

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -307,8 +307,8 @@ and
       method_binding *
       type_ list (*Type arguments*)
   | NewArray of loc * type_expr * expr
-  | NewObject of loc * string * expr list (* Used for object creation of a raw type, or regular object creation of a type that has no type parameters *)
-  | NewGenericObject of loc * string * expr list * type_expr list (*type arguments *) (*Used  to create an object instance of a parameterised type *) 
+  (* If type arguments are None -> regular object creation or raw objects. [] -> type inference required and if the list is populated: parameterised type creation *)
+  | NewObject of loc * string * expr list * type_expr list option
   | NewArrayWithInitializer of loc * type_expr * expr list 
   | IfExpr of loc * expr * expr * expr
   | SwitchExpr of
@@ -845,8 +845,7 @@ let rec expr_loc e =
   | WFunPtrCall (l, g, args) -> l
   | WFunCall (l, g, targs, args) -> l
   | WMethodCall (l, tn, m, pts, args, fb, sign) -> l
-  | NewObject (l, cn, args) -> l
-  | NewGenericObject (l, cn, args, targs) -> l
+  | NewObject (l, cn, args, targs) -> l
   | NewArray(l, _, _) -> l
   | NewArrayWithInitializer (l, _, _) -> l
   | IfExpr (l, e1, e2, e3) -> l
@@ -1052,8 +1051,7 @@ let expr_fold_open iter state e =
   | WFunCall (l, g, targs, args) -> iters state args
   | WFunPtrCall (l, g, args) -> iters state args
   | WMethodCall (l, cn, m, pts, args, mb, sign) -> iters state args
-  | NewObject (l, cn, args) -> iters state args
-  | NewGenericObject (l, cn, args, targs) -> iters state args
+  | NewObject (l, cn, args, targs) -> iters state args
   | NewArray (l, te, e0) -> iter state e0
   | NewArrayWithInitializer (l, te, es) -> iters state es
   | IfExpr (l, e1, e2, e3) -> iters state [e1; e2; e3]

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -304,8 +304,7 @@ and
       string (* method name *) *
       type_ list (* parameter types (not including receiver) *) *
       expr list (* args, including receiver if instance method *) *
-      method_binding *
-      type_ list (* class type arguments *)
+      method_binding
   | NewArray of loc * type_expr * expr
   (* If type arguments are None -> regular object creation or raw objects. [] -> type inference required and if the list is populated: parameterised type creation *)
   | NewObject of loc * string * expr list * type_expr list option
@@ -843,7 +842,7 @@ let rec expr_loc e =
   | WPureFunValueCall (l, e, es) -> l
   | WFunPtrCall (l, g, args) -> l
   | WFunCall (l, g, targs, args) -> l
-  | WMethodCall (l, tn, m, pts, args, fb, ctargs) -> l
+  | WMethodCall (l, tn, m, pts, args, fb) -> l
   | NewObject (l, cn, args, targs) -> l
   | NewArray(l, _, _) -> l
   | NewArrayWithInitializer (l, _, _) -> l
@@ -1025,7 +1024,7 @@ let expr_fold_open iter state e =
   | WPureFunValueCall (l, e, args) -> iters state (e::args)
   | WFunCall (l, g, targs, args) -> iters state args
   | WFunPtrCall (l, g, args) -> iters state args
-  | WMethodCall (l, cn, m, pts, args, mb, ctargs) -> iters state args
+  | WMethodCall (l, cn, m, pts, args, mb) -> iters state args
   | NewObject (l, cn, args, targs) -> iters state args
   | NewArray (l, te, e0) -> iter state e0
   | NewArrayWithInitializer (l, te, es) -> iters state es

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -799,11 +799,6 @@ let func_kind_of_ghostness gh =
   
 (* Region: some AST inspector functions *)
 
-let string_of_ghostness gh =
-  match gh with
-    Real -> "Real"
-    | Ghost -> "Ghost"
-
 let string_of_func_kind f=
   match f with
     Lemma(_) -> "lemma"

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -649,8 +649,7 @@ and
       (type_expr * string) list * 
       (asn * asn * ((type_expr * asn) list) * bool (*terminates*) ) option * 
       ((stmt list * loc (* Close brace *)) * int (*rank*)) option * 
-      visibility *
-      string list (* type parameters *)
+      visibility
 and
   instance_pred_decl = (* ?instance_pred_decl *)
   | InstancePredDecl of loc * string * (type_expr * string) list * asn option

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -976,25 +976,12 @@ let type_expr_loc t =
   | PredTypeExpr(l, te, _) -> l
   | PureFuncTypeExpr (l, tes) -> l
 
-let rec string_of_type_expr_name t =
-match t with
-  ManifestTypeExpr (l, t) -> "???"
-  | StructTypeExpr (l, sn, _) -> "???"
-  | IdentTypeExpr (l, _, x) -> x
-  | ConstructedTypeExpr (l, x, targs) ->  x ^ "<" ^ (
-    String.concat " --- " (
-      List.map (fun targ -> string_of_type_expr_name targ) targs)) ^ ">"
-  | PtrTypeExpr (l, te) -> string_of_type_expr_name te
-  | ArrayTypeExpr(l, te) -> string_of_type_expr_name te
-  | PredTypeExpr(l, te, _) -> String.concat ", " (List.map (fun texpr -> string_of_type_expr_name texpr) te)
-  | PureFuncTypeExpr (l, tes) -> String.concat ", " (List.map (fun texpr -> string_of_type_expr_name texpr) tes)
-
-let string_of_type_expr t = 
+let rec string_of_type_expr t = 
   match t with 
     ManifestTypeExpr (l, t) -> "ManifestTypeExpr"
   | StructTypeExpr (l, sn, _) -> "StructtypeExpr"
   | IdentTypeExpr (l, _, x) -> "IdentTypeExpr " ^ x 
-  | ConstructedTypeExpr (l, x, targs) -> "ConstructedTypeExpr " ^ (string_of_type_expr_name t)
+  | ConstructedTypeExpr (l, x, targs) -> "ConstructedTypeExpr <" ^ (String.concat ", " (List.map string_of_type_expr targs)) ^ ">"
   | PtrTypeExpr (l, te) -> "PtrTypeExpr"
   | ArrayTypeExpr(l, te) -> "ArrayTypeExpr"
   | PredTypeExpr(l, te, _) -> "PredTypeExpr"

--- a/src/explorer.ml
+++ b/src/explorer.ml
@@ -252,10 +252,11 @@ let _ =
         | FuncType(name) -> name
         | InductiveType(name, type_list) -> name ^ "(" ^ string_of_type_list type_list ^ ")" 
         | PureFuncType(type_1, type_2) -> "(" ^ string_of_type_ type_1 ^ ", " ^ string_of_type_ type_2 ^ ")"
-        | ObjType(name) -> name
+        | ObjType(name, _) -> name
         | ArrayType(type_in) -> string_of_type_ type_in ^ "[]"
         | StaticArrayType(type_in, nb_elems) -> string_of_type_ type_in ^ "[" ^ string_of_int nb_elems ^ "]"
-        | TypeParam(name) -> name
+        | GhostTypeParam(name) -> name
+        | RealTypeParam(name) -> name
         | PackageName(name) -> name
         | RefType(type_in) -> string_of_type_ type_in
         | AbstractType(name) -> name
@@ -406,13 +407,14 @@ let _ =
                 | _ -> false
             end
           | PureFuncType(type_in1, type_in2) -> (match pattern_type_ with PureFuncType(pattern_type_in1, pattern_type_in2) -> check_type_equal type_in1 pattern_type_in1 && check_type_equal type_in2 pattern_type_in2 | _ -> false)
-          | ObjType(name) -> (match pattern_type_ with ObjType(pattern_name) when name = pattern_name -> true | _ -> false) 
+          | ObjType(name, targs) -> (match pattern_type_ with ObjType(pattern_name, ptargs) when name = pattern_name -> check_type_equal_list targs ptargs | _ -> false) 
           | ArrayType(type_in) -> (match pattern_type_ with ArrayType(pattern_type_in) -> check_type_equal type_in pattern_type_in | _ -> false)
           | StaticArrayType(type_in, size) -> (match pattern_type_ with StaticArrayType(pattern_type_in, pattern_size) when size = pattern_size -> check_type_equal type_in pattern_type_in | _ -> false)
           | BoxIdType -> (match pattern_type_ with BoxIdType -> true | _ -> false)
           | HandleIdType -> (match pattern_type_ with HandleIdType -> true | _ -> false)
           | AnyType -> (match pattern_type_ with AnyType -> true | _ -> false)
-          | TypeParam(name) -> (match pattern_type_ with TypeParam(pattern_name) when name = pattern_name -> true | _ -> false) 
+          | GhostTypeParam(name) -> (match pattern_type_ with GhostTypeParam(pattern_name) when name = pattern_name -> true | _ -> false) 
+          | RealTypeParam(name) -> (match pattern_type_ with RealTypeParam(pattern_name) when name = pattern_name -> true | _ -> false) 
           | ClassOrInterfaceName(name) -> (match pattern_type_ with ClassOrInterfaceName(pattern_name) when name = pattern_name -> true | _ -> false) 
           | PackageName(name) -> (match pattern_type_ with PackageName(pattern_name) when name = pattern_name -> true | _ -> false) 
           | RefType(type_in) -> (match pattern_type_ with RefType(pattern_type_in) -> check_type_equal type_in pattern_type_in | _ -> false)

--- a/src/java_frontend/ast_translator.ml
+++ b/src/java_frontend/ast_translator.ml
@@ -310,11 +310,11 @@ and translate_class_decl decl =
         (* Extending through ast_translator doesn't support generics yet *)
         let extnds' =
           match extnds with
-            Some x -> (GEN.string_of_ref_type x,[])
-          | None -> ("java.lang.Object",[])
+            Some x -> (GEN.string_of_ref_type x, [])
+          | None -> ("java.lang.Object", [])
         in
         (* No support yet for generic implements *)
-        let impls' = List.map (fun f -> (GEN.string_of_ref_type f,[])) impls in
+        let impls' = List.map (fun f -> (GEN.string_of_ref_type f, [])) impls in
         let (decls', ghost_members') = translate_ghost_members l' id' decls' in
         let (ghost_fields', ghost_meths', ghost_preds') = split_ghost_members l ghost_members' in
         if (decls' <> []) then error l' "Not all declarations in class could be processed";
@@ -324,7 +324,7 @@ and translate_class_decl decl =
         let id' = GEN.string_of_identifier id in
         debug_print ("interface declaration " ^ id');
         (* No support yet for generic implements *)
-        let impls' = List.map (fun f -> (GEN.string_of_ref_type f,[])) impls in
+        let impls' = List.map (fun f -> (GEN.string_of_ref_type f, [])) impls in
         let (decls', fields') = translate_fields decls in
         let (decls', meths') = translate_methods id' decls' in
         let tparams' = translate_tparams_as_string tparams in
@@ -362,19 +362,17 @@ and translate_class_finality fin =
 and translate_tparams_as_string tparams = 
   debug_print "translate_tparams_as_string";
   match tparams with
-  | GEN.TypeParam(l, Identifier(sl,name), bounds) :: tail ->
+  | GEN.TypeParam(l, Identifier(sl, name), bounds) :: tail ->
     let res = translate_tparams_as_string tail
       in name::res;
-  | _ -> []
 
 and translate_tparams_as_type_expr tparams =
   debug_print "translate_tparams_as_type_expr";
   match tparams with
-  | GEN.TypeParam(l, Identifier(sl,name), bounds) :: tail ->
+  | GEN.TypeParam(l, Identifier(sl, name), bounds) :: tail ->
     let l'= translate_location l in
     let res = translate_tparams_as_type_expr tail
-      in IdentTypeExpr(l',None,name)::res;
-  | _ -> []
+      in IdentTypeExpr(l', None, name)::res;
 
 and translate_field_finality fin =
   debug_print "translate_field_finality";

--- a/src/java_frontend/ast_translator.ml
+++ b/src/java_frontend/ast_translator.ml
@@ -526,11 +526,10 @@ and translate_constructors decls =
       | GEN.Constructor(l, anns, tparams, access, params, throws, stmts, autogen) ->
           let l' = translate_location l in
           let params' = List.map translate_param params in
-          let tparams' = translate_tparams_as_string tparams in
           let contr' = check_contract l anns throws autogen in
           let stmts' = translate_block l stmts in
           let access' = translate_accessibility access in
-          Some([VF.Cons(l', params', contr', stmts', access', tparams')])
+          Some([VF.Cons(l', params', contr', stmts', access')])
       | _ -> None
   in 
   translate_class_decls_helper translator decls

--- a/src/java_frontend/ast_translator.ml
+++ b/src/java_frontend/ast_translator.ml
@@ -826,7 +826,8 @@ and translate_expression expr =
       let l' = translate_location l in
       let typ' = GEN.string_of_ref_type typ in
       let exprs' = List.map translate_expression exprs in
-      VF.NewObject(l', typ', exprs')
+      (* No support for type arguments yet when using the native compiler *)
+      VF.NewObject(l', typ', exprs', None)
   | GEN.NewArray(l, typ, dims, exprs) ->
       let l' = translate_location l in
       let typ' = translate_type typ in

--- a/src/java_frontend/ast_translator.ml
+++ b/src/java_frontend/ast_translator.ml
@@ -447,7 +447,7 @@ and translate_static_blocks cn decls =
         counter := !counter + 1;
         let contr' = check_contract l [] [] Generated in
         let stmts' = translate_block l (Some stmts) in
-        Some([VF.Meth(l', VF.Real, None, id', [], contr', stmts', VF.Static, VF.Private, false, [])])
+        Some([VF.Meth(l', VF.Real, None, id', [], contr', stmts', VF.Static, VF.Private, false)])
       end
     | _ -> None
   in 
@@ -505,7 +505,6 @@ and translate_methods cn decls =
         debug_print ("method declaration " ^ id');
         let abs' = translate_abstractness abs in
         let access' = translate_accessibility access in
-        let tparams' = translate_tparams_as_string tparams in
         let stat' = translate_staticness stat in
         let params' = 
           let params' = List.map translate_param params in
@@ -518,7 +517,7 @@ and translate_methods cn decls =
         in
         let contr' = check_contract l anns throws autogen in
         let stmts' = translate_block l stmts in
-        Some([VF.Meth(l', ghost', ret', id', params', contr', stmts', stat', access', abs', tparams')])
+        Some([VF.Meth(l', ghost', ret', id', params', contr', stmts', stat', access', abs')])
     | _ -> None
   in 
   translate_class_decls_helper translator decls

--- a/src/java_frontend/ast_translator.ml
+++ b/src/java_frontend/ast_translator.ml
@@ -300,33 +300,38 @@ and translate_class_decl decl =
         let l'= translate_location l in
         let abs' = translate_abstractness abs in
         let fin' = translate_class_finality fin in
+        let tparams' = translate_tparams_as_string tparams in
         let id' = GEN.string_of_identifier id in
         debug_print ("class declaration " ^ id');
         let (decls', meths') = translate_methods id' decls in
         let (decls', static_blocks') = translate_static_blocks id' decls' in
         let (decls', fields') = translate_fields decls' in
         let (decls', cons') = translate_constructors decls' in
+        (* Extending through ast_translator doesn't support generics yet *)
         let extnds' =
           match extnds with
-            Some x -> GEN.string_of_ref_type x
-          | None -> "java.lang.Object"
+            Some x -> (GEN.string_of_ref_type x,[])
+          | None -> ("java.lang.Object",[])
         in
-        let impls' = List.map GEN.string_of_ref_type impls in
+        (* No support yet for generic implements *)
+        let impls' = List.map (fun f -> (GEN.string_of_ref_type f,[])) impls in
         let (decls', ghost_members') = translate_ghost_members l' id' decls' in
         let (ghost_fields', ghost_meths', ghost_preds') = split_ghost_members l ghost_members' in
         if (decls' <> []) then error l' "Not all declarations in class could be processed";
-        (VF.Class(l', abs', fin', id', static_blocks' @ meths' @ ghost_meths', fields' @ ghost_fields', cons', extnds', impls', ghost_preds'), id')
+        (VF.Class(l', abs', fin', id', static_blocks' @ meths' @ ghost_meths', fields' @ ghost_fields', cons', extnds',tparams', impls', ghost_preds'), id')
     | GEN.Interface(l, anns, id, tparams, access, impls, decls) ->
         let l'= translate_location l in
         let id' = GEN.string_of_identifier id in
         debug_print ("interface declaration " ^ id');
-        let impls' = List.map GEN.string_of_ref_type impls in
+        (* No support yet for generic implements *)
+        let impls' = List.map (fun f -> (GEN.string_of_ref_type f,[])) impls in
         let (decls', fields') = translate_fields decls in
         let (decls', meths') = translate_methods id' decls' in
+        let tparams' = translate_tparams_as_string tparams in
         let (decls', ghost_members') = translate_ghost_members l' id' decls' in
         let (ghost_fields', ghost_meths', ghost_preds') = split_ghost_members l ghost_members' in
         if (decls' <> []) then error l' "Not all declarations in class could be processed";
-        (VF.Interface(l', id', impls', fields' @ ghost_fields', meths' @ ghost_meths', ghost_preds'), id')
+        (VF.Interface(l', id', impls', fields' @ ghost_fields', meths' @ ghost_meths', tparams', ghost_preds'), id')
   in 
   debug_print_end ("translate_class_decl " ^ name');
   res
@@ -353,6 +358,23 @@ and translate_class_finality fin =
   match fin with
   | GEN.Final -> VF.FinalClass
   | GEN.NonFinal -> VF.ExtensibleClass
+
+and translate_tparams_as_string tparams = 
+  debug_print "translate_tparams_as_string";
+  match tparams with
+  | GEN.TypeParam(l, Identifier(sl,name), bounds) :: tail ->
+    let res = translate_tparams_as_string tail
+      in name::res;
+  | _ -> []
+
+and translate_tparams_as_type_expr tparams =
+  debug_print "translate_tparams_as_type_expr";
+  match tparams with
+  | GEN.TypeParam(l, Identifier(sl,name), bounds) :: tail ->
+    let l'= translate_location l in
+    let res = translate_tparams_as_type_expr tail
+      in IdentTypeExpr(l',None,name)::res;
+  | _ -> []
 
 and translate_field_finality fin =
   debug_print "translate_field_finality";
@@ -427,7 +449,7 @@ and translate_static_blocks cn decls =
         counter := !counter + 1;
         let contr' = check_contract l [] [] Generated in
         let stmts' = translate_block l (Some stmts) in
-        Some([VF.Meth(l', VF.Real, None, id', [], contr', stmts', VF.Static, VF.Private, false)])
+        Some([VF.Meth(l', VF.Real, None, id', [], contr', stmts', VF.Static, VF.Private, false, [])])
       end
     | _ -> None
   in 
@@ -485,6 +507,7 @@ and translate_methods cn decls =
         debug_print ("method declaration " ^ id');
         let abs' = translate_abstractness abs in
         let access' = translate_accessibility access in
+        let tparams' = translate_tparams_as_string tparams in
         let stat' = translate_staticness stat in
         let params' = 
           let params' = List.map translate_param params in
@@ -497,7 +520,7 @@ and translate_methods cn decls =
         in
         let contr' = check_contract l anns throws autogen in
         let stmts' = translate_block l stmts in
-        Some([VF.Meth(l', ghost', ret', id', params', contr', stmts', stat', access', abs')])
+        Some([VF.Meth(l', ghost', ret', id', params', contr', stmts', stat', access', abs', tparams')])
     | _ -> None
   in 
   translate_class_decls_helper translator decls
@@ -514,10 +537,11 @@ and translate_constructors decls =
       | GEN.Constructor(l, anns, tparams, access, params, throws, stmts, autogen) ->
           let l' = translate_location l in
           let params' = List.map translate_param params in
+          let tparams' = translate_tparams_as_string tparams in
           let contr' = check_contract l anns throws autogen in
           let stmts' = translate_block l stmts in
           let access' = translate_accessibility access in
-          Some([VF.Cons(l', params', contr', stmts', access')])
+          Some([VF.Cons(l', params', contr', stmts', access', tparams')])
       | _ -> None
   in 
   translate_class_decls_helper translator decls
@@ -798,10 +822,8 @@ and translate_expression expr =
             end
         | _ -> error l' "Internal error of ast_translator";
       end
-  | GEN.NewClass(l, tparams, typ, exprs) ->
+  | GEN.NewClass(l, targs, typ, exprs) ->
       let l' = translate_location l in
-      if (List.length tparams <> 0) then
-        error l' "Generics should be erased before using this translator";
       let typ' = GEN.string_of_ref_type typ in
       let exprs' = List.map translate_expression exprs in
       VF.NewObject(l', typ', exprs')

--- a/src/java_frontend/ast_translator.ml
+++ b/src/java_frontend/ast_translator.ml
@@ -366,14 +366,6 @@ and translate_tparams_as_string tparams =
     let res = translate_tparams_as_string tail
       in name::res;
 
-and translate_tparams_as_type_expr tparams =
-  debug_print "translate_tparams_as_type_expr";
-  match tparams with
-  | GEN.TypeParam(l, Identifier(sl, name), bounds) :: tail ->
-    let l'= translate_location l in
-    let res = translate_tparams_as_type_expr tail
-      in IdentTypeExpr(l', None, name)::res;
-
 and translate_field_finality fin =
   debug_print "translate_field_finality";
   match fin with

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -279,7 +279,7 @@ and
 and
   constr m=
   match m with
-    ConsMember(Cons(l,ps,co,ss,v, tparams))::ms -> Cons(l,ps,co,ss,v, tparams)::(constr ms)
+    ConsMember(Cons(l, ps, co, ss, v, tparams))::ms -> Cons(l, ps, co, ss, v, tparams)::(constr ms)
     |_::ms -> constr ms
     | []->[]
 and
@@ -328,17 +328,16 @@ and
 and
   parse_throws_clause = parser
   [< '(l, Kwd "throws"); epost = rep_comma (parse_thrown l) >] -> epost
-and parse_array_dims t = parser
+and 
+  parse_array_dims t = parser
   [< '(l, Kwd "["); '(_, Kwd "]"); t = parse_array_dims (ArrayTypeExpr (l, t)) >] -> t
 | [< >] -> t
-and id x = parser [< >] -> x
-and parse_java_modifier = parser [< '(l, Kwd "public") >] -> VisibilityModifier(Public)
-  | [< '(l, Kwd "protected") >] -> VisibilityModifier(Protected)
-  | [< '(l, Kwd "private") >] -> VisibilityModifier(Private) 
-  | [< '(l, Kwd "static") >] -> StaticModifier
-  | [< '(l, Kwd "final") >] -> FinalModifier
-  | [< '(l, Kwd "abstract") >] -> AbstractModifier
-and parse_java_member cn = parser
+and 
+  id x = parser [< >] -> x
+and 
+  parse_java_modifier = parser [< '(l, Kwd "public") >] -> VisibilityModifier(Public) | [< '(l, Kwd "protected") >] -> VisibilityModifier(Protected) | [< '(l, Kwd "private") >] -> VisibilityModifier(Private) | [< '(l, Kwd "static") >] -> StaticModifier | [< '(l, Kwd "final") >] -> FinalModifier | [< '(l, Kwd "abstract") >] -> AbstractModifier
+and 
+  parse_java_member cn = parser
   [< modifiers = rep parse_java_modifier;
      binding = (fun _ -> if List.mem StaticModifier modifiers then Static else Instance);
      final = (fun _ -> List.mem FinalModifier modifiers);
@@ -387,12 +386,14 @@ and parse_declaration_rhs te = parser
   [< '(linit, Kwd "{"); es = parse_array_init >] ->
   (match te with ArrayTypeExpr (_, elem_te) -> NewArrayWithInitializer (linit, elem_te, es) | _ -> InitializerList (linit, es))
 | [< e = parse_expr >] -> e
-and parse_declarator t = parser
+and 
+  parse_declarator t = parser
   [< '(l, Ident x);
      tx = parse_array_braces t;
      init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);
   >] -> (l, tx, x, init, (ref false, ref None))
-and parse_method_rest l = parser
+and 
+  parse_method_rest l = parser
   [< ps = parse_paramlist;
     epost = opt parse_throws_clause;
     (ss, co) = parser
@@ -419,7 +420,8 @@ and parse_method_rest l = parser
         end
     in
     (ps, contract, ss)
-and parse_functype_paramlists = parser
+and 
+  parse_functype_paramlists = parser
   [< ps1 = parse_paramlist; ps2 = opt parse_paramlist >] -> (match ps2 with None -> ([], ps1) | Some ps2 -> (ps1, ps2))
 and
   (** Parses
@@ -448,12 +450,14 @@ and
 | [< '(l, Kwd "__forceinline") >] -> ()
 | [< '(l, Kwd "__always_inline") >] -> ()
 | [< >] -> ()
-and parse_enum_body = parser
+and 
+  parse_enum_body = parser
   [< '(_, Kwd "{");
      elems = rep_comma (parser [< '(_, Ident e); init = opt (parser [< '(_, Kwd "="); e = parse_expr >] -> e) >] -> (e, init));
      '(_, Kwd "}")
    >] -> elems
-and parse_decl = parser
+and 
+  parse_decl = parser
   [< '(l, Kwd "struct"); '(_, Ident s); d = parser
     [< fs = parse_fields; '(_, Kwd ";") >] -> Struct (l, s, Some fs)
   | [< '(_, Kwd ";") >] -> Struct (l, s, None)
@@ -518,30 +522,30 @@ and check_function_for_contract d =
     let contract = check_for_contract contract l "Function declaration should have a contract." (fun co -> co) in
     [Func(l, k, tparams, t, g, ps, gc, ft, Some contract, terminates, ss, static, v)]
   | _ -> [d]
-and 
+and
   parse_pure_decls = parser
   [< ds0 = parse_pure_decl; ds = parse_pure_decls >] -> ds0 @ ds
-  | [< >] -> []
-and 
+| [< >] -> []
+and
   parse_index_list = parser
   [< '(_, Kwd "("); is = rep_comma (parser 
     [< '(l, Ident i); e=parser
       [<'(_, Kwd ".");'(_, Kwd "class")>]-> (l,i)
       |[<>]->(l,i)>] -> e); '(_, Kwd ")") >] -> is
-and 
+and
   parse_type_params l = parser
     [< xs = parse_angle_brackets l (rep_comma (parser [< '(_, Ident x) >] -> x)) >] -> xs
   | [< >] -> []
-and 
+and
   parse_pred_body = parser
   | [< '(_, Kwd "="); p = parse_asn >] -> p
-and 
+and
   parse_pred_paramlist = parser
     [< 
       '(_, Kwd "("); ps = rep_comma parse_param;
       (ps, inputParamCount) = (parser [< '(_, Kwd ";"); ps' = rep_comma parse_param >] -> (ps @ ps', Some (List.length ps)) | [< >] -> (ps, None)); '(_, Kwd ")")
     >] -> (ps, inputParamCount)
-and 
+and
   parse_predicate_decl l (inductiveness: inductiveness) = parser 
     [< '(li, Ident g); tparams = parse_type_params li; 
      (ps, inputParamCount) = parse_pred_paramlist;
@@ -574,37 +578,36 @@ and
   | [< '(l, Kwd "import_module"); '(_, Ident g); '(lx, Kwd ";") >] -> [ImportModuleDecl (l, g)]
   | [< '(l, Kwd "require_module"); '(_, Ident g); '(lx, Kwd ";") >] -> [RequireModuleDecl (l, g)]
   | [< '(l, Kwd "abstract_type"); '(_, Ident t); '(_, Kwd ";") >] -> [AbstractTypeDecl (l, t)]
-and 
+and
   parse_action_decls = parser
   [< ad = parse_action_decl; ads = parse_action_decls >] -> ad::ads
 | [< >] -> []
-and 
+and
   parse_action_decl = parser
   [< '(l, Kwd "action"); permbased = opt (parser [< '(_, Kwd "permbased") >] -> 0); '(_, Ident an); ps = parse_paramlist; '(_, Kwd ";");
      '(_, Kwd "requires"); pre = parse_expr; '(_, Kwd ";");
      '(_, Kwd "ensures"); post = parse_expr; '(_, Kwd ";") >] -> ActionDecl (l, an, (match permbased with None -> false | Some _ -> true), ps, pre, post)
-and 
+and
   parse_handle_pred_decls = parser
   [< hpd = parse_handle_pred_decl; hpds = parse_handle_pred_decls >] -> hpd::hpds
 | [< >] -> []
-and 
+and
   parse_handle_pred_decl = parser
   [< '(l, Kwd "handle_predicate"); '(_, Ident hpn); ps = parse_paramlist;
      extends = opt (parser [< '(l, Kwd "extends"); '(_, Ident ehn) >] -> ehn);
      '(_, Kwd "{"); '(_, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";"); pbcs = parse_preserved_by_clauses; '(_, Kwd "}") >]
      -> HandlePredDecl (l, hpn, ps, extends, inv, pbcs)
-and 
+and
   parse_preserved_by_clauses = parser
   [< pbc = parse_preserved_by_clause; pbcs = parse_preserved_by_clauses >] -> pbc::pbcs
 | [< >] -> []
-and 
+and
   parse_preserved_by_clause = parser
   [< '(l, Kwd "preserved_by"); '(_, Ident an); '(_, Kwd "("); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ")");
      ss = parse_block >] -> PreservedByClause (l, an, xs, ss)
-and 
-  parse_type_params_free = parser 
-  [< '(_, Kwd "<"); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ">") >] -> xs
-and 
+and
+  parse_type_params_free = parser [< '(_, Kwd "<"); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ">") >] -> xs
+and
   parse_type_params_general = parser
   [< xs = parse_type_params_free >] -> xs
 | [<
@@ -616,13 +619,15 @@ and
     )
   >] -> xs
 | [< >] -> []
-and type_params_parse =
+and 
+  type_params_parse =
     parser
       [< xs = opt parse_type_params_general >] ->
         match xs with
          | Some(params) -> params
          | None -> []
-and parse_func_rest k t v gh = parser
+and
+  parse_func_rest k t v gh = parser
   [<
     '(l, Ident g);
     tparams = parse_type_params_general;
@@ -642,11 +647,11 @@ and parse_func_rest k t v gh = parser
         '(_, Kwd ";")
       >] -> Global (l, t, g, init)
   >] -> decl
-and 
+and
   parse_ctors_suffix = parser
   [< '(_, Kwd "|"); cs = parse_ctors >] -> cs
 | [< >] -> []
-and 
+and
   parse_ctors = parser
   [< '(l, Ident cn);
      ts = begin
@@ -659,7 +664,7 @@ and
      end;
      cs = parse_ctors_suffix
   >] -> Ctor (l, cn, ts)::cs
-and 
+and
   parse_paramtype_and_name = parser
   [< t = parse_type;
      paramname_opt = opt (parser
@@ -668,20 +673,20 @@ and
   >] ->
     let paramname = match paramname_opt with None -> "" | Some(x) -> x in
     (paramname, t)
-and 
+and
   parse_paramtype = parser [< t = parse_type; _ = opt (parser [< '(_, Ident _) >] -> ()) >] -> t
-and 
+and
   parse_fields = parser
   [< '(_, Kwd "{"); fs = parse_fields_rest >] -> fs
-and 
+and
   parse_fields_rest = parser
   [< '(_, Kwd "}") >] -> []
 | [< f = parse_field; fs = parse_fields_rest >] -> f::fs
-and 
+and
   parse_field = parser
   [< '(_, Kwd "/*@"); f = parse_field_core Ghost; '(_, Kwd "@*/") >] -> f
 | [< f = parse_field_core Real >] -> f
-and  
+and
   parse_field_core gh = parser
   [< te0 = parse_type; '(l, Ident f);
      te = parser
@@ -691,17 +696,17 @@ and
               raise (ParseException (ls, "Array must have size > 0."));
             StaticArrayTypeExpr (l, te0, int_of_big_int size)
    >] -> Field (l, gh, te, f, Instance, Public, false, None)
-and 
+and
   parse_return_type = parser
   [< t = parse_type >] -> match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t
-and 
+and
   parse_type = parser
   [< t0 = parse_primary_type; t = parse_type_suffix t0 >] -> t
-and 
+and
   parse_int_opt = parser
   [< '(_, Kwd "int") >] -> ()
 | [< >] -> ()
-and 
+and
   parse_integer_type_keyword = parser
   [< '(l, Kwd "int") >] -> (l, int_rank)
 | [< '(l, Kwd "__int8") >] -> (l, 0)
@@ -1213,10 +1218,10 @@ and
   [< e0 = parse_expr_primary; e = parse_expr_suffix_rest e0 >] -> e
 and
   parse_type_args l = parser
-   [< targs = parse_angle_brackets l (rep_comma parse_type) >] -> targs
+    [< targs = parse_angle_brackets l (rep_comma parse_type) >] -> targs
   | [< >] -> []
 and
-parse_type_args_with_diamond l0 = parser
+  parse_type_args_with_diamond l0 = parser
     [< 
     (targs, diamond) = match language with
       CLang -> (parser [< targs = parse_type_args l0 >] -> (targs, false))

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -566,7 +566,7 @@ and
   | [< '(l, Kwd "predicate_ctor"); '(_, Ident g); ps1 = parse_paramlist; (ps2, inputParamCount) = parse_pred_paramlist;
      p = parse_pred_body; '(_, Kwd ";"); >] -> [PredCtorDecl (l, g, ps1, ps2, inputParamCount, p)]
   | [< '(l, Kwd "lemma"); t = parse_return_type; d = parse_func_rest (Lemma(false, None)) t Public >] -> [d]
-  | [< '(l, Kwd "lemma_auto"); trigger = opt (parser [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); >] -> e); t = parse_return_type; d = parse_func_rest (Lemma(true, trigger)) t Public>] -> [d]
+  | [< '(l, Kwd "lemma_auto"); trigger = opt (parser [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); >] -> e); t = parse_return_type; d = parse_func_rest (Lemma(true, trigger)) t Public >] -> [d]
   | [< '(l, Kwd "box_class"); '(_, Ident bcn); ps = parse_paramlist;
        '(_, Kwd "{"); '(_, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";");
        ads = parse_action_decls; hpds = parse_handle_pred_decls; '(_, Kwd "}") >] -> [BoxClassDecl (l, bcn, ps, inv, ads, hpds)]

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -124,7 +124,7 @@ module Scala = struct
     parse_method = parser
       [< '(l, Kwd "def"); '(_, Ident mn); ps = parse_paramlist; t = parse_type_ann; co = parse_contract; '(_, Kwd "=");'(_, Kwd "{"); ss = rep parse_stmt; '(closeBraceLoc, Kwd "}")>] ->
       let rt = match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t in
-      Meth (l, Real, rt, mn, ps, Some co, Some ((ss, closeBraceLoc), next_body_rank ()), Static, Public, false, [])
+      Meth (l, Real, rt, mn, ps, Some co, Some ((ss, closeBraceLoc), next_body_rank ()), Static, Public, false)
   and
     parse_paramlist = parser
       [< '(_, Kwd "("); ps = rep_comma parse_param; '(_, Kwd ")") >] -> ps
@@ -267,7 +267,7 @@ and
 and
   methods cn m=
   match m with
-    MethMember (Meth (l, gh, t, n, ps, co, ss,s,v,abstract, tparams))::ms -> Meth (l, gh, t, n, ps, co, ss,s,v,abstract, tparams)::(methods cn ms)
+    MethMember (Meth (l, gh, t, n, ps, co, ss,s,v,abstract))::ms -> Meth (l, gh, t, n, ps, co, ss,s,v,abstract)::(methods cn ms)
     |_::ms -> methods cn ms
     | []->[]
 and
@@ -311,7 +311,7 @@ and
      | [< '(l, Kwd "lemma"); t = parse_return_type; 
           '(l, Ident x); (ps, co, ss) = parse_method_rest l >] -> 
         let ps = (IdentTypeExpr (l, None, cn), "this")::ps in
-        MethMember(Meth (l, Ghost, t, x, ps, co, ss, Instance, vis, false, []))
+        MethMember(Meth (l, Ghost, t, x, ps, co, ss, Instance, vis, false))
      | [< binding = (parser [< '(_, Kwd "static") >] -> Static | [< >] -> Instance); t = parse_type; '(l, Ident x); '(_, Kwd ";") >] ->
        FieldMember [Field (l, Ghost, t, x, binding, vis, false, None)]
     end
@@ -352,7 +352,7 @@ and parse_java_member cn = parser
             [< (ps, co, ss) = parse_method_rest l >] ->
             let ps = if binding = Instance then (IdentTypeExpr (l, None, cn), "this")::ps 
                 else ps in
-            MethMember (Meth (l, Real, t, x, ps, co, ss, binding, vis, abstract, tparams))
+            MethMember (Meth (l, Real, t, x, ps, co, ss, binding, vis, abstract))
           | [< t = id (match t with None -> raise (ParseException (l, "A field cannot be void.")) | Some(t) -> t);
                tx = parse_array_braces t;
                init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -279,7 +279,7 @@ and
 and
   constr m=
   match m with
-    ConsMember(Cons(l, ps, co, ss, v))::ms -> Cons(l, ps, co, ss, v)::(constr ms)
+    ConsMember(Cons(l,ps,co,ss,v))::ms -> Cons(l,ps,co,ss,v)::(constr ms)
     |_::ms -> constr ms
     | []->[]
 and
@@ -335,7 +335,7 @@ and
 and 
   id x = parser [< >] -> x
 and 
-  parse_java_modifier = parser [< '(l, Kwd "public") >] -> VisibilityModifier(Public) | [< '(l, Kwd "protected") >] -> VisibilityModifier(Protected) | [< '(l, Kwd "private") >] -> VisibilityModifier(Private) | [< '(l, Kwd "static") >] -> StaticModifier | [< '(l, Kwd "final") >] -> FinalModifier | [< '(l, Kwd "abstract") >] -> AbstractModifier
+  parse_java_modifier = parser [< '(_, Kwd "public") >] -> VisibilityModifier(Public) | [< '(l, Kwd "protected") >] -> VisibilityModifier(Protected) | [< '(l, Kwd "private") >] -> VisibilityModifier(Private) | [< '(l, Kwd "static") >] -> StaticModifier | [< '(l, Kwd "final") >] -> FinalModifier | [< '(l, Kwd "abstract") >] -> AbstractModifier
 and
   parse_java_member cn = parser
   [< modifiers = rep parse_java_modifier;
@@ -460,7 +460,7 @@ and
   [< '(l, Kwd "struct"); '(_, Ident s); d = parser
     [< fs = parse_fields; '(_, Kwd ";") >] -> Struct (l, s, Some fs)
   | [< '(_, Kwd ";") >] -> Struct (l, s, None)
-  | [< t = parse_type_suffix (StructTypeExpr (l, Some s, None)); d = parse_func_rest Regular (Some t) Public Real >] -> d
+  | [< t = parse_type_suffix (StructTypeExpr (l, Some s, None)); d = parse_func_rest Regular (Some t) Public >] -> d
   >] -> check_function_for_contract d
 | [< '(l, Kwd "typedef");
      rt = parse_return_type; '(_, Ident g);
@@ -492,9 +492,9 @@ and
   >] -> register_typedef g; ds
 | [< '(_, Kwd "enum"); '(l, Ident n); elems = parse_enum_body; '(_, Kwd ";"); >] ->
   [EnumDecl(l, n, elems)]
-| [< '(_, Kwd "static"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Private Real >] -> check_function_for_contract d
-| [< '(_, Kwd "extern"); t = parse_return_type; d = parse_func_rest Regular t Public Real >] -> check_function_for_contract d
-| [< '(_, Kwd "_Noreturn"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Public Real >] ->
+| [< '(_, Kwd "static"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Private >] -> check_function_for_contract d
+| [< '(_, Kwd "extern"); t = parse_return_type; d = parse_func_rest Regular t Public >] -> check_function_for_contract d
+| [< '(_, Kwd "_Noreturn"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Public >] ->
   let ds = check_function_for_contract d in
   begin match ds with
     [Func (l, k, tparams, t, g, ps, gc, ft, Some (pre, post), terminates, ss, static, v)] ->
@@ -505,7 +505,7 @@ and
   | _ -> ()
   end;
   ds
-| [< t = parse_return_type; d = parse_func_rest Regular t Public Real >] -> check_function_for_contract d
+| [< t = parse_return_type; d = parse_func_rest Regular t Public >] -> check_function_for_contract d
 and check_for_contract: 'a. 'a option -> loc -> string -> (asn * asn -> 'a) -> 'a = fun contract l m f ->
   match contract with
     | Some spec -> spec 
@@ -556,7 +556,7 @@ and
 and
   parse_pure_decl = parser
     [< '(l, Kwd "inductive"); '(li, Ident i); tparams = parse_type_params li; '(_, Kwd "="); cs = (parser [< cs = parse_ctors >] -> cs | [< cs = parse_ctors_suffix >] -> cs); '(_, Kwd ";") >] -> [Inductive (l, i, tparams, cs)]
-  | [< '(l, Kwd "fixpoint"); t = parse_return_type; d = parse_func_rest Fixpoint t Public Ghost>] -> [d]
+  | [< '(l, Kwd "fixpoint"); t = parse_return_type; d = parse_func_rest Fixpoint t Public>] -> [d]
   | [< '(l, Kwd "predicate"); result = parse_predicate_decl l Inductiveness_Inductive >] -> result
   | [< '(l, Kwd "copredicate"); result = parse_predicate_decl l Inductiveness_CoInductive >] -> result
   | [< '(l, Kwd "predicate_family"); '(_, Ident g); is = parse_paramlist; (ps, inputParamCount) = parse_pred_paramlist; '(_, Kwd ";") >]
@@ -565,8 +565,8 @@ and
      p = parse_pred_body; '(_, Kwd ";"); >] -> [PredFamilyInstanceDecl (l, g, [], is, ps, p)]
   | [< '(l, Kwd "predicate_ctor"); '(_, Ident g); ps1 = parse_paramlist; (ps2, inputParamCount) = parse_pred_paramlist;
      p = parse_pred_body; '(_, Kwd ";"); >] -> [PredCtorDecl (l, g, ps1, ps2, inputParamCount, p)]
-  | [< '(l, Kwd "lemma"); t = parse_return_type; d = parse_func_rest (Lemma(false, None)) t Public Ghost >] -> [d]
-  | [< '(l, Kwd "lemma_auto"); trigger = opt (parser [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); >] -> e); t = parse_return_type; d = parse_func_rest (Lemma(true, trigger)) t Public Ghost>] -> [d]
+  | [< '(l, Kwd "lemma"); t = parse_return_type; d = parse_func_rest (Lemma(false, None)) t Public >] -> [d]
+  | [< '(l, Kwd "lemma_auto"); trigger = opt (parser [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); >] -> e); t = parse_return_type; d = parse_func_rest (Lemma(true, trigger)) t Public>] -> [d]
   | [< '(l, Kwd "box_class"); '(_, Ident bcn); ps = parse_paramlist;
        '(_, Kwd "{"); '(_, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";");
        ads = parse_action_decls; hpds = parse_handle_pred_decls; '(_, Kwd "}") >] -> [BoxClassDecl (l, bcn, ps, inv, ads, hpds)]
@@ -626,7 +626,7 @@ and
          | Some(params) -> params
          | None -> []
 and
-  parse_func_rest k t v gh = parser
+  parse_func_rest k t v = parser
   [<
     '(l, Ident g);
     tparams = parse_type_params_general;

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -119,12 +119,12 @@ module Scala = struct
   let rec
     parse_decl = parser
       [< '(l, Kwd "object"); '(_, Ident cn); '(_, Kwd "{"); ms = rep parse_method; '(_, Kwd "}") >] ->
-      Class (l, false, FinalClass, cn, ms, [], [], "Object", [], [])
+      Class (l, false, FinalClass, cn, ms, [], [], ("Object", []), [], [], [])
   and
     parse_method = parser
       [< '(l, Kwd "def"); '(_, Ident mn); ps = parse_paramlist; t = parse_type_ann; co = parse_contract; '(_, Kwd "=");'(_, Kwd "{"); ss = rep parse_stmt; '(closeBraceLoc, Kwd "}")>] ->
       let rt = match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t in
-      Meth (l, Real, rt, mn, ps, Some co, Some ((ss, closeBraceLoc), next_body_rank ()), Static, Public, false)
+      Meth (l, Real, rt, mn, ps, Some co, Some ((ss, closeBraceLoc), next_body_rank ()), Static, Public, false,[])
   and
     parse_paramlist = parser
       [< '(_, Kwd "("); ps = rep_comma parse_param; '(_, Kwd ")") >] -> ps
@@ -230,45 +230,44 @@ and
      abstract = (parser [< '(_, Kwd "abstract") >] -> true | [< >] -> false); 
      final = (parser [< '(_, Kwd "final") >] -> FinalClass | [< >] -> ExtensibleClass);
      ds = begin parser
-       [< '(l, Kwd "class"); '(_, Ident s); _ = type_params_parse_and_push();
-          super = parse_super_class; il = parse_interfaces; mem = parse_java_members s; ds = parse_decls_core >]
-       -> type_params_pop();
-          Class (l, abstract, final, s, methods s mem, fields mem, constr mem, super, il, instance_preds mem)::ds
-     | [< '(l, Kwd "interface"); '(_, Ident cn); _ = type_params_parse_and_push();
-          il = parse_extended_interfaces;  mem = parse_java_members cn; ds = parse_decls_core >]
-       -> type_params_pop();
-          Interface (l, cn, il, fields mem, methods cn mem, instance_preds mem)::ds
+       [< '(l, Kwd "class"); '(startLoc, Ident s); tparams = type_params_parse;
+          super = parse_super_class l; il = parse_interfaces; mem = parse_java_members s tparams; ds = parse_decls_core >]
+       -> Class (l, abstract, final, s, methods s mem, fields mem, constr mem, super, tparams, il, instance_preds mem)::ds
+     | [< '(l, Kwd "interface"); '(startLoc, Ident cn); tparams = type_params_parse;
+          il = parse_extended_interfaces;  mem = parse_java_members cn tparams; ds = parse_decls_core >]
+       -> Interface (l, cn, il, fields mem, methods cn mem, tparams, instance_preds mem)::ds
      | [< d = parse_decl; ds = parse_decls_core >] -> d@ds
      | [< '(_, Kwd ";"); ds = parse_decls_core >] -> ds
      | [< >] -> []
      end
   >] -> ds
-and parse_qualified_type_rest = parser
-  [< '(_, Kwd "."); '(_, Ident s); rest = parse_qualified_type_rest >] -> "." ^ s ^ rest
-| [< xs = parse_type_params_with_loc >] -> List.iter (fun (l,p) -> type_param_check_in_scope l p) xs; ""
-| [<>] -> ""
-and parse_qualified_type = parser
-  [<'(_, Ident s); rest = parse_qualified_type_rest >] -> s ^ rest
+and parse_qualified_type loc = parser
+  [< t = parse_type >] -> 
+    match t with 
+      IdentTypeExpr(l,p,n) -> ((match p with Some(s) -> s ^ n | None -> n), []) 
+      | ConstructedTypeExpr(l,n,targs) -> (n,targs)
+      | _ -> raise (ParseException (loc, "Invalid type"))
+  
 and
-  parse_super_class= parser
-    [<'(_, Kwd "extends"); s = parse_qualified_type >] -> s 
-  | [<>] -> "java.lang.Object"
+  parse_super_class loc = parser
+    [<'(l, Kwd "extends"); (s,targs) = parse_qualified_type l>] -> (s,targs)
+  | [<>] -> ("java.lang.Object",[])
 and
-  parse_interfaces= parser
-  [< '(_, Kwd "implements"); is = rep_comma (parser 
-    [< i = parse_qualified_type; e=parser
+  parse_interfaces = parser
+  [< '(l, Kwd "implements"); is = rep_comma (parser 
+    [< i = parse_qualified_type l; e=parser
       [<>]->(i)>] -> e); '(_, Kwd "{") >] -> is
-| [<'(_, Kwd "{")>]-> []
+  | [<'(_, Kwd "{")>]-> []
 and
-  parse_extended_interfaces= parser
-  [< '(_, Kwd "extends"); is = rep_comma (parser 
-    [< i = parse_qualified_type; e=parser
+  parse_extended_interfaces = parser
+  [< '(l, Kwd "extends"); is = rep_comma (parser 
+    [< i = parse_qualified_type l; e=parser
       [<>]->(i)>] -> e); '(_, Kwd "{") >] -> is
-| [<'(_, Kwd "{")>]-> []
+  | [<'(_, Kwd "{")>]-> []
 and
   methods cn m=
   match m with
-    MethMember (Meth (l, gh, t, n, ps, co, ss,s,v,abstract))::ms -> Meth (l, gh, t, n, ps, co, ss,s,v,abstract)::(methods cn ms)
+    MethMember (Meth (l, gh, t, n, ps, co, ss,s,v,abstract, tparams))::ms -> Meth (l, gh, t, n, ps, co, ss,s,v,abstract, tparams)::(methods cn ms)
     |_::ms -> methods cn ms
     | []->[]
 and
@@ -280,7 +279,7 @@ and
 and
   constr m=
   match m with
-    ConsMember(Cons(l,ps,co,ss,v))::ms -> Cons(l,ps,co,ss,v)::(constr ms)
+    ConsMember(Cons(l,ps,co,ss,v, tparams))::ms -> Cons(l,ps,co,ss,v, tparams)::(constr ms)
     |_::ms -> constr ms
     | []->[]
 and
@@ -292,10 +291,10 @@ and
 | [<'(_, Kwd "protected")>] -> Protected
 | [<>] -> Package
 and
-  parse_java_members cn= parser
+  parse_java_members cn tpenv = parser
   [<'(_, Kwd "}")>] -> []
-| [< '(_, Kwd "/*@"); mems1 = parse_ghost_java_members cn; mems2 = parse_java_members cn >] -> mems1 @ mems2
-| [< m=parse_java_member cn;mr=parse_java_members cn>] -> m::mr
+| [< '(_, Kwd "/*@"); mems1 = parse_ghost_java_members cn; mems2 = parse_java_members cn tpenv >] -> mems1 @ mems2
+| [< m=parse_java_member cn tpenv;mr=parse_java_members cn tpenv>] -> m::mr
 and
   parse_ghost_java_members cn = parser
   [< '(_, Kwd "@*/") >] -> []
@@ -312,7 +311,7 @@ and
      | [< '(l, Kwd "lemma"); t = parse_return_type; 
           '(l, Ident x); (ps, co, ss) = parse_method_rest l >] -> 
         let ps = (IdentTypeExpr (l, None, cn), "this")::ps in
-        MethMember(Meth (l, Ghost, t, x, ps, co, ss, Instance, vis, false))
+        MethMember(Meth (l, Ghost, t, x, ps, co, ss, Instance, vis, false, []))
      | [< binding = (parser [< '(_, Kwd "static") >] -> Static | [< >] -> Instance); t = parse_type; '(l, Ident x); '(_, Kwd ";") >] ->
        FieldMember [Field (l, Ghost, t, x, binding, vis, false, None)]
     end
@@ -329,31 +328,31 @@ and
 and
   parse_throws_clause = parser
   [< '(l, Kwd "throws"); epost = rep_comma (parse_thrown l) >] -> epost
-and
-  parse_array_dims t = parser
+and parse_array_dims t = parser
   [< '(l, Kwd "["); '(_, Kwd "]"); t = parse_array_dims (ArrayTypeExpr (l, t)) >] -> t
 | [< >] -> t
-and 
-  id x = parser [< >] -> x
-and 
-  parse_java_modifier = parser [< '(_, Kwd "public") >] -> VisibilityModifier(Public) | [< '(_, Kwd "protected") >] -> VisibilityModifier(Protected) | [< '(_, Kwd "private") >] -> VisibilityModifier(Private) | [< '(_, Kwd "static") >] -> StaticModifier | [< '(_, Kwd "final") >] -> FinalModifier | [< '(_, Kwd "abstract") >] -> AbstractModifier
-and
-  parse_java_member cn = parser
+and id x = parser [< >] -> x
+and parse_java_modifier = parser [< '(l, Kwd "public") >] -> VisibilityModifier(Public)
+  | [< '(l, Kwd "protected") >] -> VisibilityModifier(Protected)
+  | [< '(l, Kwd "private") >] -> VisibilityModifier(Private) 
+  | [< '(l, Kwd "static") >] -> StaticModifier
+  | [< '(l, Kwd "final") >] -> FinalModifier
+  | [< '(l, Kwd "abstract") >] -> AbstractModifier
+and parse_java_member cn tpenv = parser
   [< modifiers = rep parse_java_modifier;
      binding = (fun _ -> if List.mem StaticModifier modifiers then Static else Instance);
      final = (fun _ -> List.mem FinalModifier modifiers);
      abstract = (fun _ -> List.mem AbstractModifier modifiers);
      vis = (fun _ -> (match (try_find (function VisibilityModifier(_) -> true | _ -> false) modifiers) with None -> Package | Some(VisibilityModifier(vis)) -> vis));
-     _ = type_params_parse_and_push ();
+     tparams = type_params_parse;
      t = parse_return_type;
      member = parser
        [< '(l, Ident x);
           member = parser
             [< (ps, co, ss) = parse_method_rest l >] ->
-            let t' = option_map type_param_erasure_in_scope t in
-            let ps = List.map (fun (texpr, s) -> (type_param_erasure_in_scope texpr, s))
-                (if binding = Instance then (IdentTypeExpr (l, None, cn), "this")::ps else ps) in
-            MethMember (Meth (l, Real, t', x, ps, co, ss, binding, vis, abstract))
+            let ps = if binding = Instance then (IdentTypeExpr (l, None, cn),"this")::ps 
+                else ps in
+            MethMember (Meth (l, Real, t, x, ps, co, ss, binding, vis, abstract, (tpenv@tparams)))
           | [< t = id (match t with None -> raise (ParseException (l, "A field cannot be void.")) | Some(t) -> t);
                tx = parse_array_braces t;
                init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);
@@ -375,8 +374,8 @@ and
        in
        if binding = Static then raise (ParseException (l, "A constructor cannot be static."));
        if final then raise (ParseException (l, "A constructor cannot be final."));
-       ConsMember (Cons (l, ps, co, ss, vis))
-  >] -> type_params_pop (); member
+       ConsMember (Cons (l, ps, co, ss, vis, (tpenv@tparams)))
+  >] -> member
 and parse_array_init_rest = parser
   [< '(_, Kwd ","); es = opt(parser [< e = parse_expr; es = parse_array_init_rest >] -> e :: es) >] -> (match es with None -> [] | Some(es) -> es)
 | [< >] -> []
@@ -388,14 +387,12 @@ and parse_declaration_rhs te = parser
   [< '(linit, Kwd "{"); es = parse_array_init >] ->
   (match te with ArrayTypeExpr (_, elem_te) -> NewArrayWithInitializer (linit, elem_te, es) | _ -> InitializerList (linit, es))
 | [< e = parse_expr >] -> e
-and
-  parse_declarator t = parser
+and parse_declarator t = parser
   [< '(l, Ident x);
      tx = parse_array_braces t;
      init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);
   >] -> (l, tx, x, init, (ref false, ref None))
-and
-  parse_method_rest l = parser
+and parse_method_rest l = parser
   [< ps = parse_paramlist;
     epost = opt parse_throws_clause;
     (ss, co) = parser
@@ -422,8 +419,7 @@ and
         end
     in
     (ps, contract, ss)
-and
-  parse_functype_paramlists = parser
+and parse_functype_paramlists = parser
   [< ps1 = parse_paramlist; ps2 = opt parse_paramlist >] -> (match ps2 with None -> ([], ps1) | Some ps2 -> (ps1, ps2))
 and
   (** Parses
@@ -452,18 +448,16 @@ and
 | [< '(l, Kwd "__forceinline") >] -> ()
 | [< '(l, Kwd "__always_inline") >] -> ()
 | [< >] -> ()
-and
-  parse_enum_body = parser
+and parse_enum_body = parser
   [< '(_, Kwd "{");
      elems = rep_comma (parser [< '(_, Ident e); init = opt (parser [< '(_, Kwd "="); e = parse_expr >] -> e) >] -> (e, init));
      '(_, Kwd "}")
    >] -> elems
-and
-  parse_decl = parser
+and parse_decl = parser
   [< '(l, Kwd "struct"); '(_, Ident s); d = parser
     [< fs = parse_fields; '(_, Kwd ";") >] -> Struct (l, s, Some fs)
   | [< '(_, Kwd ";") >] -> Struct (l, s, None)
-  | [< t = parse_type_suffix (StructTypeExpr (l, Some s, None)); d = parse_func_rest Regular (Some t) Public >] -> d
+  | [< t = parse_type_suffix (StructTypeExpr (l, Some s, None)); d = parse_func_rest Regular (Some t) Public Real >] -> d
   >] -> check_function_for_contract d
 | [< '(l, Kwd "typedef");
      rt = parse_return_type; '(_, Ident g);
@@ -495,9 +489,9 @@ and
   >] -> register_typedef g; ds
 | [< '(_, Kwd "enum"); '(l, Ident n); elems = parse_enum_body; '(_, Kwd ";"); >] ->
   [EnumDecl(l, n, elems)]
-| [< '(_, Kwd "static"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Private >] -> check_function_for_contract d
-| [< '(_, Kwd "extern"); t = parse_return_type; d = parse_func_rest Regular t Public >] -> check_function_for_contract d
-| [< '(_, Kwd "_Noreturn"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Public >] ->
+| [< '(_, Kwd "static"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Private Real >] -> check_function_for_contract d
+| [< '(_, Kwd "extern"); t = parse_return_type; d = parse_func_rest Regular t Public Real >] -> check_function_for_contract d
+| [< '(_, Kwd "_Noreturn"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Public Real >] ->
   let ds = check_function_for_contract d in
   begin match ds with
     [Func (l, k, tparams, t, g, ps, gc, ft, Some (pre, post), terminates, ss, static, v)] ->
@@ -508,7 +502,7 @@ and
   | _ -> ()
   end;
   ds
-| [< t = parse_return_type; d = parse_func_rest Regular t Public >] -> check_function_for_contract d
+| [< t = parse_return_type; d = parse_func_rest Regular t Public Real >] -> check_function_for_contract d
 and check_for_contract: 'a. 'a option -> loc -> string -> (asn * asn -> 'a) -> 'a = fun contract l m f ->
   match contract with
     | Some spec -> spec 
@@ -524,31 +518,25 @@ and check_function_for_contract d =
     let contract = check_for_contract contract l "Function declaration should have a contract." (fun co -> co) in
     [Func(l, k, tparams, t, g, ps, gc, ft, Some contract, terminates, ss, static, v)]
   | _ -> [d]
-and
-  parse_pure_decls = parser
+and parse_pure_decls = parser
   [< ds0 = parse_pure_decl; ds = parse_pure_decls >] -> ds0 @ ds
-| [< >] -> []
-and
-  parse_index_list = parser
+  | [< >] -> []
+and parse_index_list = parser
   [< '(_, Kwd "("); is = rep_comma (parser 
     [< '(l, Ident i); e=parser
       [<'(_, Kwd ".");'(_, Kwd "class")>]-> (l,i)
       |[<>]->(l,i)>] -> e); '(_, Kwd ")") >] -> is
-and
-  parse_type_params l = parser
+and parse_type_params l = parser
     [< xs = parse_angle_brackets l (rep_comma (parser [< '(_, Ident x) >] -> x)) >] -> xs
   | [< >] -> []
-and
-  parse_pred_body = parser
+and parse_pred_body = parser
   | [< '(_, Kwd "="); p = parse_asn >] -> p
-and
-  parse_pred_paramlist = parser
+and parse_pred_paramlist = parser
     [< 
       '(_, Kwd "("); ps = rep_comma parse_param;
       (ps, inputParamCount) = (parser [< '(_, Kwd ";"); ps' = rep_comma parse_param >] -> (ps @ ps', Some (List.length ps)) | [< >] -> (ps, None)); '(_, Kwd ")")
     >] -> (ps, inputParamCount)
-and
-  parse_predicate_decl l (inductiveness: inductiveness) = parser 
+and parse_predicate_decl l (inductiveness: inductiveness) = parser 
     [< '(li, Ident g); tparams = parse_type_params li; 
      (ps, inputParamCount) = parse_pred_paramlist;
      body = opt parse_pred_body;
@@ -556,10 +544,9 @@ and
     >] ->
     [PredFamilyDecl (l, g, tparams, 0, List.map (fun (t, p) -> t) ps, inputParamCount, inductiveness)] @
     (match body with None -> [] | Some body -> [PredFamilyInstanceDecl (l, g, tparams, [], ps, body)])
-and
-  parse_pure_decl = parser
+and parse_pure_decl = parser
     [< '(l, Kwd "inductive"); '(li, Ident i); tparams = parse_type_params li; '(_, Kwd "="); cs = (parser [< cs = parse_ctors >] -> cs | [< cs = parse_ctors_suffix >] -> cs); '(_, Kwd ";") >] -> [Inductive (l, i, tparams, cs)]
-  | [< '(l, Kwd "fixpoint"); t = parse_return_type; d = parse_func_rest Fixpoint t Public>] -> [d]
+  | [< '(l, Kwd "fixpoint"); t = parse_return_type; d = parse_func_rest Fixpoint t Public Ghost>] -> [d]
   | [< '(l, Kwd "predicate"); result = parse_predicate_decl l Inductiveness_Inductive >] -> result
   | [< '(l, Kwd "copredicate"); result = parse_predicate_decl l Inductiveness_CoInductive >] -> result
   | [< '(l, Kwd "predicate_family"); '(_, Ident g); is = parse_paramlist; (ps, inputParamCount) = parse_pred_paramlist; '(_, Kwd ";") >]
@@ -568,8 +555,8 @@ and
      p = parse_pred_body; '(_, Kwd ";"); >] -> [PredFamilyInstanceDecl (l, g, [], is, ps, p)]
   | [< '(l, Kwd "predicate_ctor"); '(_, Ident g); ps1 = parse_paramlist; (ps2, inputParamCount) = parse_pred_paramlist;
      p = parse_pred_body; '(_, Kwd ";"); >] -> [PredCtorDecl (l, g, ps1, ps2, inputParamCount, p)]
-  | [< '(l, Kwd "lemma"); t = parse_return_type; d = parse_func_rest (Lemma(false, None)) t Public >] -> [d]
-  | [< '(l, Kwd "lemma_auto"); trigger = opt (parser [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); >] -> e); t = parse_return_type; d = parse_func_rest (Lemma(true, trigger)) t Public >] -> [d]
+  | [< '(l, Kwd "lemma"); t = parse_return_type; d = parse_func_rest (Lemma(false, None)) t Public Ghost >] -> [d]
+  | [< '(l, Kwd "lemma_auto"); trigger = opt (parser [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); >] -> e); t = parse_return_type; d = parse_func_rest (Lemma(true, trigger)) t Public Ghost>] -> [d]
   | [< '(l, Kwd "box_class"); '(_, Ident bcn); ps = parse_paramlist;
        '(_, Kwd "{"); '(_, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";");
        ads = parse_action_decls; hpds = parse_handle_pred_decls; '(_, Kwd "}") >] -> [BoxClassDecl (l, bcn, ps, inv, ads, hpds)]
@@ -580,37 +567,30 @@ and
   | [< '(l, Kwd "import_module"); '(_, Ident g); '(lx, Kwd ";") >] -> [ImportModuleDecl (l, g)]
   | [< '(l, Kwd "require_module"); '(_, Ident g); '(lx, Kwd ";") >] -> [RequireModuleDecl (l, g)]
   | [< '(l, Kwd "abstract_type"); '(_, Ident t); '(_, Kwd ";") >] -> [AbstractTypeDecl (l, t)]
-and
-  parse_action_decls = parser
+and parse_action_decls = parser
   [< ad = parse_action_decl; ads = parse_action_decls >] -> ad::ads
 | [< >] -> []
-and
-  parse_action_decl = parser
+and parse_action_decl = parser
   [< '(l, Kwd "action"); permbased = opt (parser [< '(_, Kwd "permbased") >] -> 0); '(_, Ident an); ps = parse_paramlist; '(_, Kwd ";");
      '(_, Kwd "requires"); pre = parse_expr; '(_, Kwd ";");
      '(_, Kwd "ensures"); post = parse_expr; '(_, Kwd ";") >] -> ActionDecl (l, an, (match permbased with None -> false | Some _ -> true), ps, pre, post)
-and
-  parse_handle_pred_decls = parser
+and parse_handle_pred_decls = parser
   [< hpd = parse_handle_pred_decl; hpds = parse_handle_pred_decls >] -> hpd::hpds
 | [< >] -> []
-and
-  parse_handle_pred_decl = parser
+and parse_handle_pred_decl = parser
   [< '(l, Kwd "handle_predicate"); '(_, Ident hpn); ps = parse_paramlist;
      extends = opt (parser [< '(l, Kwd "extends"); '(_, Ident ehn) >] -> ehn);
      '(_, Kwd "{"); '(_, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";"); pbcs = parse_preserved_by_clauses; '(_, Kwd "}") >]
      -> HandlePredDecl (l, hpn, ps, extends, inv, pbcs)
-and
-  parse_preserved_by_clauses = parser
+and parse_preserved_by_clauses = parser
   [< pbc = parse_preserved_by_clause; pbcs = parse_preserved_by_clauses >] -> pbc::pbcs
 | [< >] -> []
-and
-  parse_preserved_by_clause = parser
+and parse_preserved_by_clause = parser
   [< '(l, Kwd "preserved_by"); '(_, Ident an); '(_, Kwd "("); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ")");
      ss = parse_block >] -> PreservedByClause (l, an, xs, ss)
-and
-  parse_type_params_free = parser [< '(_, Kwd "<"); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ">") >] -> xs
-and
-  parse_type_params_general = parser
+and parse_type_params_free = parser 
+  [< '(_, Kwd "<"); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ">") >] -> xs
+and parse_type_params_general = parser
   [< xs = parse_type_params_free >] -> xs
 | [<
     xs = peek_in_ghost_range (
@@ -621,64 +601,13 @@ and
     )
   >] -> xs
 | [< >] -> []
-and
-  parse_type_params_with_loc = parser
-  [< '(_, Kwd "<"); xs = rep_comma (parser [< '(l, Ident x) >] -> (l,x)); '(_, Kwd ">") >] -> xs
-and
-  type_params_in_scope = ref []
-and
-  type_params_pop _ =
-    type_params_in_scope := List.tl !type_params_in_scope
-and
-  type_params_parse_and_push _ =
+and type_params_parse =
     parser
       [< xs = opt parse_type_params_general >] ->
-        type_params_in_scope := xs::!type_params_in_scope
-and
-  type_param_is_in_scope arg =
-    let rec is_in_scope_core arg params =
-      match params with
-      | Some(ps)::rest ->
-          if List.mem arg ps then
-            true
-          else
-            is_in_scope_core arg rest
-      | None::rest -> is_in_scope_core arg rest
-      | []-> false
-    in is_in_scope_core arg !type_params_in_scope
-and
-  type_param_check_in_scope l arg =
-    if not (type_param_is_in_scope arg) then
-      raise (ParseException (l, "Type parameter is not in scope"));
-and
-  type_param_check_texpr_in_scope texpr =
-    match texpr with
-    | PtrTypeExpr (l, targ) -> type_param_check_texpr_in_scope targ
-    | ArrayTypeExpr (l, targ) -> type_param_check_texpr_in_scope targ
-    | StaticArrayTypeExpr (l, targ, i) -> type_param_check_texpr_in_scope targ
-    | IdentTypeExpr (l, pkgn, n) -> type_param_check_in_scope l n
-    | ConstructedTypeExpr (l, n, targs) -> type_param_check_in_scope l n;
-                                           List.iter type_param_check_texpr_in_scope targs;
-    | _ -> ()
-and
-   type_param_translate_in_scope p =
-    if type_param_is_in_scope p then
-      "java.lang.Object"
-    else
-      p
-and
-  type_param_erasure_in_scope texpr =
-    match texpr with
-    | PtrTypeExpr (l, targ) -> PtrTypeExpr (l, type_param_erasure_in_scope targ)
-    | ArrayTypeExpr (l, targ) -> ArrayTypeExpr (l, type_param_erasure_in_scope targ)
-    | StaticArrayTypeExpr (l, targ, i) -> StaticArrayTypeExpr (l, type_param_erasure_in_scope targ, i)
-    | IdentTypeExpr (l, pkgn, n) -> IdentTypeExpr (l, pkgn, type_param_translate_in_scope n)
-    | ConstructedTypeExpr (l, n, targs) ->
-        List.iter type_param_check_texpr_in_scope targs;
-        IdentTypeExpr (l, None, type_param_translate_in_scope n)
-    | _ -> texpr
-and
-  parse_func_rest k t v = parser
+        match xs with
+         | Some(params) -> params
+         | None -> []
+and parse_func_rest k t v gh = parser
   [<
     '(l, Ident g);
     tparams = parse_type_params_general;
@@ -698,12 +627,10 @@ and
         '(_, Kwd ";")
       >] -> Global (l, t, g, init)
   >] -> decl
-and
-  parse_ctors_suffix = parser
+and parse_ctors_suffix = parser
   [< '(_, Kwd "|"); cs = parse_ctors >] -> cs
 | [< >] -> []
-and
-  parse_ctors = parser
+and parse_ctors = parser
   [< '(l, Ident cn);
      ts = begin
        parser
@@ -715,8 +642,7 @@ and
      end;
      cs = parse_ctors_suffix
   >] -> Ctor (l, cn, ts)::cs
-and
-  parse_paramtype_and_name = parser
+and parse_paramtype_and_name = parser
   [< t = parse_type;
      paramname_opt = opt (parser
        [< '(_, Ident paramname) >] -> paramname
@@ -724,21 +650,16 @@ and
   >] ->
     let paramname = match paramname_opt with None -> "" | Some(x) -> x in
     (paramname, t)
-and
-  parse_paramtype = parser [< t = parse_type; _ = opt (parser [< '(_, Ident _) >] -> ()) >] -> t
-and
-  parse_fields = parser
+and parse_paramtype = parser [< t = parse_type; _ = opt (parser [< '(_, Ident _) >] -> ()) >] -> t
+and parse_fields = parser
   [< '(_, Kwd "{"); fs = parse_fields_rest >] -> fs
-and
-  parse_fields_rest = parser
+and parse_fields_rest = parser
   [< '(_, Kwd "}") >] -> []
 | [< f = parse_field; fs = parse_fields_rest >] -> f::fs
-and
-  parse_field = parser
+and parse_field = parser
   [< '(_, Kwd "/*@"); f = parse_field_core Ghost; '(_, Kwd "@*/") >] -> f
 | [< f = parse_field_core Real >] -> f
-and
-  parse_field_core gh = parser
+and  parse_field_core gh = parser
   [< te0 = parse_type; '(l, Ident f);
      te = parser
         [< '(_, Kwd ";") >] -> te0
@@ -747,18 +668,14 @@ and
               raise (ParseException (ls, "Array must have size > 0."));
             StaticArrayTypeExpr (l, te0, int_of_big_int size)
    >] -> Field (l, gh, te, f, Instance, Public, false, None)
-and
-  parse_return_type = parser
+and  parse_return_type = parser
   [< t = parse_type >] -> match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t
-and
-  parse_type = parser
+and parse_type = parser
   [< t0 = parse_primary_type; t = parse_type_suffix t0 >] -> t
-and
-  parse_int_opt = parser
+and parse_int_opt = parser
   [< '(_, Kwd "int") >] -> ()
 | [< >] -> ()
-and
-  parse_integer_type_keyword = parser
+and parse_integer_type_keyword = parser
   [< '(l, Kwd "int") >] -> (l, int_rank)
 | [< '(l, Kwd "__int8") >] -> (l, 0)
 | [< '(l, Kwd "__int16") >] -> (l, 1)
@@ -823,10 +740,11 @@ and
 | [< '(l, Kwd "box") >] -> ManifestTypeExpr (l, BoxIdType)
 | [< '(l, Kwd "handle") >] -> ManifestTypeExpr (l, HandleIdType)
 | [< '(l, Kwd "any") >] -> ManifestTypeExpr (l, AnyType)
-| [< '(l, Ident n); rest = rep(parser [< '(l, Kwd "."); '(l, Ident n) >] -> n); targs = parse_type_args l;  >] -> 
+| [< '(l, Ident n); rest = rep(parser [< '(l, Kwd "."); '(l, Ident n) >] -> n); (targs, diamond) = parse_type_args_with_diamond l >] -> 
+    if diamond then raise (ParseException (l, "Diamond not supported yet")) else
     if targs <> [] then 
       match rest with
-      | [] ->  ConstructedTypeExpr (l, n, targs) 
+      | [] -> ConstructedTypeExpr (l, n, targs) 
       | _ -> raise (ParseException (l, "Package name not supported for generic types."))
     else
       match rest with
@@ -1268,8 +1186,21 @@ and
   [< e0 = parse_expr_primary; e = parse_expr_suffix_rest e0 >] -> e
 and
   parse_type_args l = parser
-    [< targs = parse_angle_brackets l (rep_comma parse_type) >] -> targs
+   [< targs = parse_angle_brackets l (rep_comma parse_type) >] -> targs
   | [< >] -> []
+and
+parse_type_args_with_diamond l0 = parser
+    [< 
+    (targs,diamond) = match language with
+      CLang -> (parser [< targs = parse_type_args l0 >] -> (targs, false))
+      | Java -> (parser
+        [< '(l1, Kwd "<"); 
+          (targs, diamond) = parser
+            [< '(_, Kwd ">") >] -> ([], true)
+            | [< targs = rep_comma parse_type; '(_, Kwd ">") >] -> (targs,false) 
+        >] -> (targs,diamond)
+        | [< >] -> ([], false))
+    >] -> (targs,diamond)
 and
   parse_new_array_expr_rest l elem_typ = parser
   [< '(_, Kwd "[");
@@ -1288,13 +1219,21 @@ and
 | [< '(l, Kwd "null") >] -> Null l
 | [< '(l, Kwd "currentThread") >] -> Var (l, "currentThread")
 | [< '(l, Kwd "varargs") >] -> Var (l, "varargs")
-| [< '(l, Kwd "new"); tp = parse_primary_type; res = (parser 
-                    [< args0 = parse_patlist >] -> 
-                    begin match tp with
-                      IdentTypeExpr(_, pac, cn) -> NewObject (l, (match pac with None -> "" | Some(pac) -> pac ^ ".") ^ cn, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0)
-                    | _ -> raise (ParseException (type_expr_loc tp, "Class name expected"))
-                    end
-                  | [< e = parse_new_array_expr_rest l tp >] -> e)
+| [< '(l, Kwd "new"); 
+  tp = parse_primary_type; 
+  res = (parser 
+    [< args0 = parse_patlist >] -> 
+      begin match tp with
+        IdentTypeExpr(_, pac, cn) -> 
+          NewObject (l, 
+            (match pac with None -> "" | Some(pac) -> pac ^ ".") ^ cn, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0)
+        | ConstructedTypeExpr(loc, name, targs) -> 
+          NewGenericObject (loc,
+              name, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0,
+              targs)
+        | _ -> raise (ParseException (type_expr_loc tp, "Class name expected"))
+      end
+    | [< e = parse_new_array_expr_rest l tp >] -> e)
   >] -> res
 | [<
     '(lx, Ident x);
@@ -1302,7 +1241,7 @@ and
       [<
         args0 = parse_patlist;
         e = parser
-          [< args = parse_patlist >] -> CallExpr (lx, x, [], args0, args,Static)
+          [< args = parse_patlist >] -> CallExpr (lx, x,[], args0, args,Static)
         | [< >] -> CallExpr (lx, x, [], [], args0,Static)
       >] -> e
     | [<

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -335,7 +335,7 @@ and
 and 
   id x = parser [< >] -> x
 and 
-  parse_java_modifier = parser [< '(_, Kwd "public") >] -> VisibilityModifier(Public) | [< '(l, Kwd "protected") >] -> VisibilityModifier(Protected) | [< '(l, Kwd "private") >] -> VisibilityModifier(Private) | [< '(l, Kwd "static") >] -> StaticModifier | [< '(l, Kwd "final") >] -> FinalModifier | [< '(l, Kwd "abstract") >] -> AbstractModifier
+  parse_java_modifier = parser [< '(_, Kwd "public") >] -> VisibilityModifier(Public) | [< '(_, Kwd "protected") >] -> VisibilityModifier(Protected) | [< '(_, Kwd "private") >] -> VisibilityModifier(Private) | [< '(_, Kwd "static") >] -> StaticModifier | [< '(_, Kwd "final") >] -> FinalModifier | [< '(_, Kwd "abstract") >] -> AbstractModifier
 and
   parse_java_member cn = parser
   [< modifiers = rep parse_java_modifier;

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1046,14 +1046,12 @@ and
   packagename_of_read l e =
   match e with
   | Var(_, x) when x <> "this" -> x
-  | VarWithTargs(_, x, targs) when x <> "this" -> x
   | Read(_, e, f) -> (packagename_of_read l e) ^ "." ^ f
   | e -> raise (ParseException (l, "Type expected."))
 and
   type_expr_of_expr e =
   match e with
     Var (l, x) -> IdentTypeExpr (l, None, x)
-  | VarWithTargs(l,x,targs) -> ConstructedTypeExpr(l,x,targs)
   | CallExpr (l, x, targs, [], [], Static) -> ConstructedTypeExpr (l, x, targs)
   | ArrayTypeExpr' (l, e) -> ArrayTypeExpr (l, type_expr_of_expr e)
   | Read(l, e, name) -> IdentTypeExpr(l, Some(packagename_of_read l e), name)
@@ -1343,7 +1341,6 @@ and
   expr_to_class_name e =
     match e with
       Var (_, x) -> x
-    | VarWithTargs(_,x,_) -> x
     | Read (_, e, f) -> expr_to_class_name e ^ "." ^ f
     | _ -> raise (ParseException (expr_loc e, "Class name expected"))
 and

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1226,11 +1226,11 @@ and
       begin match tp with
         IdentTypeExpr(_, pac, cn) -> 
           NewObject (l, 
-            (match pac with None -> "" | Some(pac) -> pac ^ ".") ^ cn, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0)
+            (match pac with None -> "" | Some(pac) -> pac ^ ".") ^ cn, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0, None)
         | ConstructedTypeExpr(loc, name, targs) -> 
-          NewGenericObject (loc,
+          NewObject (loc,
               name, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0,
-              targs)
+              Some (targs))
         | _ -> raise (ParseException (type_expr_loc tp, "Class name expected"))
       end
     | [< e = parse_new_array_expr_rest l tp >] -> e)

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -291,7 +291,7 @@ and
 | [<'(_, Kwd "protected")>] -> Protected
 | [<>] -> Package
 and
-  parse_java_members cn = parser
+  parse_java_members cn= parser
   [<'(_, Kwd "}")>] -> []
 | [< '(_, Kwd "/*@"); mems1 = parse_ghost_java_members cn; mems2 = parse_java_members cn >] -> mems1 @ mems2
 | [< m=parse_java_member cn;mr=parse_java_members cn>] -> m::mr
@@ -553,7 +553,7 @@ and
     >] ->
     [PredFamilyDecl (l, g, tparams, 0, List.map (fun (t, p) -> t) ps, inputParamCount, inductiveness)] @
     (match body with None -> [] | Some body -> [PredFamilyInstanceDecl (l, g, tparams, [], ps, body)])
-and 
+and
   parse_pure_decl = parser
     [< '(l, Kwd "inductive"); '(li, Ident i); tparams = parse_type_params li; '(_, Kwd "="); cs = (parser [< cs = parse_ctors >] -> cs | [< cs = parse_ctors_suffix >] -> cs); '(_, Kwd ";") >] -> [Inductive (l, i, tparams, cs)]
   | [< '(l, Kwd "fixpoint"); t = parse_return_type; d = parse_func_rest Fixpoint t Public Ghost>] -> [d]

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -61,6 +61,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match extended with
         None -> consume_asn rules [] h [] hpInvEnv inv true real_unit (fun _ h _ _ _ -> cont h)
       | Some(ehname) -> assert_handle_invs bcn hpmap ehname hpInvEnv h (fun h ->  consume_asn rules [] h [] hpInvEnv inv true real_unit (fun _ h _ _ _ -> cont h))
+  
   let rec verify_stmt (pn,ilist) blocks_done lblenv tparams boxes pure leminfo funcmap predinstmap sizemap tenv ghostenv h env s tcont return_cont econt =
     let l = stmt_loc s in
     if not (is_transparent_stmt s) then begin !stats#stmtExec l; reportStmtExec l end;
@@ -2052,7 +2053,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | Some cont -> cont blocks_done sizemap tenv ghostenv h env
       end
     | SuperConstructorCall(l, es) -> static_error l "super must be first statement of constructor." None
-  and 
+  and
     verify_cont (pn,ilist) blocks_done lblenv tparams boxes pure leminfo funcmap predinstmap sizemap tenv ghostenv h env ss cont return_cont econt =
     match ss with
       [] -> cont sizemap tenv ghostenv h env
@@ -2062,7 +2063,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           verify_cont (pn,ilist) blocks_done lblenv tparams boxes pure leminfo funcmap predinstmap sizemap tenv ghostenv h env ss cont return_cont econt
         ) return_cont econt
       )
-  and 
+  and
     check_backedge_termination currentThread leminfo l tenv h cont =
       let consume_func_call_perm g =
         let gterm = List.assoc g funcnameterms in
@@ -2084,7 +2085,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   (* Region: verification of blocks *)
   
-  and 
+  and
     goto_block (pn,ilist) blocks_done lblenv tparams boxes pure leminfo funcmap predinstmap sizemap tenv ghostenv h env return_cont econt block =
     let `Block (inv, ss, cont) = block in
     let l() =
@@ -2378,8 +2379,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       ctxt#assume_forall g trigger tps body
   | (WPredAsn(p_loc, p_ref, true, p_targs, p_args1, p_args2), Sep(_, WPredAsn(_, q_ref, true, q_targs, q_args1, q_args2), conditions))
     when List.length ps = 0 && List.for_all (fun arg -> match arg with | VarPat(_,_) -> true | _ -> false) (p_args1 @ p_args2) && 
-         List.length p_targs = List.length tparams' && (List.for_all (fun (x, t) -> 
-          match (x, t) with 
+         List.length p_targs = List.length tparams' && (List.for_all (fun (x, t) -> match (x, t) with 
             | (x, GhostTypeParam(y)) when x = y -> true
             | _ -> false) (zip2 tparams' p_targs)) &&
          p_ref#name = q_ref#name && List.for_all2 (fun (VarPat(_, x)) arg2 -> match arg2 with LitPat(WVar(_, y, _)) -> x = y | _ -> false) (p_args1 @ p_args2) (q_args1 @ q_args2) &&
@@ -2387,8 +2387,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       (Hashtbl.add auto_lemmas (p_ref#name) (None, tparams', List.map (fun (VarPat(_,x)) -> x) p_args1, List.map (fun (VarPat(_,x)) -> x) p_args2, pre, post))
   | (CoefAsn(loc, VarPat(_,f), WPredAsn(p_loc, p_ref, _, p_targs, p_args1, p_args2)), Sep(_, CoefAsn(_, LitPat(WVar(_, g, _)), WPredAsn(_, q_ref, true, q_targs, q_args1, q_args2)), conditions)) 
     when List.length ps = 0 && List.for_all (fun arg -> match arg with | VarPat(_,_) -> true | _ -> false) (p_args1 @ p_args2) && 
-         List.length p_targs = List.length tparams' && (List.for_all (fun (tp, t) -> 
-          match (tp, t) with 
+         List.length p_targs = List.length tparams' && (List.for_all (fun (tp, t) -> match (tp, t) with 
             | (x, GhostTypeParam(y)) when x = y -> true 
             | _ -> false) (zip2 tparams' p_targs)) &&
          p_ref#name = q_ref#name && List.for_all2 (fun (VarPat(_, x)) arg2 -> match arg2 with LitPat(WVar(_, y, _)) -> x = y | _ -> false) (p_args1 @ p_args2) (q_args1 @ q_args2) &&
@@ -2728,7 +2727,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             if fb = Instance then
             begin
               let ("this", thisTerm)::_ = env in
-              let ("this", ObjType (cn,_))::_ = ps in
+              let ("this", ObjType (cn, _))::_ = ps in
               (* CAVEAT: Remove this assumption once we allow subclassing. *)
               (* assume (ctxt#mk_eq (ctxt#mk_app get_class_symbol [thisTerm]) (List.assoc cn classterms)) $. fun () -> *)
               begin fun cont ->

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2132,7 +2132,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       verify_cont (pn,ilist) blocks_done lblenv tparams boxes true leminfo funcmap predinstmap sizemap tenv ghostenv h env epilog cont (fun _ _ -> assert false) econt
     end $. fun sizemap tenv ghostenv h env ->
     return_cont h tenv env retval
-  and 
+  and
     verify_block (pn,ilist) blocks_done lblenv tparams boxes pure leminfo funcmap predinstmap sizemap tenv ghostenv h env ss cont return_cont econt =
     let (decls, ss) =
       let rec iter decls ss =
@@ -2379,9 +2379,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       ctxt#assume_forall g trigger tps body
   | (WPredAsn(p_loc, p_ref, true, p_targs, p_args1, p_args2), Sep(_, WPredAsn(_, q_ref, true, q_targs, q_args1, q_args2), conditions))
     when List.length ps = 0 && List.for_all (fun arg -> match arg with | VarPat(_,_) -> true | _ -> false) (p_args1 @ p_args2) && 
-         List.length p_targs = List.length tparams' && (List.for_all (fun (x, t) -> match (x, t) with 
-            | (x, GhostTypeParam(y)) when x = y -> true
-            | _ -> false) (zip2 tparams' p_targs)) &&
+         List.length p_targs = List.length tparams' && (List.for_all (fun (tp, t) -> match (tp, t) with (x, GhostTypeParam(y)) when x = y -> true | _ -> false) (zip2 tparams' p_targs)) &&
          p_ref#name = q_ref#name && List.for_all2 (fun (VarPat(_, x)) arg2 -> match arg2 with LitPat(WVar(_, y, _)) -> x = y | _ -> false) (p_args1 @ p_args2) (q_args1 @ q_args2) &&
          List.for_all2 (fun ta1 ta2 -> ta1 = ta2) p_targs q_targs && is_pure_spatial_assertion conditions -> 
       (Hashtbl.add auto_lemmas (p_ref#name) (None, tparams', List.map (fun (VarPat(_,x)) -> x) p_args1, List.map (fun (VarPat(_,x)) -> x) p_args2, pre, post))

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2385,9 +2385,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       (Hashtbl.add auto_lemmas (p_ref#name) (None, tparams', List.map (fun (VarPat(_,x)) -> x) p_args1, List.map (fun (VarPat(_,x)) -> x) p_args2, pre, post))
   | (CoefAsn(loc, VarPat(_,f), WPredAsn(p_loc, p_ref, _, p_targs, p_args1, p_args2)), Sep(_, CoefAsn(_, LitPat(WVar(_, g, _)), WPredAsn(_, q_ref, true, q_targs, q_args1, q_args2)), conditions)) 
     when List.length ps = 0 && List.for_all (fun arg -> match arg with | VarPat(_,_) -> true | _ -> false) (p_args1 @ p_args2) && 
-         List.length p_targs = List.length tparams' && (List.for_all (fun (tp, t) -> match (tp, t) with 
-            | (x, GhostTypeParam(y)) when x = y -> true 
-            | _ -> false) (zip2 tparams' p_targs)) &&
+         List.length p_targs = List.length tparams' && (List.for_all (fun (tp, t) -> match (tp, t) with | (x, GhostTypeParam(y)) when x = y -> true | _ -> false) (zip2 tparams' p_targs)) &&
          p_ref#name = q_ref#name && List.for_all2 (fun (VarPat(_, x)) arg2 -> match arg2 with LitPat(WVar(_, y, _)) -> x = y | _ -> false) (p_args1 @ p_args2) (q_args1 @ q_args2) &&
          List.for_all2 (fun ta1 ta2 -> ta1 = ta2) p_targs q_targs && f = g && is_pure_spatial_assertion conditions->
       (Hashtbl.add auto_lemmas (p_ref#name) (Some(f), tparams', List.map (fun (VarPat(_,x)) -> x) p_args1, List.map (fun (VarPat(_,x)) -> x) p_args2, pre, post))

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2613,7 +2613,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let rec verify_cons (pn,ilist) cfin cn supercn superctors boxes lems cons =
     match cons with
       [] -> ()
-    | (sign, CtorInfo (lm, xmap, pre, pre_tenv, post, epost, terminates, ss, v, tparams))::rest ->
+    | (sign, CtorInfo (lm, xmap, pre, pre_tenv, post, epost, terminates, ss, v))::rest ->
       match ss with
         None ->
         let ((p, _, _), (_, _, _)) = root_caller_token lm in 
@@ -2657,12 +2657,12 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   None -> ([], [])
                 | Some(SuperConstructorCall(l, es)) -> 
                   inheritance_check cn l;
-                  ((List.map (fun e -> let (w, tp) = check_expr (pn,ilist) tparams tenv (Some true) e in tp) es), es)
+                  ((List.map (fun e -> let (w, tp) = check_expr (pn,ilist) [] tenv (Some true) e in tp) es), es)
                 in
                 match try_assoc argtypes superctors with
                   None ->
                   static_error lm "There is no superclass constructor that matches the superclass constructor call" None
-                | Some (CtorInfo (lc0, xmap0, pre0, pre_tenv0, post0, epost0, terminates0, ss0, v0, tparams0)) ->
+                | Some (CtorInfo (lc0, xmap0, pre0, pre_tenv0, post0, epost0, terminates0, ss0, v0)) ->
                   with_context (Executing (h, env, lm, "Implicit superclass constructor call")) $. fun () ->
                   if terminates && not terminates0 then static_error lm "Superclass constructor is not declared as 'terminates'" None;
                   let is_upcall =
@@ -2670,7 +2670,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                       Some (Some (_, rank0)) -> rank0 < rank
                     | _ -> true
                   in
-                  let eval_h h env e cont = verify_expr false (pn,ilist) tparams false leminfo funcmap sizemap tenv ghostenv h env None e cont econt in
+                  let eval_h h env e cont = verify_expr false (pn,ilist) [] false leminfo funcmap sizemap tenv ghostenv h env None e cont econt in
                   let pats = (List.map (fun e -> SrcPat (LitPat e)) args) in
                   verify_call funcmap eval_h lm (pn, ilist) None None [] pats ([], None, xmap0, ["this", this], pre0, post0, Some(epost0), terminates0, v0) false is_upcall (Some supercn) leminfo sizemap h [] tenv ghostenv env (fun h env _ ->
                   cont h) econt
@@ -2678,7 +2678,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let fds = get_fields (pn,ilist) cn lm in
             let rec iter h fds =
               match fds with
-                [] -> verify_cont (pn,ilist) [] [] tparams boxes in_pure_context leminfo funcmap predinstmap sizemap tenv ghostenv h env ss
+                [] -> verify_cont (pn,ilist) [] [] [] boxes in_pure_context leminfo funcmap predinstmap sizemap tenv ghostenv h env ss
                      (fun sizemap tenv ghostenv h env -> return_cont h tenv env None) return_cont econt
               | (f, {ft=t; fbinding=binding; finit=init})::fds ->
                 if binding = Instance then begin
@@ -2688,7 +2688,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                     iter h fds
                   | Some(e) -> 
                     with_context (Executing (h, [], expr_loc e, "Executing field initializer")) $. fun () ->
-                    verify_expr false (pn,ilist) tparams false leminfo funcmap sizemap [(current_class, ClassOrInterfaceName cn); ("this", ObjType (cn, [])); (current_thread_name, current_thread_type)] ghostenv h [("this", this); (current_thread_name, List.assoc current_thread_name env)] None e (fun h _ initial_value ->
+                    verify_expr false (pn,ilist) [] false leminfo funcmap sizemap [(current_class, ClassOrInterfaceName cn); ("this", ObjType (cn, [])); (current_thread_name, current_thread_type)] ghostenv h [("this", this); (current_thread_name, List.assoc current_thread_name env)] None e (fun h _ initial_value ->
                       assume_field h cn f t Real this initial_value real_unit $. fun h ->
                       iter h fds
                     ) (fun throwl h env2 exceptp excep -> assert_false h env2 throwl ("Field initializers throws exception.") None)
@@ -2706,7 +2706,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let rec verify_meths (pn,ilist) cfin cabstract boxes lems meths ctparams=
     match meths with
       [] -> ()
-    | ((g,sign), MethodInfo (l,gh, rt, ps,pre,pre_tenv,post,epost,pre_dyn,post_dyn,epost_dyn,terminates,sts,fb,v, _,abstract, mtparams))::meths ->
+    | ((g,sign), MethodInfo (l,gh, rt, ps,pre,pre_tenv,post,epost,pre_dyn,post_dyn,epost_dyn,terminates,sts,fb,v, _,abstract))::meths ->
       if abstract && not cabstract then static_error l "Abstract method can only appear in abstract class." None;
       match sts with
         None -> let ((p,_,_),(_,_,_))= root_caller_token l in 
@@ -2756,7 +2756,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             verify_exceptional_return (pn,ilist) throwl h ghostenv env exceptp excep epost
           in
           let cont sizemap tenv ghostenv h env = return_cont h tenv env None in
-          verify_block (pn, ilist) [] [] (ctparams@mtparams) boxes in_pure_context leminfo funcmap predinstmap sizemap tenv ghostenv h env ss cont return_cont econt
+          verify_block (pn, ilist) [] [] ctparams boxes in_pure_context leminfo funcmap predinstmap sizemap tenv ghostenv h env ss cont return_cont econt
         end
         end;
         verify_meths (pn, ilist) cfin cabstract boxes lems meths ctparams

--- a/src/verifast0.ml
+++ b/src/verifast0.ml
@@ -67,6 +67,7 @@ let rec string_of_type t =
   | RealType -> "real"
   | InductiveType (i, []) -> i
   | InductiveType (i, targs) -> i ^ "<" ^ String.concat ", " (List.map string_of_type targs) ^ ">"
+  | ObjType (l, []) -> "class " ^ l
   | ObjType (l, targs) -> "class " ^ l ^ "<" ^ String.concat ", " (List.map string_of_type targs) ^ ">"
   | StructType sn -> "struct " ^ sn
   | PtrType t -> string_of_type t ^ " *"

--- a/src/verifast0.ml
+++ b/src/verifast0.ml
@@ -96,8 +96,8 @@ let rec string_of_type t =
   | BoxIdType -> "box"
   | HandleIdType -> "handle"
   | AnyType -> "any"
-  | RealTypeParam x -> x
-  | GhostTypeParam x -> x ^ "'"
+  | RealTypeParam x -> if (String.capitalize_ascii x) = x then x else "<" ^ x ^ ">"
+  | GhostTypeParam x -> if (String.capitalize_ascii x) = x then "<" ^ x ^ ">" else x
   | InferredType (_, t) -> begin match !t with EqConstraint t -> string_of_type t | _ -> "?" end
   | ArrayType(t) -> (string_of_type t) ^ "[]"
   | StaticArrayType(t, s) -> (string_of_type t) ^ "[" ^ (string_of_int s) ^ "]" 

--- a/src/verifast0.ml
+++ b/src/verifast0.ml
@@ -67,7 +67,7 @@ let rec string_of_type t =
   | RealType -> "real"
   | InductiveType (i, []) -> i
   | InductiveType (i, targs) -> i ^ "<" ^ String.concat ", " (List.map string_of_type targs) ^ ">"
-  | ObjType l -> "class " ^ l
+  | ObjType (l, targs) -> "class " ^ l ^ "<" ^ String.concat ", " (List.map string_of_type targs) ^ ">"
   | StructType sn -> "struct " ^ sn
   | PtrType t -> string_of_type t ^ " *"
   | FuncType ft -> ft
@@ -96,7 +96,8 @@ let rec string_of_type t =
   | BoxIdType -> "box"
   | HandleIdType -> "handle"
   | AnyType -> "any"
-  | TypeParam x -> x
+  | RealTypeParam x -> x
+  | GhostTypeParam x -> x ^ "'"
   | InferredType (_, t) -> begin match !t with EqConstraint t -> string_of_type t | _ -> "?" end
   | ArrayType(t) -> (string_of_type t) ^ "[]"
   | StaticArrayType(t, s) -> (string_of_type t) ^ "[" ^ (string_of_int s) ^ "]" 

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -4322,20 +4322,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       begin match unfold_inferred_type t with
         ObjType (cn, targs) ->
         let check_call family pmap tparams =
-          let ptps = List.map snd pmap in
-          let tpenv = 
-            if (List.length targs > 0) then (if (List.length tparams) <> (List.length targs) 
-            then static_error l (Printf.sprintf "Wrong amount of type arguments provided. Expected: %s Actual %s." (string_of_int (List.length tparams)) (string_of_int (List.length targs))) None
-            else List.map2 (fun a b -> (a, b)) tparams targs) else [] in
-          (* We know both type params and type arguments here, if possible fill them in *)
-          let rec replaceTypeParams t = match t with 
-            GhostTypeParam t -> (try List.assoc t tpenv with _ -> GhostTypeParam t)
-            | ObjType (s,ts) -> ObjType (s, List.map replaceTypeParams ts)
-            | InductiveType (s,ts) -> InductiveType (s, List.map replaceTypeParams ts)
-            | PredType (s,ts,o,i) -> PredType (s, List.map replaceTypeParams ts, o, i)
-            | PureFuncType (a,b) -> PureFuncType (replaceTypeParams a, replaceTypeParams b)
-            | t -> t  in
-          let (wpats, tenv) = check_pats (pn,ilist) l tparams tenv (List.map replaceTypeParams ptps) pats in
+          let (wpats, tenv) = check_pats (pn,ilist) l tparams tenv (List.map snd pmap) pats in
           let index = check_expr_t (pn,ilist) tparams tenv (Some true) index (ObjType ("java.lang.Class", [])) in
           (WInstPredAsn (l, Some w, cn, get_class_finality cn, family, g, index, wpats), tenv, [])
         in

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -8,8 +8,6 @@ open Lexer
 open Parser
 open Verifast0
 open Ast
-open SExpressions
-open SExpressionEmitter
 
 type callbacks = {
   reportRange: range_kind -> loc0 -> unit;

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -3358,23 +3358,17 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         in
         try_qualified_call tn es args fb obj_type_arguments (fun () -> static_error l "No such method" None)
       end
-    | NewObject (l, cn, args) ->
+    | NewObject (l, cn, args, targs) ->
       begin match resolve Real (pn,ilist) l cn classmap with
         Some (cn, {cabstract}) ->
         if cabstract then
           static_error l "Cannot create instance of abstract class." None
         else
-          (NewObject (l, cn, args), ObjType (cn,[]), None)
-      | None -> static_error l "No such class" None
-      end
-    | NewGenericObject (l, cn, args, targs) ->
-      begin match resolve Real (pn,ilist) l cn classmap with
-        Some (cn, {cabstract}) ->
-        if cabstract then
-          static_error l "Cannot create instance of abstract class." None
-        else 
-           let targestps = List.map (fun targ -> check_pure_type (pn,ilist) tparams targ Real) targs in
-          (NewGenericObject (l, cn, args, targs), ObjType (cn,targestps), None)
+          let targestps = match targs with
+            Some(targs) -> List.map (fun targ -> check_pure_type (pn,ilist) tparams targ Real) targs
+            | None -> []
+          in
+          (NewObject (l, cn, args, targs), ObjType (cn,targestps), None)
       | None -> static_error l "No such class" None
       end
     | ReadArray(l, arr, index) ->

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -1400,13 +1400,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         InductiveType (s, [])
       | None ->
       match (search2' Real id (pn, ilist) classmap1 classmap0) with
-        Some s -> begin match List.assoc s class_arities with
-          Some (_, (_,n)) -> ObjType(s, create_objects n)
+        Some s -> begin try (match List.assoc s class_arities with (_,n) -> ObjType(s, create_objects n)) with
         | Not_found -> failwith (id ^ "is present in the classmap, but has no arity?")
         end
       | None ->  match (search2' Real id (pn, ilist) interfmap1 interfmap0) with
-        Some s -> begin List.assoc s class_arities with
-          Some (_, (_,n)) -> ObjType(s, create_objects n)
+        Some s -> begin try (match List.assoc s class_arities with (_,n) -> ObjType(s, create_objects n)) with
           | Not_found -> failwith (id ^ "is present in the interfmap, but has no arity?")
         end
       | None ->

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -513,7 +513,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 | Some _ -> false
       end in
       iter (pn,ilist) (Class(l, abstract, fin, cn, meths', fds, cons', super, tparams, inames, [])::classes) lemmas rest
-    | Func(l, Lemma(_), tparams, rt, fn, arglist, nonghost_callers_only, ftype, contract, terminates, None, fb, vis) as elem ::rest->
+    | Func(l,Lemma(_),tparams,rt,fn,arglist,nonghost_callers_only,ftype,contract,terminates,None,fb,vis) as elem ::rest->
       iter (pn, ilist) classes (elem::lemmas) rest
     | _::rest -> 
       iter (pn, ilist) classes lemmas rest

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -252,7 +252,6 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let cell = ref 0 in
       Hashtbl.add used_ids s cell;
       cell
-
   (** Generate a fresh ID based on string [s]. *)
   let mk_ident s =
     let count_cell = get_ident_use_count_cell s in
@@ -332,7 +331,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | RealType -> ProverReal
     | InductiveType _ -> ProverInductive
     | StructType sn -> ProverInductive
-    | ObjType (n,_) -> ProverInt
+    | ObjType (n, _) -> ProverInt
     | ArrayType t -> ProverInt
     | StaticArrayType (t, s) -> ProverInt
     | PtrType t -> ProverInt
@@ -512,8 +511,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 | None -> true
                 | Some _ -> false
       end in
-      iter (pn,ilist) (Class(l,abstract,fin,cn,meths',fds,cons',super, tparams,inames,[])::classes) lemmas rest
-    | Func(l,Lemma(_),tparams,rt,fn,arglist,nonghost_callers_only,ftype,contract,terminates,None,fb,vis) as elem ::rest->
+      iter (pn,ilist) (Class(l, abstract, fin, cn, meths', fds, cons', super, tparams, inames, [])::classes) lemmas rest
+    | Func(l, Lemma(_), tparams, rt, fn, arglist, nonghost_callers_only, ftype, contract, terminates, None, fb, vis) as elem ::rest->
       iter (pn, ilist) classes (elem::lemmas) rest
     | _::rest -> 
       iter (pn, ilist) classes lemmas rest
@@ -1141,7 +1140,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | (Inductive (l, i, tparams, ctors))::ds -> let n=full_name pn i in
         if n = "bool" || n = "boolean" || n = "int" || List.mem_assoc n idm || List.mem_assoc n inductivemap0 then
           static_error l "Duplicate datatype name." None
-        else 
+        else
           iter pn ((n, (l, tparams, ctors))::idm) ds
       | _::ds -> iter pn idm ds
     in
@@ -1277,8 +1276,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let rec check_interfs ls=
                   match ls with
                     [] -> []
-                  | (n,targs)::ls -> match search2' Real n (pn,ilist) ifdm interfmap0 with 
-                              Some i -> (i,targs)::check_interfs ls
+                  | (n, targs)::ls -> match search2' Real n (pn, ilist) ifdm interfmap0 with 
+                              Some i -> (i, targs)::check_interfs ls
                             | None -> raise Not_found
                 in
                 check_interfs interfs
@@ -1287,7 +1286,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             with Not_found ->
               iter (ifdm, classlist) rest ((List.hd ds)::todo)
           end
-      | (pn, ilist, Class (l, abstract, fin, i, meths,fields,constr,(super,supertargs), tparams,interfs,preds))::rest ->
+      | (pn, ilist, Class (l, abstract, fin, i, meths, fields, constr, (super, supertargs), tparams, interfs, preds))::rest ->
         let i= full_name pn i in
         if List.mem_assoc i ifdm then
           static_error l ("There exists already an interface with this name: "^i) None
@@ -1301,8 +1300,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let rec check_interfs ls=
                     match ls with
                       [] -> []
-                    | (n,targs)::ls -> match search2' Real n (pn,ilist) ifdm interfmap0 with 
-                                Some i -> (i,targs)::check_interfs ls
+                    | (n, targs)::ls -> match search2' Real n (pn, ilist) ifdm interfmap0 with 
+                                Some i -> (i, targs)::check_interfs ls
                               | None -> raise Not_found
                 in
                 check_interfs interfs
@@ -1314,7 +1313,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   None-> raise Not_found
                 | Some super -> super
               in
-              iter (ifdm, (i, (l,abstract,fin,meths,fields,constr,(super,supertargs),tparams,interfs,preds,pn,ilist))::classlist) rest todo
+              iter (ifdm, (i, (l, abstract, fin, meths, fields, constr, (super, supertargs), tparams, interfs, preds, pn, ilist))::classlist) rest todo
             with Not_found ->
               iter (ifdm, classlist) rest ((List.hd ds)::todo)
           end
@@ -1328,7 +1327,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec check_interfs kind i ls (pn,ilist) =
               match ls with
                 [] -> kind ^ " " ^ i ^ " is part of an inheritance cycle"
-              | (i,tparams)::ls -> match search2' Real i (pn,ilist) ifdm interfmap0 with 
+              | (i, targs)::ls -> match search2' Real i (pn,ilist) ifdm interfmap0 with 
                           Some i -> check_interfs kind i ls (pn,ilist)
                         | None -> "Interface " ^ i ^ " not found"
             in
@@ -1336,14 +1335,14 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               match ds_rest with
               | (pn, ilist, (Interface (l, i, interfs, fields, meths, pred_specs, tparams)))::_ ->
                   (l, check_interfs "Interface" i interfs (pn,ilist))
-              | (pn, ilist, (Class (l, abstract, fin, i, meths,fields,constr,(super,passedTparams), tparams,interfs,preds)))::_ ->
-                  match search2' Real super (pn,ilist) classlist classmap0 with
+              | (pn, ilist, (Class (l, abstract, fin, i, meths, fields, constr, (super, super_targs), tparams, interfs, preds)))::_ ->
+                  match search2' Real super (pn, ilist) classlist classmap0 with
                     None-> 
                       if i = "java.lang.Object" || super = "java.lang.Object" then 
                         (l, check_interfs "Class" i interfs (pn,ilist))
                       else
                         (l, "Class " ^ super ^ " not found")
-                  | Some super -> (l, check_interfs "Class" i interfs (pn,ilist));
+                  | Some super -> (l, check_interfs "Class" i interfs (pn, ilist));
             in
             static_error l message None
           else
@@ -1365,14 +1364,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let abstract_types_map = abstract_types_map1 @ abstract_types_map0
   
-  let classmap_arities =
+  let class_arities =
     List.map (fun (cn, (l, _, _, _, _, _, _, tparams, _, _, _, _)) -> (cn, (l, List.length tparams))) classmap1
     @ List.map (fun (cn, {cl=l; ctpenv=tparams}) -> (cn, (l, List.length tparams))) classmap0
-
-  let interfmap_arities =
-    List.map (fun (cn, (l, _, _, _, _, _, _, tparams)) -> (cn, (l, List.length tparams))) interfmap1
+    @ List.map (fun (cn, (l, _, _, _, _, _, _, tparams)) -> (cn, (l, List.length tparams))) interfmap1
     @ List.map (fun (cn, InterfaceInfo (l, _, _, _, _, tparams)) -> (cn, (l, List.length tparams))) interfmap0
-    
 
   (* Region: check_pure_type: checks validity of type expressions *)
   let check_pure_type_core typedefmap1 (pn,ilist) tpenv te envType =
@@ -1397,27 +1393,27 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match try_assoc2 id typedefmap0 typedefmap1 with
         Some t -> t
       | None ->
-      match resolve Ghost (pn,ilist) l id inductive_arities with
+      match resolve Ghost (pn, ilist) l id inductive_arities with
         Some (s, (ld, n)) ->
         if n > 0 then static_error l "Missing type arguments." None;
         reportUseSite DeclKind_InductiveType ld l;
         InductiveType (s, [])
       | None ->
-      match (search2' Real id (pn,ilist) classmap1 classmap0) with
-        Some s -> begin match resolve Real (pn,ilist) l id classmap_arities with
+      match (search2' Real id (pn, ilist) classmap1 classmap0) with
+        Some s -> begin match List.assoc s class_arities with
           Some (_, (_,n)) -> ObjType(s, create_objects n)
-        | None -> failwith (id ^ "is present in the classmap, but has no arity?")
+        | Not_found -> failwith (id ^ "is present in the classmap, but has no arity?")
         end
-      | None ->  match (search2' Real id (pn,ilist) interfmap1 interfmap0) with
-        Some s -> begin match resolve Real (pn,ilist) l id interfmap_arities with
+      | None ->  match (search2' Real id (pn, ilist) interfmap1 interfmap0) with
+        Some s -> begin List.assoc s class_arities with
           Some (_, (_,n)) -> ObjType(s, create_objects n)
-          | None -> failwith (id ^ "is present in the interfmap, but has no arity?")
+          | Not_found -> failwith (id ^ "is present in the interfmap, but has no arity?")
         end
       | None ->
       if List.mem_assoc id functypenames || List.mem_assoc id functypemap0 then
         FuncType id
       else
-      match resolve Ghost (pn,ilist) l id abstract_types_map with
+      match resolve Ghost (pn, ilist) l id abstract_types_map with
         Some (n, l) ->
         AbstractType n
       | None ->
@@ -1426,37 +1422,31 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | IdentTypeExpr (l, Some(pac), id) ->
       let full_name = pac ^ "." ^ id in
       begin
-      if List.mem id tpenv 
-        then begin match envType with
-          Ghost -> GhostTypeParam (id)
-          | Real -> RealTypeParam (id)
-        end
-      else
-      match resolve Real (pac,ilist) l id classmap_arities with
-        Some (_, (_,n)) -> ObjType(full_name, create_objects n)
-      | None -> match resolve Real (pac,ilist) l id interfmap_arities with
-        Some (_, (_,n)) -> ObjType(full_name, create_objects n)
+      match resolve Real (pac,ilist) l id class_arities with
+        Some (_, (_, n)) -> ObjType(full_name, create_objects n)
+      | None -> match resolve Real (pac,ilist) l id class_arities with
+        Some (_, (_, n)) -> ObjType(full_name, create_objects n)
       | None -> static_error l ("No such type parameter, inductive datatype, class, interface, or function type: " ^ full_name) None
       end
     | ConstructedTypeExpr (l, id, targs) ->
       begin
-          match resolve Ghost (pn,ilist) l id inductive_arities with
+      match resolve Ghost (pn,ilist) l id inductive_arities with
+        Some (id, (ld, n)) ->
+          if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
+          reportUseSite DeclKind_InductiveType ld l;
+          InductiveType (id, List.map check targs)
+        | None -> match resolve Real (pn,ilist) l id class_arities with
           Some (id, (ld, n)) ->
-            if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
-            reportUseSite DeclKind_InductiveType ld l;
-            InductiveType (id, List.map check targs)
-          | None -> match resolve Real (pn,ilist) l id interfmap_arities with
+          if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
+          ObjType (id, List.map check targs)
+        | None -> 
+          begin
+          match resolve Real (pn,ilist) l id class_arities with
             Some (id, (ld, n)) ->
-              if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
-              ObjType (id, List.map check targs)
-            | None -> 
-              begin
-              match resolve Real (pn,ilist) l id classmap_arities with
-                Some (id, (ld, n)) ->
-                if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
-                ObjType (id, List.map check targs)
-              | None -> static_error l ("No such Ghost inductive or Real parameterised datatype. " ^ pn ^ "." ^ id) None
-              end
+            if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
+            ObjType (id, List.map check targs)
+          | None -> static_error l ("No such inductive type, class, or interface.") None
+          end
       end
     | StructTypeExpr (l, sn, Some _) ->
       static_error l "A struct type with a body is not supported in this position." None
@@ -1496,20 +1486,20 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let typedefmap = typedefmap1 @ typedefmap0
   
-  (* envtype indicates if we are type checking in a ghost or real environment *)
-  let check_pure_type (pn,ilist) tpenv te envType = check_pure_type_core typedefmap (pn,ilist) tpenv te envType
+  (* envType indicates if we are type checking in a ghost or real environment *)
+  let check_pure_type (pn,ilist) tpenv te envType = check_pure_type_core typedefmap (pn,ilist) tpenv envType te
   
   let classmap1 =
     List.map
-      begin fun (sn, (l,abstract,fin,meths,fds,constr,(super,supertargs),tparams, interfs,preds,pn,ilist)) ->
-        let supertargs = List.map (fun te -> check_pure_type (pn,ilist) tparams te Real) supertargs in
-        let interfs = List.map (fun (i,tes) -> (i,List.map (fun te -> check_pure_type (pn,ilist) tparams te Real) tes)) interfs in
+      begin fun (sn, (l, abstract, fin, meths, fds, constr, (super, supertargs), tparams, interfs, preds, pn, ilist)) ->
+        let supertargs = List.map (check_pure_type (pn,ilist) tparams Real) supertargs in
+        let interfs = List.map (fun (i,tes) -> (i,List.map (check_pure_type (pn,ilist) tparams Real) tes)) interfs in
         let rec iter fmap fds =
           match fds with
-            [] -> (sn, (l,abstract,fin,meths, List.rev fmap,constr,(super,supertargs),tparams, interfs,preds,pn,ilist))
+            [] -> (sn, (l, abstract, fin, meths, List.rev fmap, constr, (super, supertargs), tparams, interfs, preds, pn, ilist))
           | Field (fl, fgh, t, f, fbinding, fvis, ffinal, finit)::fds ->
             if List.mem_assoc f fmap then static_error fl "Duplicate field name." None;
-            iter ((f, {fl; fgh; ft=check_pure_type (pn,ilist) tparams t Real; fvis; fbinding; ffinal; finit; fvalue=ref None})::fmap) fds
+            iter ((f, {fl; fgh; ft=check_pure_type (pn,ilist) tparams Real t; fvis; fbinding; ffinal; finit; fvalue=ref None})::fmap) fds
         in
         iter [] fds
       end
@@ -1519,7 +1509,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     if tpenv = [] then t else
     match t with
       RealTypeParam x | GhostTypeParam x -> (try List.assoc x tpenv  with _ -> failwith 
-        (Printf.sprintf "not found! looking for %s in env %s" x (String.concat ", " (List.map (fun (a,b) -> a ^ "->" ^(string_of_type b)) tpenv))))
+        (Printf.sprintf "not found! looking for %s in env %s" x (String.concat ", " (List.map (fun (a,b) -> a ^ "->" ^ (string_of_type b)) tpenv))))
     | PtrType t -> PtrType (instantiate_type tpenv t)
     | InductiveType (i, targs) -> InductiveType (i, List.map (instantiate_type tpenv) targs)
     | PredType ([], pts, inputParamCount, inductiveness) -> PredType ([], List.map (instantiate_type tpenv) pts, inputParamCount, inductiveness)
@@ -1578,7 +1568,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
              (sn, (l, Some fmap, padding_predsym_opt, s))
            | Field (lf, gh, t, f, Instance, Public, final, init)::fds ->
              if List.mem_assoc f fmap then static_error lf "Duplicate field name." None;
-             let t = check_pure_type ("", []) [] t gh in
+             let t = check_pure_type ("", []) [] gh t in
              let offset = if gh = Ghost then None else Some (get_unique_var_symb (sn ^ "_" ^ f ^ "_offset") intType) in
              let entry = (f, (lf, gh, t, offset)) in
              iter (entry::fmap) fds (has_ghost_fields || gh = Ghost)
@@ -1618,32 +1608,32 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | _ -> []
     ) functypenames
   
-  let rec is_subtype_of x y = 
+  let rec is_subtype_of x y =
     x = y ||
     y = "java.lang.Object" ||
     match try_assoc x classmap1 with
-      Some (_, _, _, _, _, _, (super, _),_, interfaces, _, _, _) ->
-      is_subtype_of super y || List.exists (fun (itf,_) -> is_subtype_of itf y) interfaces
+      Some (_, _, _, _, _, _, (super, _), _, interfaces, _, _, _) ->
+      is_subtype_of super y || List.exists (fun (itf, _) -> is_subtype_of itf y) interfaces
     | None ->
       match try_assoc x classmap0 with
         Some {csuper=(super, _); cinterfs=interfaces} ->
-        is_subtype_of super y || List.exists (fun (itf,_) -> is_subtype_of itf y) interfaces
+        is_subtype_of super y || List.exists (fun (itf, _) -> is_subtype_of itf y) interfaces
       | None -> begin match try_assoc x interfmap1 with
-          Some (_, _, _, _, interfaces, _, _, _) -> List.exists (fun (itf,_)   -> is_subtype_of itf y) interfaces
+          Some (_, _, _, _, interfaces, _, _, _) -> List.exists (fun (itf, _) -> is_subtype_of itf y) interfaces
         | None -> begin match try_assoc x interfmap0 with
-            Some (InterfaceInfo (_, _, _, _, interfaces, tparams)) -> List.exists (fun (itf,_) -> is_subtype_of itf y) interfaces
+            Some (InterfaceInfo (_, _, _, _, interfaces, tparams)) -> List.exists (fun (itf, _) -> is_subtype_of itf y) interfaces
           | None -> false 
           end
         end
   
   let is_subtype_of_ x y =
     match (x, y) with
-      (ObjType (x,_), ObjType (y,_)) -> is_subtype_of x y
+      (ObjType (x, _), ObjType (y, _)) -> is_subtype_of x y
     | _ -> false
   
   let is_unchecked_exception_type tp = 
     match tp with
-     ObjType (cn,_) -> (is_subtype_of cn "java.lang.RuntimeException") || (is_subtype_of cn "java.lang.Error")
+     ObjType (cn, _) -> (is_subtype_of cn "java.lang.RuntimeException") || (is_subtype_of cn "java.lang.Error")
     | _ -> false
 
   (* Region: globaldeclmap *)
@@ -1662,7 +1652,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           match try_assoc x gdm with
             Some (_) -> static_error l "Duplicate global variable name." None
           | None -> 
-            let tp = check_pure_type ("",[]) [] te Real in
+            let tp = check_pure_type ("", []) [] Real te in
             let global_symb = get_unique_var_symb x (PtrType tp) in
             iter ((x, (l, tp, global_symb, ref init)) :: gdm) ds
         end
@@ -1731,18 +1721,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match tparams with
         [] -> ()
       | x::xs ->
-        if List.mem x tparams0 then static_error l (Printf.sprintf "Type parameter '%s' hides existing type parameter '%s'." x x) None; iter xs
-    in
-    iter tparams
-
-  let check_tparams_m l tparams0 tparams =
-    let rec iter tparams =
-      match tparams with
-        [] -> ()
-      | (x,gh)::xs ->
-        if List.mem (x,gh) tparams0 then static_error l (Printf.sprintf "Type parameter '%s' hides existing type parameter '%s'." x x) None;
-        if List.mem (x,gh) xs then static_error l (Printf.sprintf "Duplicate type parameter '%s'." x) None;
-        iter xs
+        if List.mem x tparams0 then static_error l (Printf.sprintf "Type parameter '%s' hides existing type parameter '%s'." x x) None; iter xs;
+        if List.mem x xs then static_error l (Printf.sprintf "Duplicate type parameter '%s'." x) None
     in
     iter tparams
   
@@ -1761,7 +1741,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             if List.mem_assoc full_cn pfm || List.mem_assoc full_cn purefuncmap0 then
               static_error lc ("Duplicate pure function name: " ^ full_cn) None
             else begin
-              let ts = List.map (fun arg -> check_pure_type (pn,ilist) tparams arg Ghost) argument_type_expressions in
+              let ts = List.map (check_pure_type (pn,ilist) tparams Ghost) argument_type_expressions in
               let csym =
                 mk_func_symbol full_cn (List.map provertype_of_type ts) ProverInductive (Proverapi.Ctor (CtorByOrdinal j))
               in
@@ -1777,7 +1757,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let rt =
           match rto with
             None -> static_error l "Return type of fixpoint functions cannot be void." None
-          | Some rt -> (check_pure_type (pn,ilist) tparams rt Ghost)
+          | Some rt -> (check_pure_type (pn,ilist) tparams Ghost rt)
         in
         if nonghost_callers_only then static_error l "A fixpoint function cannot be marked nonghost_callers_only." None;
         if functype <> None then static_error l "Fixpoint functions cannot implement a function type." None;
@@ -1789,7 +1769,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               [] -> List.rev pmap
             | (te, p)::ps ->
               let _ = if List.mem_assoc p pmap then static_error l "Duplicate parameter name." None in
-              let t = check_pure_type (pn,ilist) tparams te Ghost in
+              let t = check_pure_type (pn,ilist) tparams Ghost te in
               iter ((p, t)::pmap) ps
           in
           iter [] ps
@@ -1892,7 +1872,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             match pt with
             | Bool | Void | Int (_, _) | RealType | PtrType _ | ObjType _ | ArrayType _ | BoxIdType | HandleIdType | AbstractType _ -> ()
             | AnyType -> ec_contains_any ptr negative
-            | GhostTypeParam _ | RealTypeParam _ -> if negative then static_error l "A type parameter may not appear in a negative position in an inductive datatype definition." None
+            | GhostTypeParam _ -> if negative then static_error l "A type parameter may not appear in a negative position in an inductive datatype definition." None
             | InductiveType (i0, tps) ->
               List.iter (fun t -> check_type negative t) tps;
               begin match try_assoc i0 welldefined_map with
@@ -1954,7 +1934,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec type_is_inhabited tp =
               match tp with
                 Bool | Int (_, _) | RealType | PtrType _ | ObjType _ | ArrayType _ | BoxIdType | HandleIdType | AnyType -> true
-              | GhostTypeParam _ | RealTypeParam _ -> true  (* Should be checked at instantiation site. *)
+              | GhostTypeParam _ -> true  (* Should be checked at instantiation site. *)
               | PredType (tps, pts, _, _) -> true
               | PureFuncType (t1, t2) -> type_is_inhabited t2
               | InductiveType (i0, tps) ->
@@ -2018,7 +1998,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   None -> None
                 | Some cond ->
                   let Some tpenv = zip tparams targs in
-                  fold_cond [] (fun x -> type_is_infinite  (List.assoc x tpenv)) cond
+                  fold_cond [] (fun x -> type_is_infinite (List.assoc x tpenv)) cond
                 end
               end
           in
@@ -2038,9 +2018,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         (i, (l, tparams, ctors, cond, containsAny))
       end
   
-  let inductivemap = 
-    inductivemap1 @ 
-    inductivemap0
+  let inductivemap = inductivemap1 @ inductivemap0
 
   let rec unfold_inferred_type t =
     match t with
@@ -2102,36 +2080,32 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let rec expect_type_core l msg (inAnnotation: bool option) t t0 =
     match (unfold_inferred_type t, unfold_inferred_type t0) with
-      (ObjType ("null",[]), ObjType _) -> ()
-    | (ObjType ("null",[]), RealTypeParam _) -> ()
-    | (RealTypeParam t, ObjType("java.lang.Object", [])) -> ()
-    | (GhostTypeParam t, ObjType("java.lang.Object", [])) -> ()
-    | (RealTypeParam t, ObjType _) -> ()
-    | (RealTypeParam t, RealTypeParam t0) -> ()
-    | (ObjType("java.lang.Object", []), RealTypeParam t) -> ()
-    | (ObjType ("null",[]), ArrayType _) -> ()
-    | (ArrayType _, ObjType ("java.lang.Object",[])) -> ()
+      (ObjType ("null", []), ObjType _) -> ()
+    | (ObjType ("null", []), RealTypeParam _) -> ()
+    | (ObjType(_, []), RealTypeParam t) -> ()
+    | (ObjType ("null", []), ArrayType _) -> ()
+    | (ArrayType _, ObjType ("java.lang.Object", [])) -> ()
     (* Note that in Java short[] is not assignable to int[] *)
     | (ArrayType et, ArrayType et0) when et = et0 -> ()
-    | (ArrayType (ObjType(t0,ts0)), ArrayType (ObjType(t1,ts1))) -> expect_type_core l msg None (ObjType (t0,ts0)) (ObjType(t1,ts1))
+    | (ArrayType (ObjType(t0, ts0)), ArrayType (ObjType(t1, ts1))) -> expect_type_core l msg None (ObjType (t0, ts0)) (ObjType(t1, ts1))
     | (StaticArrayType _, PtrType _) -> ()
     | (Int (Signed, m), Int (Signed, n)) when m <= n -> ()
     | (Int (Unsigned, m), Int (Unsigned, n)) when m <= n -> ()
     | (Int (Unsigned, m), Int (Signed, n)) when m < n -> ()
     | (Int (_, _), Int (_, _)) when inAnnotation = Some true -> ()
-    | (ObjType (x,_), ObjType (y,_)) when is_subtype_of x y -> ()
+    | (ObjType (x, _), ObjType (y, _)) when is_subtype_of x y -> ()
     | (PredType ([], ts, inputParamCount, inductiveness), PredType ([], ts0, inputParamCount0, inductiveness0)) ->
       begin
         match zip ts ts0 with
           Some tpairs when List.for_all (fun (t, t0) -> unify t t0) tpairs && (inputParamCount0 = None || inputParamCount = inputParamCount0) -> ()
-        | _ -> static_error l (msg ^ "Type mismatch for predicate. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
+        | _ -> static_error l (msg ^ "Predicate type mismatch. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
       end
     | (PureFuncType (t1, t2), PureFuncType (t10, t20)) -> expect_type_core l msg inAnnotation t10 t1; expect_type_core l msg inAnnotation t2 t20
     | (InductiveType (_, _) as tp, AnyType) -> if not (type_satisfies_contains_any_constraint true tp) then static_error l (msg ^ "Cannot cast type " ^ string_of_type tp ^ " to 'any' because it contains 'any' in a negative position.") None
     | (InductiveType (i1, args1), InductiveType (i2, args2)) when i1 = i2 ->
       List.iter2 (expect_type_core l msg inAnnotation) args1 args2
     | _ -> if unify t t0 then ()
-        else if string_of_type t = "int8[]" && string_of_type t0 = "class Object<>" then failwith "type mismatch" else static_error l (msg ^ "Type mismatch. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
+        else static_error l (msg ^ "Type mismatch. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
   
   let expect_type l (inAnnotation: bool option) t t0 = expect_type_core l "" inAnnotation t t0
   
@@ -2144,10 +2118,10 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     if proverType = proverType0 then e else ProverTypeConversion (proverType, proverType0, e)
   
   let box e t t0 =
-    match unfold_inferred_type t0 with GhostTypeParam _ | RealTypeParam _ -> convert_provertype_expr e (provertype_of_type t) ProverInductive | _ -> e
+    match unfold_inferred_type t0 with GhostTypeParam _ -> convert_provertype_expr e (provertype_of_type t) ProverInductive | _ -> e
   
   let unbox e t0 t =
-    match unfold_inferred_type t0 with GhostTypeParam _ | RealTypeParam _ -> convert_provertype_expr e ProverInductive (provertype_of_type t) | _ -> e
+    match unfold_inferred_type t0 with GhostTypeParam _ -> convert_provertype_expr e ProverInductive (provertype_of_type t) | _ -> e
 
   (* A universal type is one that is isomorphic to the universe for purposes of type erasure *)
   let rec is_universal_type tp =
@@ -2178,14 +2152,14 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         in
         check_tparams_distinct tparams;
         (* The return type cannot mention type parameters. *)
-        let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) [] rt Ghost) in
+        let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) [] Ghost rt) in
         let ftxmap =
           let rec iter xm xs =
             match xs with
               [] -> List.rev xm
             | (te, x)::xs ->
               if List.mem_assoc x xm then static_error l "Duplicate function type parameter name." None;
-              let t = check_pure_type (pn,ilist) tparams te Ghost in
+              let t = check_pure_type (pn,ilist) tparams Ghost te in
               iter ((x, t)::xm) xs
           in
           iter [] ftxs
@@ -2196,7 +2170,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               [] -> List.rev xm
             | (te, x)::xs ->
               if List.mem_assoc x xm || List.mem_assoc x ftxmap then static_error l "Duplicate parameter name." None;
-              let t = check_pure_type (pn,ilist) tparams te Ghost in
+              let t = check_pure_type (pn,ilist) tparams Ghost te in
               iter ((x, t)::xm) xs
           in
           iter [] xs
@@ -2282,13 +2256,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let rec iter (pn,ilist) pm ds =
       match ds with
         PredFamilyDecl (l, p, tparams, arity, tes, inputParamCount, inductiveness)::ds -> let p=full_name pn p in
-        let ts = List.map (fun te -> check_pure_type (pn,ilist) tparams te Ghost) tes in
+        let ts = List.map (check_pure_type (pn,ilist) tparams Ghost) tes in
         begin
           match try_assoc2' Ghost (pn,ilist) p pm predfammap0 with
             Some (l0, tparams0, arity0, ts0, symb0, inputParamCount0, inductiveness0) ->
             let tpenv =
-              match zip tparams0 
-                (List.map (fun tparam -> GhostTypeParam (tparam)) tparams) with
+              match zip tparams0 (List.map (fun tparam -> GhostTypeParam (tparam)) tparams) with
                 None -> static_error l "Predicate family redeclarations declares a different number of type parameters." None
               | Some bs -> bs
             in
@@ -2325,7 +2298,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               if List.mem_assoc x pmap then static_error l "Duplicate parameter name." None;
               if startswith x "old_" then static_error l "Box parameter name cannot start with old_." None;
                if x = "this" then static_error l "Box parameter may not be named \"this\"." None;
-              iter ((x, check_pure_type (pn,ilist) [] te Ghost)::pmap) ps
+              iter ((x, check_pure_type (pn,ilist) [] Ghost te)::pmap) ps
           in
           iter [] ps
         in
@@ -2347,7 +2320,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                     if List.mem_assoc x pmap then static_error l "Duplicate action parameter name." None;
                     if startswith x "old_" then static_error l "Action parameter name cannot start with old_." None;
                     if x = "this" then static_error l "Action parameter may not be named \"this\"." None;
-                    iter ((x, check_pure_type (pn,ilist) [] te Ghost)::pmap) ps
+                    iter ((x, check_pure_type (pn,ilist) [] Ghost te)::pmap) ps
                 in
                 iter [] ps
               in
@@ -2405,7 +2378,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                     if List.mem_assoc x pmap then static_error l "Duplicate handle predicate parameter name." None;
                     if startswith x "old_" then static_error l "Handle predicate parameter name cannot start with old_." None;
                     if x = "this" then static_error l "Handle predicate parameter may not be named \"this\"." None;
-                    iter ((x, check_pure_type (pn,ilist) [] te Ghost)::pmap) ps
+                    iter ((x, check_pure_type (pn,ilist) [] Ghost te)::pmap) ps
                 in
                 iter [] ps
               in
@@ -2442,7 +2415,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match interfmap1_todo with
         [] -> List.rev interfmap1_done
       | (tn, (li, fields, methods, preds, interfs, pn, ilist, tparams))::interfmap1_todo ->
-        let interfs = List.map (fun (i,tes) -> (i,List.map (fun te -> check_pure_type (pn,ilist) tparams te Real) tes)) interfs in
+        let interfs = List.map (fun (i, tes) -> (i, List.map (check_pure_type (pn,ilist) tparams Real) tes)) interfs in
         let rec iter_preds predmap preds =
           match preds with
             [] -> iter_interfs ((tn, (li, fields, methods, List.rev predmap, interfs, pn, ilist, tparams))::interfmap1_done) interfmap1_todo
@@ -2454,7 +2427,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   [] -> List.rev pmap
                 | (tp, x)::ps ->
                   if List.mem_assoc x pmap then static_error l "Duplicate parameter name." None;
-                  let tp = check_pure_type (pn,ilist) tparams tp Real in
+                  let tp = check_pure_type (pn,ilist) tparams Real tp in
                   iter ((x, tp)::pmap) ps
               in
               iter [] ps
@@ -2465,7 +2438,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   begin match try_assoc tn itfmap with
                     Some info ->
                     let (preds, itfs) = get_preds_and_itfs info in
-                    let itfnames = List.map (fun (f,_) -> f) itfs in
+                    let itfnames = List.map fst itfs in
                     begin match try_assoc g preds with
                       Some (l, pmap, family, symb) -> [(family, pmap, symb)]
                     | None -> flatmap preds_in_itf itfnames
@@ -2477,7 +2450,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 check_itfmap (function InterfaceInfo (li, fields, methods, preds, interfs, tparams) -> (preds, interfs)) interfmap0 $. fun () ->
                 []
               in
-              match flatmap preds_in_itf (List.map (fun (f,_) -> f ) interfs) with
+              match flatmap preds_in_itf (List.map fst interfs) with
                 [] -> (tn, get_unique_var_symb (tn ^ "#" ^ g) (PredType ([], [], None, Inductiveness_Inductive)))
               | [(family, pmap0, symb)] ->
                 if not (for_all2 (fun (x, t) (x0, t0) -> expect_type_core l "Predicate parameter covariance check" (Some true) t t0; true) pmap pmap0) then
@@ -2508,7 +2481,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   [] -> List.rev pmap
                 | (tp, x)::ps ->
                   if List.mem_assoc x pmap then static_error l "Duplicate parameter name." None;
-                  let tp = check_pure_type (pn,ilist) [] tp Ghost in
+                  let tp = check_pure_type (pn,ilist) [] Ghost tp in
                   iter ((x, tp)::pmap) ps
               in
               iter [] ps
@@ -2519,7 +2492,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   begin match try_assoc tn itfmap with
                     Some info ->
                     let (preds, itfs) = get_preds_and_itfs info in
-                    let itfnames = List.map (fun (f,_) -> f) itfs in
+                    let itfnames = List.map fst itfs in
                     begin match try_assoc g preds with
                       Some (l, pmap, family, symb) -> [(family, pmap, symb)]
                     | None -> flatmap preds_in_itf itfnames
@@ -2536,10 +2509,10 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let check_classmap classmap proj fallback =
                   begin match try_assoc cn classmap with
                     Some info ->
-                    let ((super,passedTparams), interfs, predmap) = proj info in
+                    let ((super, superTargs), interfs, predmap) = proj info in
                     begin match try_assoc g predmap with
                       Some (l, pmap, family, symb, body) -> [(family, pmap, symb)]
-                    | None -> preds_in_class super @ flatmap preds_in_itf (List.map (fun (itf,_) -> itf) interfs)
+                    | None -> preds_in_class super @ flatmap preds_in_itf (List.map (fun (itf, _) -> itf) interfs)
                     end
                   | None -> fallback ()
                   end
@@ -2552,7 +2525,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   $. fun () ->
                 []
               in
-              match preds_in_class ((fun (spr,_) -> spr) super) @ flatmap preds_in_itf (List.map (fun (itf,_) -> itf) interfs) with
+              match preds_in_class ((fun (spr,_) -> spr) super) @ flatmap preds_in_itf (List.map (fun (itf, _) -> itf) interfs) with
                 (* InstancePredDecl currently does not support coinductive declarations. *)
                 [] -> (cn, get_unique_var_symb (cn ^ "#" ^ g) (PredType ([], [], None, Inductiveness_Inductive)))
               | [(family, pmap0, symb)] ->
@@ -2591,7 +2564,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   Some _ -> static_error l "Duplicate parameter name." None
                 | _ -> ()
               end;
-              let t = check_pure_type (pn,ilist) [] te Ghost in
+              let t = check_pure_type (pn,ilist) [] Ghost te in
               if not (type_satisfies_contains_any_constraint true t) then static_error (type_expr_loc te) "This type cannot be used as a predicate constructor parameter type because it contains 'any' or a predicate type in a negative position." None;
               iter ((x, t)::pmap) ps
           in
@@ -2607,7 +2580,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   Some _ -> static_error l "Duplicate parameter name." None
                 | _ -> ()
               end;
-              let t = check_pure_type (pn,ilist) [] te Ghost in
+              let t = check_pure_type (pn,ilist) [] Ghost te in
               iter ((x, t)::psmap) ((x, t)::pmap) ps
           in
           iter ps1 [] ps2
@@ -2663,7 +2636,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     interfmap1 |> List.map begin function (i, (l, fields, meths, preds, supers, pn, ilist, tparams)) ->
       let fieldmap =
         fields |> List.map begin function Field (fl, fgh, ft, f, _, _, _, finit) ->
-          let ft = check_pure_type (pn,ilist) [] ft Real in
+          let ft = check_pure_type (pn,ilist) [] Real ft in
           (f, {fl; fgh; ft; fvis=Public; fbinding=Static; ffinal=true; finit; fvalue=ref None})
         end
       in
@@ -2672,7 +2645,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let rec lookup_class_field cn fn =
     match try_assoc cn classmap1 with
-      Some (_, _, _, _, fds, _, (super, passedTparams), _, itfs, _, _, _) ->
+      Some (_, _, _, _, fds, _, (super, superTargs), _, itfs, _, _, _) ->
       begin match try_assoc fn fds with
         None when cn = "java.lang.Object" -> None
       | Some f -> Some (f, cn)
@@ -2680,11 +2653,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match lookup_class_field super fn with
         Some _ as result -> result
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (itf,_) -> itf) itfs)
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map fst itfs)
       end
     | None -> 
     match try_assoc cn classmap0 with
-      Some {cfds; csuper=(csuper,_); cinterfs} ->
+      Some {cfds; csuper=(csuper, _); cinterfs} ->
       begin match try_assoc fn cfds with
         None when cn = "java.lang.Object" -> None
       | Some f -> Some (f, cn)
@@ -2692,7 +2665,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match lookup_class_field csuper fn with
         Some _ as result -> result
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (itf,_) -> itf) cinterfs)
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map fst cinterfs)
       end
     | None ->
     match try_assoc cn interfmap1 with
@@ -2700,7 +2673,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       begin match try_assoc fn fds with
         Some f -> Some (f, cn)
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (f,_) -> f) supers)
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map fst supers)
       end
     | None ->
     match try_assoc cn interfmap0 with
@@ -2708,7 +2681,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       begin match try_assoc fn fds with
         Some f -> Some (f, cn)
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (f,_) -> f) supers)
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map fst supers)
       end
     | None ->
     None
@@ -2814,17 +2787,17 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       else *)
         check_expr_t_core_core functypemap funcmap classmap interfmap (pn,ilist) tparams tenv inAnnotation e t0 true in
     let rec get_methods tn mn =
-      let erase_sign sign = List.map (fun tp -> match tp with RealTypeParam t -> ObjType("java.lang.Object",[]) | t -> t) sign in
+      let erase_sign sign = List.map (fun tp -> match tp with RealTypeParam t -> ObjType("java.lang.Object", []) | t -> t) sign in
       let remove_overrides declared_methods inherited_methods =
-        let inherited_method_erased = List.map (fun (sign,info) -> (sign, erase_sign sign, info)) inherited_methods in
-        let declared_methods_erased = List.map (fun (sign,info) -> (erase_sign sign, info)) declared_methods in
-        List.map (fun (sign,_,info) -> (sign,info))  
+        let inherited_method_erased = List.map (fun (sign, info) -> (sign, erase_sign sign, info)) inherited_methods in
+        let declared_methods_erased = List.map (fun (sign, info) -> (erase_sign sign, info)) declared_methods in
+        List.map (fun (sign, _, info) -> (sign, info))  
           (List.filter (fun (sign, erased_sign, info) -> not (List.mem_assoc erased_sign declared_methods_erased)) inherited_method_erased) in
       if tn = "" then [] else
       match try_assoc tn classmap with
-        Some {cmeths; csuper=(csuper,_); cinterfs} ->
+        Some {cmeths; csuper=(csuper, _); cinterfs} ->
         let inherited_methods =
-          get_methods csuper mn @ flatmap (fun ifn -> get_methods ifn mn) (List.map (fun (itf,_) -> itf) cinterfs)
+          get_methods csuper mn @ flatmap (fun ifn -> get_methods ifn mn) (List.map fst cinterfs)
         in
         let declared_methods =
           flatmap
@@ -2842,7 +2815,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         end
         meths
       in
-      let inherited_methods = flatmap (fun ifn -> get_methods ifn mn) (List.map (fun (f,_) -> f) interfs) in
+      let inherited_methods = flatmap (fun ifn -> get_methods ifn mn) (List.map fst interfs) in
       declared_methods @ (remove_overrides declared_methods inherited_methods)
     in
     (*
@@ -2909,7 +2882,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     match e with
       True l -> (e, boolt, None)
     | False l -> (e, boolt, None)
-    | Null l -> (e, ObjType ("null",[]), None)
+    | Null l -> (e, ObjType ("null", []), None)
     | Var (l, x) ->
       begin
       match try_assoc x tenv with
@@ -2920,7 +2893,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       if language <> Java then cont () else
       let field_of_this =
         match try_assoc "this" tenv with
-        | Some ObjType (cn,_) ->
+        | Some ObjType (cn, _) ->
           begin match lookup_class_field cn x with
             None -> None
           | Some ({fgh; ft; fbinding; ffinal; fvalue}, fclass) ->
@@ -3094,7 +3067,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           | _ -> None
         in
         (operation_expr funcmap l t operator w1 w2, t, value)
-      | (ObjType ("java.lang.String",[]) as t, _) when operator = Add ->
+      | (ObjType ("java.lang.String", []) as t, _) when operator = Add ->
         let w2 = checkt e2 t in
         (WOperation (l, operator, [w1; w2], t), t, None)
       | _ -> static_error l ("Operand of addition or subtraction must be pointer, integer, char, short, or real number: t1 "^(string_of_type t1)^" t2 "^(string_of_type t2)) None
@@ -3163,7 +3136,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         (floating_point_fun_call_expr funcmap l Double "of_real" [TypedExpr (e, RealType)], Double, None)
     | ClassLit (l, s) ->
       let s = check_classname (pn, ilist) (l, s) in
-      (ClassLit (l, s), ObjType ("java.lang.Class",[]), None)
+      (ClassLit (l, s), ObjType ("java.lang.Class", []), None)
     | StringLit (l, s) ->
       if inAnnotation = Some true then
         (* TODO: Do the right thing for non-ASCII characters *)
@@ -3176,7 +3149,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ -> (e, (PtrType (Int (Signed, 0))), None)
         end
     | CastExpr (l, te, e) ->
-      let t = check_pure_type (pn,ilist) tparams te Ghost in
+      let t = check_pure_type (pn,ilist) tparams Ghost te in
       let w = checkt_cast e t in
       (CastExpr (l, ManifestTypeExpr (type_expr_loc te, t), w), t, None)
     | TypedExpr (w, t) ->
@@ -3217,7 +3190,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let Some tpenv = zip callee_tparams targs in
            (targs, tpenv)
         else
-          let targs = List.map (fun tp -> check_pure_type (pn,ilist) tparams tp Ghost) targes in
+          let targs = List.map (check_pure_type (pn,ilist) tparams Ghost) targes in
           let tpenv =
             match zip callee_tparams targs with
               None -> static_error l "Incorrect number of type arguments." None
@@ -3241,7 +3214,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ ->
         match (g, es) with
           ("malloc", [SizeofExpr (ls, te)]) ->
-          let t = check_pure_type (pn,ilist) tparams te Ghost in
+          let t = check_pure_type (pn,ilist) tparams Ghost te in
           (WFunCall (l, g, [], es), PtrType t, None)
         | _ ->
         match resolve2 (pn,ilist) l g funcmap with
@@ -3285,15 +3258,15 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let ms = get_methods tn g in
         if ms = [] then on_fail () else
         let argtps = List.map (fun e -> let (_, tp, _) = (check e) in tp) args in
-        (* Select the real methods with the correct amount of type parameters *)
+        (* Select the real methods with the correct number of type parameters *)
         let ms = List.map (fun (sign, (tn', lm, gh, rt, xmap, pre, post, epost, terminates, fb', v, abstract, meth_tparams)) ->
-          let wtargs = if (List.length meth_tparams = List.length targes || gh = Ghost) then List.map (fun tp -> check_pure_type (pn,ilist) meth_tparams tp gh) targes else
+          let wtargs = if (List.length meth_tparams = List.length targes || gh = Ghost) then List.map (check_pure_type (pn,ilist) meth_tparams gh) targes else
             (* Should do type inference here, for now just use Object. Because of this some casts may be required because the return type may be wrong *)
             List.map (fun tparam -> ObjType("java.lang.Object", [])) meth_tparams in
           let targenv = 
             (* First make the targenv on the class level, then append the one for the method level *)
             (
-              if inAnnotation <> Some(true) then List.map2 (fun a b -> (a,b)) class_tparams class_targs else []
+              if inAnnotation <> Some(true) then List.map2 (fun a b -> (a, b)) class_tparams class_targs else []
             )@
             (
               let targs_c = List.length wtargs in
@@ -3305,7 +3278,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                       (string_of_int tparams_c) 
                       (string_of_int targs_c)
                      ) None
-                  else List.map2 (fun a b -> (a,b)) 
+                  else List.map2 (fun a b -> (a, b)) 
                     meth_tparams 
                     wtargs
             )
@@ -3323,7 +3296,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             Some(rt) -> replace_type rt
             | None -> Void
           in 
-          (sign',(tn', lm, gh, rt', xmap, pre, post, epost, terminates, fb', v, abstract,tparams, wtargs, class_targs, sign))) ms in
+          (sign', (tn', lm, gh, rt', xmap, pre, post, epost, terminates, fb', v, abstract,tparams, wtargs, class_targs, sign))) ms in
         let ms = List.filter (fun (sign, _) -> is_assignable_to_sign inAnnotation argtps sign) ms in
         let make_well_typed_method m =
           match m with
@@ -3375,7 +3348,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           static_error l "Cannot create instance of abstract class." None
         else
           let targestps = match targs with
-            Some(targs) -> List.map (fun targ -> check_pure_type (pn,ilist) tparams targ Real) targs
+            Some(targs) -> List.map (check_pure_type (pn,ilist) tparams Real) targs
             | None -> []
           in
           (NewObject (l, cn, args, targs), ObjType (cn,targestps), None)
@@ -3396,11 +3369,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | _ when language = CLang -> static_error l "Target of array access is not an array or pointer." None
       end
     | NewArray (l, te, len) ->
-      let t = check_pure_type (pn,ilist) tparams te Real in
+      let t = check_pure_type (pn,ilist) tparams Real te in
       ignore $. checkt len intType;
       (e, (ArrayType t), None)
     | NewArrayWithInitializer (l, te, es) ->
-      let t = check_pure_type (pn,ilist) tparams te Real in
+      let t = check_pure_type (pn,ilist) tparams Real te in
       (e, ArrayType t, None)
     | IfExpr (l, e1, e2, e3) ->
       let w1 = checkcon e1 in
@@ -3421,7 +3394,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let (t0, wcdef_opt) =
                   match cdef_opt with
                     None ->
-                    if ctors <> [] then static_error l ("Missing cases: " ^ String.concat ", " (List.map (fun (ctor, _) -> ctor) ctors)) None;
+                    if ctors <> [] then static_error l ("Missing cases: " ^ String.concat ", " (List.map fst ctors)) None;
                     (t0, None)
                   | Some (lcdef, edef) ->
                     if ctors = [] then static_error lcdef "Superfluous default clause" None;
@@ -3474,17 +3447,17 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ -> static_error l "Switch expression operand must be inductive value." None
       end
     | SizeofExpr(l, te) ->
-      let t = check_pure_type (pn,ilist) tparams te Real in
+      let t = check_pure_type (pn,ilist) tparams Real te in
       (SizeofExpr (l, ManifestTypeExpr (type_expr_loc te, t)), sizeType, None)
     | InstanceOfExpr(l, e, te) ->
-      let t = check_pure_type (pn,ilist) tparams te Real in
+      let t = check_pure_type (pn,ilist) tparams Real te in
       let w = checkt e (ObjType ("java.lang.Object", [])) in
       (InstanceOfExpr (l, w, ManifestTypeExpr (type_expr_loc te, t)), boolt, None)
     | SuperMethodCall(l, mn, args) ->
       let rec get_implemented_instance_method cn mn argtps =
         if cn = "java.lang.Object" then None else
         match try_assoc cn classmap with 
-        | Some {cmeths; csuper=(csuper,_)} ->
+        | Some {cmeths; csuper=(csuper, _)} ->
           begin try
             let m =
               List.find
@@ -3508,7 +3481,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | Some(ObjType(cn, targs)) -> 
         begin match try_assoc cn classmap with
           None -> static_error l "No matching method." None
-        | Some {csuper=(csuper,_)} ->
+        | Some {csuper=(csuper, _)} ->
             begin match get_implemented_instance_method csuper mn argtps with
               None -> static_error l "No matching method." None
             | Some(((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, tparams))) ->
@@ -3568,7 +3541,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
        * eval_core_cps0 (search for "No other cast allowed by the type
        * checker changes the value").
        *)
-      let (w,t,value) = check_expr_core functypemap funcmap classmap interfmap (pn,ilist) tparams tenv inAnnotation e in
+      let (w, t, value) = check_expr_core functypemap funcmap classmap interfmap (pn,ilist) tparams tenv inAnnotation e in
       let check () =
         begin match (t, t0) with
         | _ when t = t0 -> w
@@ -4114,7 +4087,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let (interfs, preds, tparams) = get_interfs_and_preds info in
           begin match try_assoc g preds with
             Some (_, pmap, family, symb) -> [(family, pmap, tparams)]
-          | None -> List.flatten (List.map (fun i -> find_in_interf i) (List.map (fun (f,_) -> f) interfs))
+          | None -> List.flatten (List.map (fun i -> find_in_interf i) (List.map fst interfs))
           end
         | None -> fallback ()
       in
@@ -4129,7 +4102,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let ((super,_), interfs, preds, tparams) = proj info in
           begin match try_assoc g preds with
             Some (_, pmap, family, symb, body) -> [(family, pmap, tparams)]
-          | None -> find_in_class super @ flatmap find_in_interf (List.map (fun (itf,_) -> itf) interfs)
+          | None -> find_in_class super @ flatmap find_in_interf (List.map fst interfs)
           end
         | None -> fallback ()
       in
@@ -4300,7 +4273,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let (wv, tenv') = check_pat (pn,ilist) tparams tenv t v in
       (WPointsTo (l, wlhs, t, wv), tenv', [])
     | PredAsn (l, p, targs, ps0, ps) ->
-      let targs = List.map (fun te -> check_pure_type (pn, ilist) tparams te Ghost) targs in
+      let targs = List.map (check_pure_type (pn, ilist) tparams Ghost) targs in
       begin fun cont ->
          match try_assoc p tenv |> option_map unfold_inferred_type with
            Some (PredType (callee_tparams, ts, inputParamCount, inductiveness)) -> cont (p, false, callee_tparams, [], ts, inputParamCount)
@@ -4308,7 +4281,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           begin match resolve Ghost (pn,ilist) l p predfammap with
             Some (pname, (_, callee_tparams, arity, xs, _, inputParamCount, inductiveness)) ->
             let ts0 = match file_type path with
-              Java-> list_make arity (ObjType ("java.lang.Class",[]))
+              Java-> list_make arity (ObjType ("java.lang.Class", []))
             | _   -> list_make arity (PtrType Void)
             in
             cont (pname, true, callee_tparams, ts0, xs, inputParamCount)
@@ -4379,7 +4352,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let tpenv = 
             if (List.length targs > 0) then (if (List.length tparams) <> (List.length targs) 
             then static_error l (Printf.sprintf "Wrong amount of type arguments provided. Expected: %s Actual %s." (string_of_int (List.length tparams)) (string_of_int (List.length targs))) None
-            else List.map2 (fun a b -> (a,b)) tparams targs) else [] in
+            else List.map2 (fun a b -> (a, b)) tparams targs) else [] in
           (* We know both type params and type arguments here, if possible fill them in *)
           let rec replaceTypeParams t = match t with 
             GhostTypeParam t -> (try List.assoc t tpenv with _ -> GhostTypeParam t)
@@ -4465,7 +4438,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | ForallAsn (l, te, i, e) -> 
       begin match try_assoc i tenv with
         None -> 
-          let t = check_pure_type (pn,ilist) tparams te Ghost in
+          let t = check_pure_type (pn,ilist) tparams Ghost te in
           let w = check_expr_t (pn,ilist) tparams ((i, t) :: tenv) (Some true) e boolt in
           (ForallAsn(l, ManifestTypeExpr(l, t), i, w), tenv, [])
       | Some _ -> static_error l ("bound variable " ^ i ^ " hides existing local variable " ^ i) None
@@ -4744,7 +4717,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         match pxs with
           [] -> List.rev xm
         | (t0, (te, x))::xs -> 
-          let t = check_pure_type (pn,ilist) tparams' te Ghost in
+          let t = check_pure_type (pn,ilist) tparams' Ghost te in
           expect_type l (Some true) t (instantiate_type tpenv t0);
           if List.mem_assoc x tenv then static_error l ("Parameter '" ^ x ^ "' hides existing local variable '" ^ x ^ "'.") None;
           if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
@@ -4801,8 +4774,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     in
     iter' predinstmap1 ps
   
-  let predinstmap = predinstmap1 @ 
-    predinstmap0
+  let predinstmap = predinstmap1 @ predinstmap0
   
   let predctormap1 =
     List.map
@@ -5022,16 +4994,16 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let calculate_ancestry_intfmap0 already_calculated_ancestries (clinfname, info) =
       let super_clintf =
         match info with
-          InterfaceInfo (_, _, _, _, intfs,_) ->
-            ((List.map (fun (f,_) -> f) intfs), false, false)
+          InterfaceInfo (_, _, _, _, intfs, _) ->
+            ((List.map fst intfs), false, false)
       in
       calculate_ancestry_from_direct_ancesters_info already_calculated_ancestries clinfname super_clintf
     in
     let calculate_ancestry_intfmap1 already_calculated_ancestries (clinfname, info) =
       let super_clintf =
         match info with
-          (_, _, _, _, intfs, _, _,_) ->
-            ((List.map (fun (f,_) -> f) intfs), false, false)
+          (_, _, _, _, intfs, _, _, _) ->
+            ((List.map fst intfs), false, false)
       in
       calculate_ancestry_from_direct_ancesters_info already_calculated_ancestries clinfname super_clintf
     in
@@ -5040,16 +5012,16 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let iafc =
           if info.cfinal = FinalClass then true else false
         in
-        let (csuper,passedTparams) = info.csuper in
-        if csuper = "" then ((List.map (fun (itf,_) -> itf) info.cinterfs), true, iafc) else ((csuper :: (List.map (fun (itf,_) -> itf) info.cinterfs)), true, iafc) (* super class of Java.lang.Object is registered as "" *)
+        let (csuper, superTargs) = info.csuper in
+        if csuper = "" then ((List.map fst info.cinterfs), true, iafc) else ((csuper :: (List.map fst info.cinterfs)), true, iafc) (* super class of Java.lang.Object is registered as "" *)
       in
       calculate_ancestry_from_direct_ancesters_info already_calculated_ancestries clinfname super_clintf
     in
     let calculate_ancestry_classmap1 already_calculated_ancestries (clinfname, info) =
       let super_clintf =
         match info with
-          (_, _, fin, _, _, _, (spr,passedTparams), _, intfs, _, _, _) ->
-            let intfs = (List.map (fun (itf,_) -> itf) intfs) in
+          (_, _, fin, _, _, _, (spr, superTargs), _, intfs, _, _, _) ->
+            let intfs = (List.map fst intfs) in
             let iafc =
               if fin = FinalClass then true else false
             in
@@ -5102,10 +5074,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         calculate_all_ancestries anc_intfmap0_intfmap1 classmap0 calculate_ancestry_classmap0
       in
       let anc_intfmap0_intfmap1_classmap0_classmap1 =
-        calculate_all_ancestries 
-          anc_intfmap0_intfmap1_classmap0 
-          classmap1 
-          calculate_ancestry_classmap1
+        calculate_all_ancestries anc_intfmap0_intfmap1_classmap0 classmap1 calculate_ancestry_classmap1
       in
       anc_intfmap0_intfmap1_classmap0_classmap1
     in
@@ -5731,7 +5700,7 @@ let check_if_list_is_defined () =
             match try_assoc cn case_clauses with
               Some (ps, e) ->
               let apply (_::gvs) cvs =
-                let Some genv = zip (List.map (fun (x, t) -> x) env) gvs in
+                let Some genv = zip (List.map fst env) gvs in
                 let Some penv = zip ps cvs in
                 let penv =
                   if tparams = [] then penv else
@@ -5752,7 +5721,7 @@ let check_if_list_is_defined () =
             | None ->
               let (Some (_, e)) = cdef_opt in
               let apply (_::gvs) cvs =
-                let Some genv = zip (List.map (fun (x, t) -> x) env) gvs in
+                let Some genv = zip (List.map fst env) gvs in
                 eval_core None None genv e
               in
               (csym, apply)
@@ -5817,7 +5786,7 @@ let check_if_list_is_defined () =
            cs
        in
        ctxt#set_fpclauses fsym i clauses
-         | (g, (l, t, pmap, None, w, pn, ilist, fsym)) ->
+       | (g, (l, t, pmap, None, w, pn, ilist, fsym)) ->
        ctxt#begin_formal;
        let env = imap (fun i (x, tp) -> let pt = typenode_of_type tp in (pt, (x, ctxt#mk_bound i pt))) pmap in
        let tps = List.map fst env in

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -252,7 +252,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let cell = ref 0 in
       Hashtbl.add used_ids s cell;
       cell
-
+  
   (** Generate a fresh ID based on string [s]. *)
   let mk_ident s =
     let count_cell = get_ident_use_count_cell s in
@@ -507,7 +507,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let cons' = cons |> List.filter begin
         fun x ->
           match x with
-            | Cons (lm, ps, co, ss, v, _) ->
+            | Cons (lm, ps, co, ss, v) ->
               match ss with
                 | None -> true
                 | Some _ -> false
@@ -4046,8 +4046,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | ([], _) -> static_error l "Too many patterns" None
     | (_, []) -> static_error l "Too few patterns" None
   
-  let check_pat (pn,ilist) tparams tenv t p = 
-  let (w, tenv') = check_pat_core (pn,ilist) tparams tenv t p in (w, tenv' @ tenv)
+  let check_pat (pn,ilist) tparams tenv t p = let (w, tenv') = check_pat_core (pn,ilist) tparams tenv t p in (w, tenv' @ tenv)
   
   let rec check_pats (pn,ilist) l tparams tenv ts ps =
     match (ts, ps) with

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -1437,8 +1437,6 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       begin
       match resolve Real (pac, ilist) l id class_arities with
         Some (_, (_, n)) -> ObjType(full_name, create_objects n)
-      | None -> match resolve Real (pac, ilist) l id class_arities with
-        Some (_, (_, n)) -> ObjType(full_name, create_objects n)
       | None -> static_error l ("No such type parameter, inductive datatype, class, interface, or function type: " ^ full_name) None
       end
     | ConstructedTypeExpr (l, id, targs) ->
@@ -3436,7 +3434,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       (SizeofExpr (l, ManifestTypeExpr (type_expr_loc te, t)), sizeType, None)
     | InstanceOfExpr(l, e, te) ->
       let t = check_pure_type (pn,ilist) tparams Real te in
-      let w = checkt e (javaLangObject) in
+      let w = checkt e javaLangObject in
       (InstanceOfExpr (l, w, ManifestTypeExpr (type_expr_loc te, t)), boolt, None)
     | SuperMethodCall(l, mn, args) ->
       let rec get_implemented_instance_method cn mn argtps =

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -2508,7 +2508,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   [] -> List.rev pmap
                 | (tp, x)::ps ->
                   if List.mem_assoc x pmap then static_error l "Duplicate parameter name." None;
-                  let tp = check_pure_type (pn,ilist) tparams tp Real in
+                  let tp = check_pure_type (pn,ilist) [] tp Ghost in
                   iter ((x, tp)::pmap) ps
               in
               iter [] ps

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -3277,11 +3277,6 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let ms = get_methods tn g in
         if ms = [] then on_fail () else
         let argtps = List.map (fun e -> let (_, tp, _) = (check e) in tp) args in
-        Printf.printf "Trying qualified call: <%s> %s.%s (%s);\n"
-          (String.concat ", " (List.map string_of_type class_targs))
-          tn
-          g
-          (String.concat ", " (List.map string_of_type argtps));
         (* Select the real methods with the correct number of type parameters *)
         let ms = List.map (fun (sign, (tn', lm, gh, rt, xmap, pre, post, epost, terminates, fb', v, abstract)) ->
           let targenv = if inAnnotation <> Some(true) then List.map2 (fun a b -> (a, b)) class_tparams class_targs else []

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -252,7 +252,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let cell = ref 0 in
       Hashtbl.add used_ids s cell;
       cell
-  
+
   (** Generate a fresh ID based on string [s]. *)
   let mk_ident s =
     let count_cell = get_ident_use_count_cell s in
@@ -332,7 +332,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | RealType -> ProverReal
     | InductiveType _ -> ProverInductive
     | StructType sn -> ProverInductive
-    | ObjType n -> ProverInt
+    | ObjType (n,_) -> ProverInt
     | ArrayType t -> ProverInt
     | StaticArrayType (t, s) -> ProverInt
     | PtrType t -> ProverInt
@@ -342,7 +342,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | BoxIdType -> ProverInt
     | HandleIdType -> ProverInt
     | AnyType -> ProverInductive
-    | TypeParam _ -> ProverInductive
+    | RealTypeParam _ -> ProverInt
+    | GhostTypeParam _ -> ProverInductive
     | Void -> ProverInductive
     | InferredType (_, t) -> begin match !t with EqConstraint t -> provertype_of_type t | _ -> t := EqConstraint (InductiveType ("unit", [])); ProverInductive end
     | AbstractType _ -> ProverInductive
@@ -493,12 +494,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let rec iter (pn,ilist) classes lemmas ds=
       match ds with
       [] -> (classes,lemmas)
-    | Class (l, abstract, fin, cn, meths, fds, cons, super, inames, preds)::rest ->
+    | Class (l, abstract, fin, cn, meths, fds, cons, super, tparams, inames, preds)::rest ->
       let cn = full_name pn cn in
       let meths' = meths |> List.filter begin
         fun x ->
           match x with
-            | Meth(lm, gh, t, n, ps, co, ss,fb,v,abstract) ->
+            | Meth(lm, gh, t, n, ps, co, ss,fb,v,abstract, tparams) ->
               match ss with
                 | None -> true
                 | Some _ -> false
@@ -506,12 +507,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let cons' = cons |> List.filter begin
         fun x ->
           match x with
-            | Cons (lm, ps, co, ss, v) ->
+            | Cons (lm, ps, co, ss, v, _) ->
               match ss with
                 | None -> true
                 | Some _ -> false
       end in
-      iter (pn,ilist) (Class(l,abstract,fin,cn,meths',fds,cons',super,inames,[])::classes) lemmas rest
+      iter (pn,ilist) (Class(l,abstract,fin,cn,meths',fds,cons',super, tparams,inames,[])::classes) lemmas rest
     | Func(l,Lemma(_),tparams,rt,fn,arglist,nonghost_callers_only,ftype,contract,terminates,None,fb,vis) as elem ::rest->
       iter (pn, ilist) classes (elem::lemmas) rest
     | _::rest -> 
@@ -648,6 +649,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * visibility
       * bool (* is override *)
       * bool (* is abstract *)
+      * string list (* type parameters *)
     type interface_method_info =
       ItfMethodInfo of
         loc
@@ -661,6 +663,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * bool (* terminates *)
       * visibility
       * bool (* is abstract *)
+      * string list (*type parameters*)
     type field_info = {
         fl: loc;
         fgh: ghostness;
@@ -682,6 +685,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * bool (* terminates *)
       * ((stmt list * loc) * int (*rank for termination check*)) option option
       * visibility
+      * string list (*type parameters*)
     type inst_pred_info =
         loc
       * type_ map
@@ -699,7 +703,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * field_info map
       * (signature * interface_method_info) list
       * interface_inst_pred_info map
-      * string list (* superinterfaces *)
+      * (string * type_ list) list (* superinterfaces with passed targs *)
+      * string list (* type parameters *)
     type class_info = {
       cl: loc;
       cabstract: bool;
@@ -707,11 +712,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       cmeths: (signature * method_info) list;
       cfds: field_info map;
       cctors: (type_ list * ctor_info) list;
-      csuper: string;
-      cinterfs: string list;
+      csuper: (string  * type_ list);
+      cinterfs: (string * type_ list) list;
       cpreds: inst_pred_info map;
       cpn: string; (* package *)
-      cilist: import list
+      cilist: import list;
+      ctpenv: string list
     }
     type box_action_permission_info =
         termnode (* term representing action permission predicate *)
@@ -1135,7 +1141,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | (Inductive (l, i, tparams, ctors))::ds -> let n=full_name pn i in
         if n = "bool" || n = "boolean" || n = "int" || List.mem_assoc n idm || List.mem_assoc n inductivemap0 then
           static_error l "Duplicate datatype name." None
-        else
+        else 
           iter pn ((n, (l, tparams, ctors))::idm) ds
       | _::ds -> iter pn idm ds
     in
@@ -1241,6 +1247,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | Some f -> Some f 
     | None -> resolve Ghost (pn, imports) l name map
 
+  let resolve2' ghost (pn, imports) l name map0 map1 =
+    match resolve ghost (pn, imports) l name map0 with 
+    | Some f -> Some f 
+    | None -> resolve ghost (pn, imports) l name map1 
+
   let search2' ghost x (pn,imports) xys1 xys2 =
     match search' ghost x (pn,imports) xys1 with
       None -> search' ghost x (pn,imports) xys2
@@ -1252,7 +1263,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
    let rec iter (ifdm, classlist) ds todo =
      match ds with 
       | [] -> (ifdm, classlist, todo)
-      | (pn, ilist, Interface (l, i, interfs, fields, meths, pred_specs))::rest ->
+      | (pn, ilist, Interface (l, i, interfs, fields, meths, tparams, pred_specs))::rest ->
         let i= full_name pn i in 
         if List.mem_assoc i ifdm then
           static_error l ("There exists already an interface with this name: "^i) None
@@ -1266,17 +1277,17 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let rec check_interfs ls=
                   match ls with
                     [] -> []
-                  | i::ls -> match search2' Real i (pn,ilist) ifdm interfmap0 with 
-                              Some i -> i::check_interfs ls
+                  | (n,targs)::ls -> match search2' Real n (pn,ilist) ifdm interfmap0 with 
+                              Some i -> (i,targs)::check_interfs ls
                             | None -> raise Not_found
                 in
                 check_interfs interfs
               in
-              iter (((i, (l, fields, meths, pred_specs, interfs, pn, ilist))::ifdm), classlist) rest todo
+              iter (((i, (l, fields, meths, pred_specs, interfs, pn, ilist, tparams))::ifdm), classlist) rest todo
             with Not_found ->
               iter (ifdm, classlist) rest ((List.hd ds)::todo)
           end
-      | (pn, ilist, Class (l, abstract, fin, i, meths,fields,constr,super,interfs,preds))::rest ->
+      | (pn, ilist, Class (l, abstract, fin, i, meths,fields,constr,(super,supertargs), tparams,interfs,preds))::rest ->
         let i= full_name pn i in
         if List.mem_assoc i ifdm then
           static_error l ("There exists already an interface with this name: "^i) None
@@ -1290,8 +1301,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let rec check_interfs ls=
                     match ls with
                       [] -> []
-                    | i::ls -> match search2' Real i (pn,ilist) ifdm interfmap0 with 
-                                Some i -> i::check_interfs ls
+                    | (n,targs)::ls -> match search2' Real n (pn,ilist) ifdm interfmap0 with 
+                                Some i -> (i,targs)::check_interfs ls
                               | None -> raise Not_found
                 in
                 check_interfs interfs
@@ -1303,7 +1314,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   None-> raise Not_found
                 | Some super -> super
               in
-              iter (ifdm, (i, (l,abstract,fin,meths,fields,constr,super,interfs,preds,pn,ilist))::classlist) rest todo
+              iter (ifdm, (i, (l,abstract,fin,meths,fields,constr,(super,supertargs),tparams,interfs,preds,pn,ilist))::classlist) rest todo
             with Not_found ->
               iter (ifdm, classlist) rest ((List.hd ds)::todo)
           end
@@ -1317,15 +1328,15 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec check_interfs kind i ls (pn,ilist) =
               match ls with
                 [] -> kind ^ " " ^ i ^ " is part of an inheritance cycle"
-              | i::ls -> match search2' Real i (pn,ilist) ifdm interfmap0 with 
+              | (i,tparams)::ls -> match search2' Real i (pn,ilist) ifdm interfmap0 with 
                           Some i -> check_interfs kind i ls (pn,ilist)
                         | None -> "Interface " ^ i ^ " not found"
             in
             let (l, message) =
               match ds_rest with
-              | (pn, ilist, (Interface (l, i, interfs, fields, meths, pred_specs)))::_ ->
+              | (pn, ilist, (Interface (l, i, interfs, fields, meths, pred_specs, tparams)))::_ ->
                   (l, check_interfs "Interface" i interfs (pn,ilist))
-              | (pn, ilist, (Class (l, abstract, fin, i, meths,fields,constr,super,interfs,preds)))::_ ->
+              | (pn, ilist, (Class (l, abstract, fin, i, meths,fields,constr,(super,passedTparams), tparams,interfs,preds)))::_ ->
                   match search2' Real super (pn,ilist) classlist classmap0 with
                     None-> 
                       if i = "java.lang.Object" || super = "java.lang.Object" then 
@@ -1354,9 +1365,17 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let abstract_types_map = abstract_types_map1 @ abstract_types_map0
   
+  let classmap_arities =
+    List.map (fun (cn, (l, _, _, _, _, _, _, tparams, _, _, _, _)) -> (cn, (l, List.length tparams))) classmap1
+    @ List.map (fun (cn, {cl=l; ctpenv=tparams}) -> (cn, (l, List.length tparams))) classmap0
+
+  let interfmap_arities =
+    List.map (fun (cn, (l, _, _, _, _, _, _, tparams)) -> (cn, (l, List.length tparams))) interfmap1
+    @ List.map (fun (cn, InterfaceInfo (l, _, _, _, _, tparams)) -> (cn, (l, List.length tparams))) interfmap0
+    
+
   (* Region: check_pure_type: checks validity of type expressions *)
-  
-  let check_pure_type_core typedefmap1 (pn,ilist) tpenv te =
+  let check_pure_type_core typedefmap1 (pn,ilist) tpenv te envType =
     let rec check te =
     match te with
       ManifestTypeExpr (l, t) -> t
@@ -1367,10 +1386,13 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let tp = check t in
         StaticArrayType(tp, s)
     | IdentTypeExpr (l, None, id) ->
-      if List.mem id tpenv then
-        TypeParam id
-      else
       begin
+      if List.mem id tpenv 
+        then begin match envType with
+          Ghost -> GhostTypeParam (id)
+          | Real -> RealTypeParam (id)
+        end
+      else
       match try_assoc2 id typedefmap0 typedefmap1 with
         Some t -> t
       | None ->
@@ -1381,10 +1403,10 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         InductiveType (s, [])
       | None ->
       match (search2' Real id (pn,ilist) classmap1 classmap0) with
-        Some s -> ObjType s
+        Some s -> ObjType (s,[])
       | None ->
       match (search2' Real id (pn,ilist) interfmap1 interfmap0) with
-        Some s -> ObjType s
+        Some s -> ObjType (s,[])
       | None ->
       if List.mem_assoc id functypenames || List.mem_assoc id functypemap0 then
         FuncType id
@@ -1397,20 +1419,38 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       end
     | IdentTypeExpr (l, Some(pac), id) ->
       let full_name = pac ^ "." ^ id in
-      begin match (search2' Real full_name (pn,ilist) classmap1 classmap0) with
-          Some s -> ObjType s
+      begin
+      if List.mem id tpenv 
+        then begin match envType with
+          Ghost -> GhostTypeParam (id)
+          | Real -> RealTypeParam (id)
+        end
+      else
+      match (search2' Real full_name (pn,ilist) classmap1 classmap0) with
+        Some s -> ObjType (s,[])
         | None -> match (search2' Real full_name (pn,ilist) interfmap1 interfmap0) with
-                    Some s->ObjType s
+                    Some s->ObjType (s,[])
                   | None -> static_error l ("No such type parameter, inductive datatype, class, interface, or function type: " ^ full_name) None
       end
     | ConstructedTypeExpr (l, id, targs) ->
       begin
-      match resolve Ghost (pn,ilist) l id inductive_arities with
-        Some (id, (ld, n)) ->
-        if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
-        reportUseSite DeclKind_InductiveType ld l;
-        InductiveType (id, List.map check targs)
-      | None -> static_error l "No such inductive datatype." None
+          match resolve Ghost (pn,ilist) l id inductive_arities with
+          Some (id, (ld, n)) ->
+            if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
+            reportUseSite DeclKind_InductiveType ld l;
+            InductiveType (id, List.map check targs)
+          | None -> match resolve Real (pn,ilist) l id interfmap_arities with
+            Some (id, (ld, n)) ->
+              if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
+              ObjType (id, List.map check targs)
+            | None -> 
+              begin
+              match resolve Real (pn,ilist) l id classmap_arities with
+                Some (id, (ld, n)) ->
+                if n <> List.length targs then static_error l "Incorrect number of type arguments." None;
+                ObjType (id, List.map check targs)
+              | None -> static_error l ("No such Ghost inductive or Real parameterised datatype. " ^ pn ^ "." ^ id) None
+              end
       end
     | StructTypeExpr (l, sn, Some _) ->
       static_error l "A struct type with a body is not supported in this position." None
@@ -1443,24 +1483,27 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match tdds with
         [] -> tdm1
       | (d, (l, te))::tdds ->
-        let t = check_pure_type_core tdm1 ("",[]) [] te in
+        let t = check_pure_type_core tdm1 ("",[]) [] te Real in
         iter ((d,t)::tdm1) tdds
     in
     iter [] typedefdeclmap
   
   let typedefmap = typedefmap1 @ typedefmap0
   
-  let check_pure_type (pn,ilist) tpenv te = check_pure_type_core typedefmap (pn,ilist) tpenv te
+  (* envtype indicates if we are type checking in a ghost or real environment *)
+  let check_pure_type (pn,ilist) tpenv te envType = check_pure_type_core typedefmap (pn,ilist) tpenv te envType
   
   let classmap1 =
     List.map
-      begin fun (sn, (l,abstract,fin,meths,fds,constr,super,interfs,preds,pn,ilist)) ->
+      begin fun (sn, (l,abstract,fin,meths,fds,constr,(super,supertargs),tparams, interfs,preds,pn,ilist)) ->
+        let supertargs = List.map (fun te -> check_pure_type (pn,ilist) tparams te Real) supertargs in
+        let interfs = List.map (fun (i,tes) -> (i,List.map (fun te -> check_pure_type (pn,ilist) tparams te Real) tes)) interfs in
         let rec iter fmap fds =
           match fds with
-            [] -> (sn, (l,abstract,fin,meths, List.rev fmap,constr,super,interfs,preds,pn,ilist))
+            [] -> (sn, (l,abstract,fin,meths, List.rev fmap,constr,(super,supertargs),tparams, interfs,preds,pn,ilist))
           | Field (fl, fgh, t, f, fbinding, fvis, ffinal, finit)::fds ->
             if List.mem_assoc f fmap then static_error fl "Duplicate field name." None;
-            iter ((f, {fl; fgh; ft=check_pure_type (pn,ilist) [] t; fvis; fbinding; ffinal; finit; fvalue=ref None})::fmap) fds
+            iter ((f, {fl; fgh; ft=check_pure_type (pn,ilist) tparams t Real; fvis; fbinding; ffinal; finit; fvalue=ref None})::fmap) fds
         in
         iter [] fds
       end
@@ -1469,7 +1512,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let rec instantiate_type tpenv t =
     if tpenv = [] then t else
     match t with
-      TypeParam x -> List.assoc x tpenv
+      RealTypeParam x | GhostTypeParam x -> (try List.assoc x tpenv  with _ -> failwith 
+        (Printf.sprintf "not found! looking for %s in env %s" x (String.concat ", " (List.map (fun (a,b) -> a ^ "->" ^(string_of_type b)) tpenv))))
     | PtrType t -> PtrType (instantiate_type tpenv t)
     | InductiveType (i, targs) -> InductiveType (i, List.map (instantiate_type tpenv) targs)
     | PredType ([], pts, inputParamCount, inductiveness) -> PredType ([], List.map (instantiate_type tpenv) pts, inputParamCount, inductiveness)
@@ -1528,7 +1572,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
              (sn, (l, Some fmap, padding_predsym_opt, s))
            | Field (lf, gh, t, f, Instance, Public, final, init)::fds ->
              if List.mem_assoc f fmap then static_error lf "Duplicate field name." None;
-             let t = check_pure_type ("", []) [] t in
+             let t = check_pure_type ("", []) [] t gh in
              let offset = if gh = Ghost then None else Some (get_unique_var_symb (sn ^ "_" ^ f ^ "_offset") intType) in
              let entry = (f, (lf, gh, t, offset)) in
              iter (entry::fmap) fds (has_ghost_fields || gh = Ghost)
@@ -1568,32 +1612,32 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | _ -> []
     ) functypenames
   
-  let rec is_subtype_of x y =
+  let rec is_subtype_of x y = 
     x = y ||
     y = "java.lang.Object" ||
     match try_assoc x classmap1 with
-      Some (_, _, _, _, _, _, super, interfaces, _, _, _) ->
-      is_subtype_of super y || List.exists (fun itf -> is_subtype_of itf y) interfaces
+      Some (_, _, _, _, _, _, (super, _),_, interfaces, _, _, _) ->
+      is_subtype_of super y || List.exists (fun (itf,_) -> is_subtype_of itf y) interfaces
     | None ->
       match try_assoc x classmap0 with
-        Some {csuper=super; cinterfs=interfaces} ->
-        is_subtype_of super y || List.exists (fun itf -> is_subtype_of itf y) interfaces
+        Some {csuper=(super, _); cinterfs=interfaces} ->
+        is_subtype_of super y || List.exists (fun (itf,_) -> is_subtype_of itf y) interfaces
       | None -> begin match try_assoc x interfmap1 with
-          Some (_, _, _, _, interfaces, _, _) -> List.exists (fun itf -> is_subtype_of itf y) interfaces
+          Some (_, _, _, _, interfaces, _, _, _) -> List.exists (fun (itf,_)   -> is_subtype_of itf y) interfaces
         | None -> begin match try_assoc x interfmap0 with
-            Some (InterfaceInfo (_, _, _, _, interfaces)) -> List.exists (fun itf -> is_subtype_of itf y) interfaces
+            Some (InterfaceInfo (_, _, _, _, interfaces, tparams)) -> List.exists (fun (itf,_) -> is_subtype_of itf y) interfaces
           | None -> false 
           end
         end
   
   let is_subtype_of_ x y =
     match (x, y) with
-      (ObjType x, ObjType y) -> is_subtype_of x y
+      (ObjType (x,_), ObjType (y,_)) -> is_subtype_of x y
     | _ -> false
   
   let is_unchecked_exception_type tp = 
     match tp with
-     ObjType cn -> (is_subtype_of cn "java.lang.RuntimeException") || (is_subtype_of cn "java.lang.Error")
+     ObjType (cn,_) -> (is_subtype_of cn "java.lang.RuntimeException") || (is_subtype_of cn "java.lang.Error")
     | _ -> false
 
   (* Region: globaldeclmap *)
@@ -1612,7 +1656,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           match try_assoc x gdm with
             Some (_) -> static_error l "Duplicate global variable name." None
           | None -> 
-            let tp = check_pure_type ("",[]) [] te in
+            let tp = check_pure_type ("",[]) [] te Real in
             let global_symb = get_unique_var_symb x (PtrType tp) in
             iter ((x, (l, tp, global_symb, ref init)) :: gdm) ds
         end
@@ -1681,8 +1725,17 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match tparams with
         [] -> ()
       | x::xs ->
-        if List.mem x tparams0 then static_error l (Printf.sprintf "Type parameter '%s' hides existing type parameter '%s'." x x) None;
-        if List.mem x xs then static_error l (Printf.sprintf "Duplicate type parameter '%s'." x) None;
+        if List.mem x tparams0 then static_error l (Printf.sprintf "Type parameter '%s' hides existing type parameter '%s'." x x) None; iter xs
+    in
+    iter tparams
+
+  let check_tparams_m l tparams0 tparams =
+    let rec iter tparams =
+      match tparams with
+        [] -> ()
+      | (x,gh)::xs ->
+        if List.mem (x,gh) tparams0 then static_error l (Printf.sprintf "Type parameter '%s' hides existing type parameter '%s'." x x) None;
+        if List.mem (x,gh) xs then static_error l (Printf.sprintf "Duplicate type parameter '%s'." x) None;
         iter xs
     in
     iter tparams
@@ -1702,11 +1755,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             if List.mem_assoc full_cn pfm || List.mem_assoc full_cn purefuncmap0 then
               static_error lc ("Duplicate pure function name: " ^ full_cn) None
             else begin
-              let ts = List.map (check_pure_type (pn,ilist) tparams) argument_type_expressions in
+              let ts = List.map (fun arg -> check_pure_type (pn,ilist) tparams arg Ghost) argument_type_expressions in
               let csym =
                 mk_func_symbol full_cn (List.map provertype_of_type ts) ProverInductive (Proverapi.Ctor (CtorByOrdinal j))
               in
-              let purefunc = (full_cn, (lc, tparams, InductiveType (i, List.map (fun x -> TypeParam x) tparams), (List.combine argument_names ts), csym)) in
+              let purefunc = (full_cn, (lc, tparams, InductiveType (i, List.map (fun tparam -> GhostTypeParam tparam) tparams), (List.combine argument_names ts), csym)) in
               citer (j + 1) ((cn, purefunc)::ctormap) (purefunc::pfm) ctors
             end
         in
@@ -1718,7 +1771,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let rt =
           match rto with
             None -> static_error l "Return type of fixpoint functions cannot be void." None
-          | Some rt -> (check_pure_type (pn,ilist) tparams rt)
+          | Some rt -> (check_pure_type (pn,ilist) tparams rt Ghost)
         in
         if nonghost_callers_only then static_error l "A fixpoint function cannot be marked nonghost_callers_only." None;
         if functype <> None then static_error l "Fixpoint functions cannot implement a function type." None;
@@ -1730,7 +1783,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               [] -> List.rev pmap
             | (te, p)::ps ->
               let _ = if List.mem_assoc p pmap then static_error l "Duplicate parameter name." None in
-              let t = check_pure_type (pn,ilist) tparams te in
+              let t = check_pure_type (pn,ilist) tparams te Ghost in
               iter ((p, t)::pmap) ps
           in
           iter [] ps
@@ -1833,7 +1886,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             match pt with
             | Bool | Void | Int (_, _) | RealType | PtrType _ | ObjType _ | ArrayType _ | BoxIdType | HandleIdType | AbstractType _ -> ()
             | AnyType -> ec_contains_any ptr negative
-            | TypeParam _ -> if negative then static_error l "A type parameter may not appear in a negative position in an inductive datatype definition." None
+            | GhostTypeParam _ | RealTypeParam _ -> if negative then static_error l "A type parameter may not appear in a negative position in an inductive datatype definition." None
             | InductiveType (i0, tps) ->
               List.iter (fun t -> check_type negative t) tps;
               begin match try_assoc i0 welldefined_map with
@@ -1895,7 +1948,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec type_is_inhabited tp =
               match tp with
                 Bool | Int (_, _) | RealType | PtrType _ | ObjType _ | ArrayType _ | BoxIdType | HandleIdType | AnyType -> true
-              | TypeParam _ -> true  (* Should be checked at instantiation site. *)
+              | GhostTypeParam _ | RealTypeParam _ -> true  (* Should be checked at instantiation site. *)
               | PredType (tps, pts, _, _) -> true
               | PureFuncType (t1, t2) -> type_is_inhabited t2
               | InductiveType (i0, tps) ->
@@ -1936,7 +1989,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let rec type_is_infinite tp =
             match tp with
               Bool -> Some []
-            | TypeParam x -> Some [x]
+            | GhostTypeParam x -> Some [x]
             | Int (_, _) | RealType | PtrType _ | PredType (_, _, _, _) | ObjType _ | ArrayType _ | BoxIdType | HandleIdType | AnyType -> None
             | PureFuncType (_, _) -> None (* CAVEAT: This assumes we do *not* have extensionality *)
             | InductiveType (i0, targs) ->
@@ -1959,7 +2012,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   None -> None
                 | Some cond ->
                   let Some tpenv = zip tparams targs in
-                  fold_cond [] (fun x -> type_is_infinite (List.assoc x tpenv)) cond
+                  fold_cond [] (fun x -> type_is_infinite  (List.assoc x tpenv)) cond
                 end
               end
           in
@@ -1979,7 +2032,9 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         (i, (l, tparams, ctors, cond, containsAny))
       end
   
-  let inductivemap = inductivemap1 @ inductivemap0
+  let inductivemap = 
+    inductivemap1 @ 
+    inductivemap0
 
   let rec unfold_inferred_type t =
     match t with
@@ -1994,7 +2049,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let rec type_satisfies_contains_any_constraint allowContainsAnyPositive tp =
     match unfold_inferred_type tp with
       Bool | AbstractType _ | Int (_, _) | Float | Double | LongDouble | RealType | FuncType _ | PtrType _ | ObjType _ | ArrayType _ | BoxIdType | HandleIdType -> true
-    | TypeParam _ -> false (* Assume the worst *)
+    | RealTypeParam _ | GhostTypeParam _ -> false (* Assume the worst *)
     | AnyType | PredType (_, _, _, _) -> allowContainsAnyPositive
     | PureFuncType (t1, t2) -> type_satisfies_contains_any_constraint false t1 && type_satisfies_contains_any_constraint allowContainsAnyPositive t2
     | InductiveType (i, targs) ->
@@ -2041,29 +2096,36 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let rec expect_type_core l msg (inAnnotation: bool option) t t0 =
     match (unfold_inferred_type t, unfold_inferred_type t0) with
-      (ObjType "null", ObjType _) -> ()
-    | (ObjType "null", ArrayType _) -> ()
-    | (ArrayType _, ObjType "java.lang.Object") -> ()
+      (ObjType ("null",[]), ObjType _) -> ()
+    | (ObjType ("null",[]), RealTypeParam _) -> ()
+    | (RealTypeParam t, ObjType("java.lang.Object", [])) -> ()
+    | (GhostTypeParam t, ObjType("java.lang.Object", [])) -> ()
+    | (RealTypeParam t, ObjType _) -> ()
+    | (RealTypeParam t, RealTypeParam t0) -> ()
+    | (ObjType("java.lang.Object", []), RealTypeParam t) -> ()
+    | (ObjType ("null",[]), ArrayType _) -> ()
+    | (ArrayType _, ObjType ("java.lang.Object",[])) -> ()
     (* Note that in Java short[] is not assignable to int[] *)
     | (ArrayType et, ArrayType et0) when et = et0 -> ()
-    | (ArrayType (ObjType objtype), ArrayType (ObjType objtype0)) -> expect_type_core l msg None (ObjType objtype) (ObjType objtype0)
+    | (ArrayType (ObjType (objtype,tpargs)), ArrayType (ObjType (objtype0,tpargs0))) -> expect_type_core l msg None (ObjType (objtype, tpargs)) (ObjType (objtype0,tpargs))
     | (StaticArrayType _, PtrType _) -> ()
     | (Int (Signed, m), Int (Signed, n)) when m <= n -> ()
     | (Int (Unsigned, m), Int (Unsigned, n)) when m <= n -> ()
     | (Int (Unsigned, m), Int (Signed, n)) when m < n -> ()
     | (Int (_, _), Int (_, _)) when inAnnotation = Some true -> ()
-    | (ObjType x, ObjType y) when is_subtype_of x y -> ()
+    | (ObjType (x,_), ObjType (y,_)) when is_subtype_of x y -> ()
     | (PredType ([], ts, inputParamCount, inductiveness), PredType ([], ts0, inputParamCount0, inductiveness0)) ->
       begin
         match zip ts ts0 with
           Some tpairs when List.for_all (fun (t, t0) -> unify t t0) tpairs && (inputParamCount0 = None || inputParamCount = inputParamCount0) -> ()
-        | _ -> static_error l (msg ^ "Type mismatch. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
+        | _ -> static_error l (msg ^ "Type mismatch for predicate. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
       end
     | (PureFuncType (t1, t2), PureFuncType (t10, t20)) -> expect_type_core l msg inAnnotation t10 t1; expect_type_core l msg inAnnotation t2 t20
     | (InductiveType (_, _) as tp, AnyType) -> if not (type_satisfies_contains_any_constraint true tp) then static_error l (msg ^ "Cannot cast type " ^ string_of_type tp ^ " to 'any' because it contains 'any' in a negative position.") None
     | (InductiveType (i1, args1), InductiveType (i2, args2)) when i1 = i2 ->
       List.iter2 (expect_type_core l msg inAnnotation) args1 args2
-    | _ -> if unify t t0 then () else static_error l (msg ^ "Type mismatch. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
+    | _ -> if unify t t0 then ()
+        else static_error l (msg ^ "Type mismatch. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
   
   let expect_type l (inAnnotation: bool option) t t0 = expect_type_core l "" inAnnotation t t0
   
@@ -2076,16 +2138,16 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     if proverType = proverType0 then e else ProverTypeConversion (proverType, proverType0, e)
   
   let box e t t0 =
-    match unfold_inferred_type t0 with TypeParam _ -> convert_provertype_expr e (provertype_of_type t) ProverInductive | _ -> e
+    match unfold_inferred_type t0 with GhostTypeParam _ | RealTypeParam _ -> convert_provertype_expr e (provertype_of_type t) ProverInductive | _ -> e
   
   let unbox e t0 t =
-    match unfold_inferred_type t0 with TypeParam _ -> convert_provertype_expr e ProverInductive (provertype_of_type t) | _ -> e
+    match unfold_inferred_type t0 with GhostTypeParam _ | RealTypeParam _ -> convert_provertype_expr e ProverInductive (provertype_of_type t) | _ -> e
 
   (* A universal type is one that is isomorphic to the universe for purposes of type erasure *)
   let rec is_universal_type tp =
     match tp with
       Bool | AbstractType _ -> false
-    | TypeParam x -> true
+    | GhostTypeParam x | RealTypeParam x -> true
     | Int (_, _) | RealType | PtrType _ | PredType (_, _, _, _) | ObjType _ | ArrayType _ | BoxIdType | HandleIdType | AnyType -> true
     | PureFuncType (t1, t2) -> is_universal_type t1 && is_universal_type t2
     | InductiveType (i0, targs) ->
@@ -2110,14 +2172,14 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         in
         check_tparams_distinct tparams;
         (* The return type cannot mention type parameters. *)
-        let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) [] rt) in
+        let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) [] rt Ghost) in
         let ftxmap =
           let rec iter xm xs =
             match xs with
               [] -> List.rev xm
             | (te, x)::xs ->
               if List.mem_assoc x xm then static_error l "Duplicate function type parameter name." None;
-              let t = check_pure_type (pn,ilist) tparams te in
+              let t = check_pure_type (pn,ilist) tparams te Ghost in
               iter ((x, t)::xm) xs
           in
           iter [] ftxs
@@ -2128,7 +2190,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               [] -> List.rev xm
             | (te, x)::xs ->
               if List.mem_assoc x xm || List.mem_assoc x ftxmap then static_error l "Duplicate parameter name." None;
-              let t = check_pure_type (pn,ilist) tparams te in
+              let t = check_pure_type (pn,ilist) tparams te Ghost in
               iter ((x, t)::xm) xs
           in
           iter [] xs
@@ -2182,12 +2244,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let field_pred_map1 = (* dient om dingen te controleren bij read/write controle v velden*)
     match file_type path with
       Java ->
-      classmap1 |> flatmap begin fun (cn, (_,_,_,_, fds,_,_,_,_,_,_)) ->
+      classmap1 |> flatmap begin fun (cn, (_,_,_,_, fds,_,_,_,_,_,_,_)) ->
         fds |> List.map begin fun (fn, {fl; ft; fbinding}) ->
           let predfam =
             match fbinding with
               Static -> mk_predfam (cn ^ "_" ^ fn) fl [] 0 [ft] (Some 0) Inductiveness_Inductive
-            | Instance -> mk_predfam (cn ^ "_" ^ fn) fl [] 0 [ObjType cn; ft] (Some 1) Inductiveness_Inductive
+            | Instance -> mk_predfam (cn ^ "_" ^ fn) fl [] 0 [ObjType (cn,[]); ft] (Some 1) Inductiveness_Inductive
           in
           ((cn, fn), predfam)
         end
@@ -2214,12 +2276,13 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let rec iter (pn,ilist) pm ds =
       match ds with
         PredFamilyDecl (l, p, tparams, arity, tes, inputParamCount, inductiveness)::ds -> let p=full_name pn p in
-        let ts = List.map (check_pure_type (pn,ilist) tparams) tes in
+        let ts = List.map (fun te -> check_pure_type (pn,ilist) tparams te Ghost) tes in
         begin
           match try_assoc2' Ghost (pn,ilist) p pm predfammap0 with
             Some (l0, tparams0, arity0, ts0, symb0, inputParamCount0, inductiveness0) ->
             let tpenv =
-              match zip tparams0 (List.map (fun x -> TypeParam x) tparams) with
+              match zip tparams0 
+                (List.map (fun tparam -> GhostTypeParam (tparam)) tparams) with
                 None -> static_error l "Predicate family redeclarations declares a different number of type parameters." None
               | Some bs -> bs
             in
@@ -2256,7 +2319,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               if List.mem_assoc x pmap then static_error l "Duplicate parameter name." None;
               if startswith x "old_" then static_error l "Box parameter name cannot start with old_." None;
                if x = "this" then static_error l "Box parameter may not be named \"this\"." None;
-              iter ((x, check_pure_type (pn,ilist) [] te)::pmap) ps
+              iter ((x, check_pure_type (pn,ilist) [] te Ghost)::pmap) ps
           in
           iter [] ps
         in
@@ -2278,7 +2341,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                     if List.mem_assoc x pmap then static_error l "Duplicate action parameter name." None;
                     if startswith x "old_" then static_error l "Action parameter name cannot start with old_." None;
                     if x = "this" then static_error l "Action parameter may not be named \"this\"." None;
-                    iter ((x, check_pure_type (pn,ilist) [] te)::pmap) ps
+                    iter ((x, check_pure_type (pn,ilist) [] te Ghost)::pmap) ps
                 in
                 iter [] ps
               in
@@ -2336,7 +2399,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                     if List.mem_assoc x pmap then static_error l "Duplicate handle predicate parameter name." None;
                     if startswith x "old_" then static_error l "Handle predicate parameter name cannot start with old_." None;
                     if x = "this" then static_error l "Handle predicate parameter may not be named \"this\"." None;
-                    iter ((x, check_pure_type (pn,ilist) [] te)::pmap) ps
+                    iter ((x, check_pure_type (pn,ilist) [] te Ghost)::pmap) ps
                 in
                 iter [] ps
               in
@@ -2372,10 +2435,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let rec iter_interfs interfmap1_done interfmap1_todo =
       match interfmap1_todo with
         [] -> List.rev interfmap1_done
-      | (tn, (li, fields, methods, preds, interfs, pn, ilist))::interfmap1_todo ->
+      | (tn, (li, fields, methods, preds, interfs, pn, ilist, tparams))::interfmap1_todo ->
+        let interfs = List.map (fun (i,tes) -> (i,List.map (fun te -> check_pure_type (pn,ilist) tparams te Real) tes)) interfs in
         let rec iter_preds predmap preds =
           match preds with
-            [] -> iter_interfs ((tn, (li, fields, methods, List.rev predmap, interfs, pn, ilist))::interfmap1_done) interfmap1_todo
+            [] -> iter_interfs ((tn, (li, fields, methods, List.rev predmap, interfs, pn, ilist, tparams))::interfmap1_done) interfmap1_todo
           | InstancePredDecl (l, g, ps, body)::preds ->
             if List.mem_assoc g predmap then static_error l "Duplicate predicate name." None;
             let pmap =
@@ -2384,7 +2448,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   [] -> List.rev pmap
                 | (tp, x)::ps ->
                   if List.mem_assoc x pmap then static_error l "Duplicate parameter name." None;
-                  let tp = check_pure_type (pn,ilist) [] tp in
+                  let tp = check_pure_type (pn,ilist) tparams tp Real in
                   iter ((x, tp)::pmap) ps
               in
               iter [] ps
@@ -2395,18 +2459,19 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   begin match try_assoc tn itfmap with
                     Some info ->
                     let (preds, itfs) = get_preds_and_itfs info in
+                    let itfnames = List.map (fun (f,_) -> f) itfs in
                     begin match try_assoc g preds with
                       Some (l, pmap, family, symb) -> [(family, pmap, symb)]
-                    | None -> flatmap preds_in_itf itfs
+                    | None -> flatmap preds_in_itf itfnames
                     end
                   | None -> fallback ()
                   end
                 in
-                check_itfmap (function (li, fields, methods, preds, interfs, pn, ilist) -> (preds, interfs)) interfmap1_done $. fun () ->
-                check_itfmap (function InterfaceInfo (li, fields, methods, preds, interfs) -> (preds, interfs)) interfmap0 $. fun () ->
+                check_itfmap (function (li, fields, methods, preds, interfs, pn, ilist, tparams) -> (preds, interfs)) interfmap1_done $. fun () ->
+                check_itfmap (function InterfaceInfo (li, fields, methods, preds, interfs, tparams) -> (preds, interfs)) interfmap0 $. fun () ->
                 []
               in
-              match flatmap preds_in_itf interfs with
+              match flatmap preds_in_itf (List.map (fun (f,_) -> f ) interfs) with
                 [] -> (tn, get_unique_var_symb (tn ^ "#" ^ g) (PredType ([], [], None, Inductiveness_Inductive)))
               | [(family, pmap0, symb)] ->
                 if not (for_all2 (fun (x, t) (x0, t0) -> expect_type_core l "Predicate parameter covariance check" (Some true) t t0; true) pmap pmap0) then
@@ -2424,8 +2489,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let rec iter classmap1_done classmap1_todo =
       match classmap1_todo with
         [] -> List.rev classmap1_done
-      | (cn, (lc, abstract, fin, methods, fds_opt, ctors, super, interfs, preds, pn, ilist))::classmap1_todo ->
-        let cont predmap = iter ((cn, (lc, abstract, fin, methods, fds_opt, ctors, super, interfs, List.rev predmap, pn, ilist))::classmap1_done) classmap1_todo in
+      | (cn, (lc, abstract, fin, methods, fds_opt, ctors, super, tparams, interfs, preds, pn, ilist))::classmap1_todo ->
+        let cont predmap = iter ((cn, (lc, abstract, fin, methods, fds_opt, ctors, super, tparams, interfs, List.rev predmap, pn, ilist))::classmap1_done) classmap1_todo in
         let rec iter predmap preds =
           match preds with
             [] -> cont predmap
@@ -2437,7 +2502,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   [] -> List.rev pmap
                 | (tp, x)::ps ->
                   if List.mem_assoc x pmap then static_error l "Duplicate parameter name." None;
-                  let tp = check_pure_type (pn,ilist) [] tp in
+                  let tp = check_pure_type (pn,ilist) tparams tp Real in
                   iter ((x, tp)::pmap) ps
               in
               iter [] ps
@@ -2448,15 +2513,16 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   begin match try_assoc tn itfmap with
                     Some info ->
                     let (preds, itfs) = get_preds_and_itfs info in
+                    let itfnames = List.map (fun (f,_) -> f) itfs in
                     begin match try_assoc g preds with
                       Some (l, pmap, family, symb) -> [(family, pmap, symb)]
-                    | None -> flatmap preds_in_itf itfs
+                    | None -> flatmap preds_in_itf itfnames
                     end
                   | None -> fallback ()
                   end
                 in
-                check_itfmap (function (li, fields, methods, preds, interfs, pn, ilist) -> (preds, interfs)) interfmap1 $. fun () ->
-                check_itfmap (function InterfaceInfo (li, fields, methods, preds, interfs) -> (preds, interfs)) interfmap0 $. fun () ->
+                check_itfmap (function (li, fields, methods, preds, interfs, pn, ilist, tparams) -> (preds, interfs)) interfmap1 $. fun () ->
+                check_itfmap (function InterfaceInfo (li, fields, methods, preds, interfs, tparams) -> (preds, interfs)) interfmap0 $. fun () ->
                 []
               in
               let rec preds_in_class cn =
@@ -2464,23 +2530,23 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let check_classmap classmap proj fallback =
                   begin match try_assoc cn classmap with
                     Some info ->
-                    let (super, interfs, predmap) = proj info in
+                    let ((super,passedTparams), interfs, predmap) = proj info in
                     begin match try_assoc g predmap with
                       Some (l, pmap, family, symb, body) -> [(family, pmap, symb)]
-                    | None -> preds_in_class super @ flatmap preds_in_itf interfs
+                    | None -> preds_in_class super @ flatmap preds_in_itf (List.map (fun (itf,_) -> itf) interfs)
                     end
                   | None -> fallback ()
                   end
                 in
                 check_classmap classmap1_done
-                  (function (lc, abstract, fin, methods, fds_opt, ctors, super, interfs, predmap, pn, ilist) -> (super, interfs, predmap))
+                  (function (lc, abstract, fin, methods, fds_opt, ctors, super, tpenv, interfs, predmap, pn, ilist) -> (super, interfs, predmap))
                   $. fun () ->
                 check_classmap classmap0
                   (function {csuper; cinterfs; cpreds} -> (csuper, cinterfs, cpreds))
                   $. fun () ->
                 []
               in
-              match preds_in_class super @ flatmap preds_in_itf interfs with
+              match preds_in_class ((fun (spr,_) -> spr) super) @ flatmap preds_in_itf (List.map (fun (itf,_) -> itf) interfs) with
                 (* InstancePredDecl currently does not support coinductive declarations. *)
                 [] -> (cn, get_unique_var_symb (cn ^ "#" ^ g) (PredType ([], [], None, Inductiveness_Inductive)))
               | [(family, pmap0, symb)] ->
@@ -2519,7 +2585,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   Some _ -> static_error l "Duplicate parameter name." None
                 | _ -> ()
               end;
-              let t = check_pure_type (pn,ilist) [] te in
+              let t = check_pure_type (pn,ilist) [] te Ghost in
               if not (type_satisfies_contains_any_constraint true t) then static_error (type_expr_loc te) "This type cannot be used as a predicate constructor parameter type because it contains 'any' or a predicate type in a negative position." None;
               iter ((x, t)::pmap) ps
           in
@@ -2535,7 +2601,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   Some _ -> static_error l "Duplicate parameter name." None
                 | _ -> ()
               end;
-              let t = check_pure_type (pn,ilist) [] te in
+              let t = check_pure_type (pn,ilist) [] te Ghost in
               iter ((x, t)::psmap) ((x, t)::pmap) ps
           in
           iter ps1 [] ps2
@@ -2588,19 +2654,19 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     List.map (fun (l, i) -> if not (List.mem i funcnames) then static_error l "No such function name." None; i) is 
   
   let interfmap1 =
-    interfmap1 |> List.map begin function (i, (l, fields, meths, preds, supers, pn, ilist)) ->
+    interfmap1 |> List.map begin function (i, (l, fields, meths, preds, supers, pn, ilist, tparams)) ->
       let fieldmap =
         fields |> List.map begin function Field (fl, fgh, ft, f, _, _, _, finit) ->
-          let ft = check_pure_type (pn,ilist) [] ft in
+          let ft = check_pure_type (pn,ilist) [] ft Real in
           (f, {fl; fgh; ft; fvis=Public; fbinding=Static; ffinal=true; finit; fvalue=ref None})
         end
       in
-      (i, (l, fieldmap, meths, preds, supers, pn, ilist))
+      (i, (l, fieldmap, meths, preds, supers, pn, ilist, tparams))
     end
   
   let rec lookup_class_field cn fn =
     match try_assoc cn classmap1 with
-      Some (_, _, _, _, fds, _, super, itfs, _, _, _) ->
+      Some (_, _, _, _, fds, _, (super, passedTparams), _, itfs, _, _, _) ->
       begin match try_assoc fn fds with
         None when cn = "java.lang.Object" -> None
       | Some f -> Some (f, cn)
@@ -2608,11 +2674,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match lookup_class_field super fn with
         Some _ as result -> result
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) itfs
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (itf,_) -> itf) itfs)
       end
     | None -> 
     match try_assoc cn classmap0 with
-      Some {cfds; csuper; cinterfs} ->
+      Some {cfds; csuper=(csuper,_); cinterfs} ->
       begin match try_assoc fn cfds with
         None when cn = "java.lang.Object" -> None
       | Some f -> Some (f, cn)
@@ -2620,23 +2686,23 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match lookup_class_field csuper fn with
         Some _ as result -> result
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) cinterfs
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (itf,_) -> itf) cinterfs)
       end
     | None ->
     match try_assoc cn interfmap1 with
-      Some (_, fds, _, _, supers, _, _) ->
+      Some (_, fds, _, _, supers, _, _, _) ->
       begin match try_assoc fn fds with
         Some f -> Some (f, cn)
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) supers
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (f,_) -> f) supers)
       end
     | None ->
     match try_assoc cn interfmap0 with
-      Some (InterfaceInfo (_, fds, _, _, supers)) ->
+      Some (InterfaceInfo (_, fds, _, _, supers, _)) ->
       begin match try_assoc fn fds with
         Some f -> Some (f, cn)
       | None ->
-      head_flatmap_option (fun cn -> lookup_class_field cn fn) supers
+      head_flatmap_option (fun cn -> lookup_class_field cn fn) (List.map (fun (f,_) -> f) supers)
       end
     | None ->
     None
@@ -2688,7 +2754,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         if not (List.mem_assoc (methodName, signature) cmeths) then
           static_error l (Printf.sprintf "Internal error: no method '%s(%s)' found in class '%s'" methodName (String.concat ", " (List.map string_of_type signature)) className) None
       end;
-      WMethodCall (l, className, methodName, signature, args, Static)
+      WMethodCall (l, className, methodName, signature, args, Static, [])
     else
     let g = "vf__" ^ prefix ^ "_" ^ fun_name in
     if not (List.mem_assoc g funcmap) then static_error l "Must include header <math.h> when using floating-point operations." None;
@@ -2744,27 +2810,27 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let rec get_methods tn mn =
       if tn = "" then [] else
       match try_assoc tn classmap with
-        Some {cmeths; csuper; cinterfs} ->
+        Some {cmeths; csuper=(csuper,_); cinterfs} ->
         let inherited_methods =
-          get_methods csuper mn @ flatmap (fun ifn -> get_methods ifn mn) cinterfs
+          get_methods csuper mn @ flatmap (fun ifn -> get_methods ifn mn) (List.map (fun (itf,_) -> itf) cinterfs)
         in
         let declared_methods =
           flatmap
-            begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract)) ->
-              if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, fb, v, abstract))] else []
+            begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, tparams)) ->
+              if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, fb, v, abstract, tparams))] else []
             end
             cmeths
         in
         declared_methods @ List.filter (fun (sign, info) -> not (List.mem_assoc sign declared_methods)) inherited_methods
       | None ->
-      let InterfaceInfo (_, fields, meths, _, interfs) = List.assoc tn interfmap in
+      let InterfaceInfo (_, fields, meths, _, interfs, _) = List.assoc tn interfmap in
       let declared_methods = flatmap
-        begin fun ((mn', sign), ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract)) ->
-          if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre, post, epost, terminates, Instance, v, abstract))] else []
+        begin fun ((mn', sign), ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract, tparams)) ->
+          if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre, post, epost, terminates, Instance, v, abstract, tparams))] else []
         end
         meths
       in
-      let inherited_methods = flatmap (fun ifn -> get_methods ifn mn) interfs in
+      let inherited_methods = flatmap (fun ifn -> get_methods ifn mn) (List.map (fun (f,_) -> f) interfs) in
       declared_methods @ List.filter (fun (sign, info) -> not (List.mem_assoc sign declared_methods)) inherited_methods
     in
     (*
@@ -2831,7 +2897,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     match e with
       True l -> (e, boolt, None)
     | False l -> (e, boolt, None)
-    | Null l -> (e, ObjType "null", None)
+    | Null l -> (e, ObjType ("null",[]), None)
     | Var (l, x) ->
       begin
       match try_assoc x tenv with
@@ -2842,7 +2908,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       if language <> Java then cont () else
       let field_of_this =
         match try_assoc "this" tenv with
-        | Some ObjType cn ->
+        | Some ObjType (cn,_) ->
           begin match lookup_class_field cn x with
             None -> None
           | Some ({fgh; ft; fbinding; ffinal; fvalue}, fclass) ->
@@ -3016,7 +3082,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           | _ -> None
         in
         (operation_expr funcmap l t operator w1 w2, t, value)
-      | (ObjType "java.lang.String" as t, _) when operator = Add ->
+      | (ObjType ("java.lang.String",[]) as t, _) when operator = Add ->
         let w2 = checkt e2 t in
         (WOperation (l, operator, [w1; w2], t), t, None)
       | _ -> static_error l ("Operand of addition or subtraction must be pointer, integer, char, short, or real number: t1 "^(string_of_type t1)^" t2 "^(string_of_type t2)) None
@@ -3085,7 +3151,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         (floating_point_fun_call_expr funcmap l Double "of_real" [TypedExpr (e, RealType)], Double, None)
     | ClassLit (l, s) ->
       let s = check_classname (pn, ilist) (l, s) in
-      (ClassLit (l, s), ObjType "java.lang.Class", None)
+      (ClassLit (l, s), ObjType ("java.lang.Class",[]), None)
     | StringLit (l, s) ->
       if inAnnotation = Some true then
         (* TODO: Do the right thing for non-ASCII characters *)
@@ -3094,11 +3160,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         check (InitializerList (l, es))
       else
         begin match language with
-          Java-> (e, ObjType "java.lang.String", None)
+          Java-> (e, ObjType ("java.lang.String", []), None)
         | _ -> (e, (PtrType (Int (Signed, 0))), None)
         end
     | CastExpr (l, te, e) ->
-      let t = check_pure_type (pn,ilist) tparams te in
+      let t = check_pure_type (pn,ilist) tparams te Ghost in
       let w = checkt_cast e t in
       (CastExpr (l, ManifestTypeExpr (type_expr_loc te, t), w), t, None)
     | TypedExpr (w, t) ->
@@ -3121,8 +3187,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       (WVar (l2, x, LocalVar), PtrType pointeeType, None)
     | AddressOf (l, e) -> let (w, t, _) = check e in (AddressOf (l, w), PtrType t, None)
     | CallExpr (l, "getClass", [], [], [LitPat target], Instance) when language = Java ->
-      let w = checkt target (ObjType "java.lang.Object") in
-      (WMethodCall (l, "java.lang.Object", "getClass", [], [w], Instance), ObjType "java.lang.Class", None)
+      let w = checkt target (ObjType ("java.lang.Object", [])) in
+      (WMethodCall (l, "java.lang.Object", "getClass", [], [w], Instance, []), ObjType ("java.lang.Class", []), None)
     | ExprCallExpr (l, e, es) ->
       let (w, t, _) = check e in
       let t = unfold_inferred_type t in
@@ -3137,9 +3203,9 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         if callee_tparams <> [] && targes = [] then
           let targs = List.map (fun _ -> InferredType (object end, ref Unconstrained)) callee_tparams in
           let Some tpenv = zip callee_tparams targs in
-          (targs, tpenv)
+           (targs, tpenv)
         else
-          let targs = List.map (check_pure_type (pn,ilist) tparams) targes in
+          let targs = List.map (fun tp -> check_pure_type (pn,ilist) tparams tp Ghost) targes in
           let tpenv =
             match zip callee_tparams targs with
               None -> static_error l "Incorrect number of type arguments." None
@@ -3163,7 +3229,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ ->
         match (g, es) with
           ("malloc", [SizeofExpr (ls, te)]) ->
-          let t = check_pure_type (pn,ilist) tparams te in
+          let t = check_pure_type (pn,ilist) tparams te Ghost in
           (WFunCall (l, g, [], es), PtrType t, None)
         | _ ->
         match resolve2 (pn,ilist) l g funcmap with
@@ -3189,18 +3255,72 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           static_error l (match language with CLang -> "No such function: " ^ g | Java -> "No such method or function: " ^ g) None
       in
       if language = CLang || classmap = [] then func_call () else
-      let try_qualified_call tn es args fb on_fail =
+      let try_qualified_call tn es args fb real_type_arguments on_fail =
         let ms = get_methods tn g in
         if ms = [] then on_fail () else
         let argtps = List.map (fun e -> let (_, tp, _) = (check e) in tp) args in
+        let ms = List.map (fun (sign, (tn', lm, gh, rt, xmap, pre, post, epost, terminates, fb', v, abstract, tparams)) ->
+            (* Build a list of type arguments, either from the ones that got passed, or the ones you have to assume *)
+            let targenv = 
+              (if gh == Real && (List.length real_type_arguments) > 0 
+                then begin
+                let type_arguments_count = List.length real_type_arguments in
+                let tparams_count = List.length tparams in
+                if type_arguments_count <> tparams_count
+                  then static_error l 
+                    (Printf.sprintf "Wrong amount of type arguments provided for method: %s. Expected: %s Actual: %s" 
+                      g
+                      (string_of_int tparams_count) 
+                      (string_of_int type_arguments_count)
+                     ) None
+                  else List.map2 (fun a b -> (a,b)) tparams real_type_arguments 
+                end
+                else (*Build a list of type arguments, inferred from the signature *)
+                (* Only bother mapping if the amount of arguments given fits the sign, otherwise the method won't be a match anyway*)
+                if (List.length argtps) <> (List.length sign) 
+                  then []
+                  else 
+                  let mappedSign = 
+                    let rec findMapping t t0 = match (t,t0) with 
+                      | (RealTypeParam t,_) -> [Some((t,t0))]
+                      | (ArrayType t, ArrayType t0) -> findMapping t t0
+                      | (ObjType (n,ts), ObjType (n0,ts0)) -> if (List.length ts) <> (List.length ts) 
+                        then static_error l (Printf.sprintf "Passed type is incompatible. Expected %s. Real %s."
+                          (string_of_type (ObjType (n,ts)))
+                          (string_of_type (ObjType (n0, ts0)))) None
+                        else List.concat (List.map2 findMapping ts ts0)
+                      | (_,_) -> [None] in
+                        List.concat (List.map2 findMapping sign argtps) in
+                  let filtered_mapped_sign = List.filter (fun entry -> match entry with | Some(s) -> true | None -> false) mappedSign in
+                    List.map (fun entry -> match entry with Some(s) -> s) filtered_mapped_sign)
+                    (* TODO: we are making assumptions, check the common parent if one type parameter maps on multiple argument types, otherwise something is wrong*)
+            in
+            let rec extract_targs targenv tparams = 
+              match targenv with
+                (p,a)::t -> if (List.mem p tparams) then extract_targs t tparams else a::(extract_targs t (p::tparams))
+                | [] -> [] in
+            let targs = extract_targs targenv [] 
+            in
+           (* Replace the argument types parameters with their concrete type if they are a type parameter *)
+            let rec replace_type t = match t with
+                RealTypeParam t -> begin try List.assoc t targenv with _ ->(* Type argument not provided, erase to object *)
+                    ObjType ("java.lang.Object", []) end
+                | ArrayType t -> ArrayType (replace_type t)
+                | ObjType (n,ts) -> ObjType (n, List.map replace_type ts)
+                | t -> t in
+            let sign' = 
+                List.map replace_type sign in
+            let rt' = match rt with
+              Some(rt) -> replace_type rt
+              | None -> Void
+            in (sign',(tn', lm, gh, rt', xmap, pre, post, epost, terminates, fb', v, abstract,tparams,targs, sign))) ms in
         let ms = List.filter (fun (sign, _) -> is_assignable_to_sign inAnnotation argtps sign) ms in
         let make_well_typed_method m =
           match m with
-          (sign, (tn', lm, gh, rt, xmap, pre, post, epost, terminates, fb', v, abstract)) ->
+          (sign', (tn', lm, gh, rt, xmap, pre, post, epost, terminates, fb', v, abstract, _, targs, sign)) ->
             let (fb, es) = if fb = Instance && fb' = Static then (Static, List.tl es) else (fb, es) in
-            if fb <> fb' then static_error l "Instance method requires target object" None;
-            let rt = match rt with None -> Void | Some rt -> rt in
-            (WMethodCall (l, tn', g, sign, es, fb), rt, None)
+            if fb <> fb' then static_error l "Instance method requires target object" None
+            else (WMethodCall (l, tn', g, sign, es, fb, targs), rt, None)
         in
         begin match ms with
           [] -> static_error l "No matching method" None
@@ -3217,12 +3337,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         Static ->
         begin fun on_fail ->
           match try_assoc "this" tenv with
-            Some (ObjType cn) ->
-            try_qualified_call cn (Var (l, "this")::es) es Instance on_fail
+            Some (ObjType (cn, targs)) ->
+            try_qualified_call cn (Var (l, "this")::es) es Instance targs on_fail
           | _ ->
           match try_assoc current_class tenv with
             Some (ClassOrInterfaceName tn) ->
-            try_qualified_call tn es es Static on_fail
+            try_qualified_call tn es es Static (List.map (fun te -> check_pure_type (pn,ilist) tparams te Real) targes) on_fail
           | _ ->
           on_fail ()
         end $. fun () ->
@@ -3230,21 +3350,31 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | Instance ->
         let arg0e::args = es in
         let (_, arg0tp, _) = check arg0e in
-        let (tn, es, fb) =
+        let (tn, es, fb, obj_type_arguments) =
           match unfold_inferred_type arg0tp with
-            ObjType tn -> (tn, es, Instance)
-          | ClassOrInterfaceName tn -> (tn, List.tl es, Static)
+            ObjType (tn, targs) -> (tn, es, Instance, targs)
+          | ClassOrInterfaceName tn -> (tn, List.tl es, Static, [])
           | _ -> static_error l "Target of method call must be object or class" None
         in
-        try_qualified_call tn es args fb (fun () -> static_error l "No such method" None)
+        try_qualified_call tn es args fb obj_type_arguments (fun () -> static_error l "No such method" None)
       end
     | NewObject (l, cn, args) ->
       begin match resolve Real (pn,ilist) l cn classmap with
         Some (cn, {cabstract}) ->
         if cabstract then
           static_error l "Cannot create instance of abstract class." None
+        else
+          (NewObject (l, cn, args), ObjType (cn,[]), None)
+      | None -> static_error l "No such class" None
+      end
+    | NewGenericObject (l, cn, args, targs) ->
+      begin match resolve Real (pn,ilist) l cn classmap with
+        Some (cn, {cabstract}) ->
+        if cabstract then
+          static_error l "Cannot create instance of abstract class." None
         else 
-          (NewObject (l, cn, args), ObjType cn, None)
+           let targestps = List.map (fun targ -> check_pure_type (pn,ilist) tparams targ Real) targs in
+          (NewGenericObject (l, cn, args, targs), ObjType (cn,targestps), None)
       | None -> static_error l "No such class" None
       end
     | ReadArray(l, arr, index) ->
@@ -3262,11 +3392,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | _ when language = CLang -> static_error l "Target of array access is not an array or pointer." None
       end
     | NewArray (l, te, len) ->
-      let t = check_pure_type (pn,ilist) tparams te in
+      let t = check_pure_type (pn,ilist) tparams te Real in
       ignore $. checkt len intType;
       (e, (ArrayType t), None)
     | NewArrayWithInitializer (l, te, es) ->
-      let t = check_pure_type (pn,ilist) tparams te in
+      let t = check_pure_type (pn,ilist) tparams te Real in
       (e, ArrayType t, None)
     | IfExpr (l, e1, e2, e3) ->
       let w1 = checkcon e1 in
@@ -3340,21 +3470,21 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ -> static_error l "Switch expression operand must be inductive value." None
       end
     | SizeofExpr(l, te) ->
-      let t = check_pure_type (pn,ilist) tparams te in
+      let t = check_pure_type (pn,ilist) tparams te Real in
       (SizeofExpr (l, ManifestTypeExpr (type_expr_loc te, t)), sizeType, None)
     | InstanceOfExpr(l, e, te) ->
-      let t = check_pure_type (pn,ilist) tparams te in
-      let w = checkt e (ObjType "java.lang.Object") in
+      let t = check_pure_type (pn,ilist) tparams te Real in
+      let w = checkt e (ObjType ("java.lang.Object", [])) in
       (InstanceOfExpr (l, w, ManifestTypeExpr (type_expr_loc te, t)), boolt, None)
     | SuperMethodCall(l, mn, args) ->
       let rec get_implemented_instance_method cn mn argtps =
         if cn = "java.lang.Object" then None else
         match try_assoc cn classmap with 
-        | Some {cmeths; csuper} ->
+        | Some {cmeths; csuper=(csuper,_)} ->
           begin try
             let m =
               List.find
-                begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract)) ->
+                begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, tparams)) ->
                   mn = mn' &&  is_assignable_to_sign inAnnotation argtps sign && not abstract
                 end
                 cmeths
@@ -3371,13 +3501,13 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let thistype = try_assoc "this" tenv in
       begin match thistype with
         None -> static_error l "super calls not allowed in static context." None
-      | Some(ObjType(cn)) -> 
+      | Some(ObjType(cn, targs)) -> 
         begin match try_assoc cn classmap with
           None -> static_error l "No matching method." None
-        | Some {csuper} ->
+        | Some {csuper=(csuper,_)} ->
             begin match get_implemented_instance_method csuper mn argtps with
               None -> static_error l "No matching method." None
-            | Some(((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract))) ->
+            | Some(((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, tparams))) ->
               let tp = match rt with Some(tp) -> tp | _ -> Void in
               let rank = match ss with Some (Some (_, rank)) -> Some rank | None -> None in
               (WSuperMethodCall (l, csuper, mn, Var (l, "this") :: wargs, (lm, gh, rt, xmap, pre, post, epost, terminates, rank, v)), tp, None)
@@ -3434,8 +3564,9 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
        * eval_core_cps0 (search for "No other cast allowed by the type
        * checker changes the value").
        *)
-      let (w, t, value) = check_expr_core functypemap funcmap classmap interfmap (pn,ilist) tparams tenv inAnnotation e in
-      let check () = begin match (t, t0) with
+      let (w,t,value) = check_expr_core functypemap funcmap classmap interfmap (pn,ilist) tparams tenv inAnnotation e in
+      let check () =
+        begin match (t, t0) with
         | _ when t = t0 -> w
         | (ObjType _, ObjType _) when isCast -> w
         | (PtrType _, Int (_, _)) when isCast -> w
@@ -3443,7 +3574,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | (Int (_, _), Int (_, _)) when isCast -> w
         | ((Int (_, _)|Float|Double|LongDouble), (Float|Double|LongDouble)) -> floating_point_fun_call_expr funcmap (expr_loc w) t0 ("of_" ^ identifier_string_of_type t) [TypedExpr (w, t)]
         | ((Float|Double|LongDouble), (Int (_, _))) -> floating_point_fun_call_expr funcmap (expr_loc w) t0 ("of_" ^ identifier_string_of_type t) [TypedExpr (w, t)]
-        | (ObjType ("java.lang.Object"), ArrayType _) when isCast -> w
+        | (ObjType ("java.lang.Object", []), ArrayType _) when isCast -> w
         | _ ->
           expect_type (expr_loc e) inAnnotation t t0;
           if try expect_type dummy_loc inAnnotation t0 t; false with StaticError _ -> true then
@@ -3474,8 +3605,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           match params_with_correct_name with
           | [(name, type_)] -> 
             let (_, _, ctormap, _, _) = List.assoc inductive_name inductivemap in
-            let [(cn, (_, (_, tparams, _, parameter_names_and_types, (_, _))) : (string * inductive_ctor_info) )] = ctormap in
-            let Some tpenv = zip tparams targs in
+            let [(cn, (_, (_, cons_tparams, _, parameter_names_and_types, (_, _))) : (string * inductive_ctor_info) )] = ctormap in
+            let Some tpenv = zip cons_tparams targs in
             let type_instantiated = instantiate_type tpenv type_ in
             (WReadInductiveField(l, w, inductive_name, constructor_name, f, targs), type_instantiated, None)
           | [] -> static_error l ("The constructor of the inductive data type '" ^ inductive_name ^ "' does not have any field with name '" ^ f ^ "'.") None
@@ -3501,7 +3632,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         end
       | _ -> static_error l ("Invalid dereference; struct type '" ^ sn ^ "' has not been defined.") None
       end
-    | ObjType cn ->
+    | ObjType (cn, targs) ->
       begin
       match lookup_class_field cn f with
         None -> static_error l ("No such field in class '" ^ cn ^ "'.") None
@@ -3715,7 +3846,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let classmap1 =
     List.map
-      begin fun (cn, (l, abstract, fin, meths, fds, constr, super, interfs, preds, pn, ilist)) ->
+      begin fun (cn, (l, abstract, fin, meths, fds, constr, super, tpenv, interfs, preds, pn, ilist)) ->
         let fds =
           List.map
             begin function
@@ -3727,12 +3858,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             end
             fds
         in
-        (cn, (l, abstract, fin, meths, fds, constr, super, interfs, preds, pn, ilist))
+        (cn, (l, abstract, fin, meths, fds, constr, super, tpenv, interfs, preds, pn, ilist))
       end
       classmap1
   
   let interfmap1 =
-    interfmap1 |> List.map begin fun (itf, (l, fds, meths, preds, interfs, pn, ilist)) ->
+    interfmap1 |> List.map begin fun (itf, (l, fds, meths, preds, interfs, pn, ilist, tparams)) ->
       let fds = fds |> List.map begin function
           (f, ({ft; fbinding=Static; finit=Some e} as fd)) ->
           let e = check_expr_t (pn,ilist) [] [current_class, ClassOrInterfaceName itf] (Some true) e ft in
@@ -3741,7 +3872,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | fd -> fd
         end
       in
-      (itf, (l, fds, meths, preds, interfs, pn, ilist))
+      (itf, (l, fds, meths, preds, interfs, pn, ilist, tparams))
     end
 
   let check_c_initializer (pn,ilist) tparams tenv e tp =
@@ -3856,16 +3987,16 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     and eval_field callers ((cn, fn) as f) =
       if List.mem f callers then raise NotAConstant;
       match try_assoc cn classmap1 with
-        Some (l, abstract, fin, meths, fds, const, super, interfs, preds, pn, ilist) -> eval_field_body (f::callers) (List.assoc fn fds)
+        Some (l, abstract, fin, meths, fds, const, super, tpenv, interfs, preds, pn, ilist) -> eval_field_body (f::callers) (List.assoc fn fds)
       | None ->
       match try_assoc cn classmap0 with
         Some {cfds} -> eval_field_body (f::callers) (List.assoc fn cfds)
       | None ->
       match try_assoc cn interfmap1 with
-        Some (li, fds, meths, preds, interfs, pn, ilist) -> eval_field_body (f::callers) (List.assoc fn fds)
+        Some (li, fds, meths, preds, interfs, pn, ilist, tparams) -> eval_field_body (f::callers) (List.assoc fn fds)
       | None ->
       match try_assoc cn interfmap0 with
-        Some (InterfaceInfo (li, fields, meths, preds, interfs)) -> eval_field_body (f::callers) (List.assoc fn fields)
+        Some (InterfaceInfo (li, fields, meths, preds, interfs, tparams)) -> eval_field_body (f::callers) (List.assoc fn fields)
       | None ->
       assert false
     and eval_field_body callers {fbinding; ffinal; finit; fvalue} =
@@ -3886,8 +4017,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let compute_fields fds is_itf_fields =
       fds |> List.iter (fun (f, fbody) -> try ignore $. eval_field_body [] fbody with NotAConstant -> if is_itf_fields then let {fl} = fbody in static_error fl "Interface field initializer must be constant expression" None)
     in
-    classmap1 |> List.iter (fun (cn, (l, abstract, fin, meths, fds, constr, super, interfs, preds, pn, ilist)) -> compute_fields fds false);
-    interfmap1 |> List.iter (fun (ifn, (li, fds, meths, preds, interfs, pn, ilist)) -> compute_fields fds true)
+    classmap1 |> List.iter (fun (cn, (l, abstract, fin, meths, fds, constr, super, tpenv, interfs, preds, pn, ilist)) -> compute_fields fds false);
+    interfmap1 |> List.iter (fun (ifn, (li, fds, meths, preds, interfs, pn, ilist, tparams)) -> compute_fields fds true)
   
   (* Region: type checking of assertions *)
   
@@ -3945,7 +4076,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | ([], _) -> static_error l "Too many patterns" None
     | (_, []) -> static_error l "Too few patterns" None
   
-  let check_pat (pn,ilist) tparams tenv t p = let (w, tenv') = check_pat_core (pn,ilist) tparams tenv t p in (w, tenv' @ tenv)
+  let check_pat (pn,ilist) tparams tenv t p = 
+  let (w, tenv') = check_pat_core (pn,ilist) tparams tenv t p in (w, tenv' @ tenv)
   
   let rec check_pats (pn,ilist) l tparams tenv ts ps =
     match (ts, ps) with
@@ -3958,11 +4090,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | (_, []) -> static_error l "Too few patterns" None
   
   let get_class_of_this =
-    WMethodCall (dummy_loc, "java.lang.Object", "getClass", [], [WVar (dummy_loc, "this", LocalVar)], Instance)
+    WMethodCall (dummy_loc, "java.lang.Object", "getClass", [], [WVar (dummy_loc, "this", LocalVar)], Instance, [])
   
   let get_class_finality tn = (* Returns ExtensibleClass if tn is an interface *)
     match try_assoc tn classmap1 with
-      Some (lc, abstract, fin, methods, fds_opt, ctors, super, interfs, preds, pn, ilist) ->
+      Some (lc, abstract, fin, methods, fds_opt, ctors, super, tpenv, interfs, preds, pn, ilist) ->
       fin
     | None ->
       match try_assoc tn classmap0 with
@@ -3975,39 +4107,39 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let search_interfmap get_interfs_and_preds interfmap fallback =
         match try_assoc itf interfmap with
           Some info ->
-          let (interfs, preds) = get_interfs_and_preds info in
+          let (interfs, preds, tparams) = get_interfs_and_preds info in
           begin match try_assoc g preds with
-            Some (_, pmap, family, symb) -> [(family, pmap)]
-          | None -> List.flatten (List.map (fun i -> find_in_interf i) interfs)
+            Some (_, pmap, family, symb) -> [(family, pmap, tparams)]
+          | None -> List.flatten (List.map (fun i -> find_in_interf i) (List.map (fun (f,_) -> f) interfs))
           end
         | None -> fallback ()
       in
-      search_interfmap (function (li, fields, meths, preds, interfs, pn, ilist) -> (interfs, preds)) interfmap1 $. fun () ->
-      search_interfmap (function InterfaceInfo (li, fields, meths, preds, interfs) -> (interfs, preds)) interfmap0 $. fun () ->
+      search_interfmap (function (li, fields, meths, preds, interfs, pn, ilist, tparams) -> (interfs, preds, tparams)) interfmap1 $. fun () ->
+      search_interfmap (function InterfaceInfo (li, fields, meths, preds, interfs, tparams) -> (interfs, preds, tparams)) interfmap0 $. fun () ->
       []
     in
     let rec find_in_class cn =
       let search_classmap classmap proj fallback =
         match try_assoc cn classmap with
           Some info ->
-          let (super, interfs, preds) = proj info in
+          let ((super,_), interfs, preds, tparams) = proj info in
           begin match try_assoc g preds with
-            Some (_, pmap, family, symb, body) -> [(family, pmap)]
-          | None -> find_in_class super @ flatmap find_in_interf interfs
+            Some (_, pmap, family, symb, body) -> [(family, pmap, tparams)]
+          | None -> find_in_class super @ flatmap find_in_interf (List.map (fun (itf,_) -> itf) interfs)
           end
         | None -> fallback ()
       in
       search_classmap classmap1
-        (function (_, abstract, fin, methods, fds_opt, ctors, super, interfs, preds, pn, ilist) -> (super, interfs, preds))
+        (function (_, abstract, fin, methods, fds_opt, ctors, super, tpenv, interfs, preds, pn, ilist) -> (super, interfs, preds, tpenv))
         $. fun () ->
       search_classmap classmap0
-        (function {csuper; cinterfs; cpreds} -> (csuper, cinterfs, cpreds))
+        (function {csuper; cinterfs; cpreds; ctpenv} -> (csuper, cinterfs, cpreds, ctpenv))
         $. fun () ->
       []
     in
     begin match find_in_class cn @ find_in_interf cn with
       [] -> error ()
-    | [(family, pmap)] -> check_call family pmap
+    | [(family, pmap, tparams)] -> check_call family pmap tparams
     | _ -> static_error l (Printf.sprintf "Ambiguous instance predicate assertion: multiple predicates named '%s' in scope" g) None
     end
   
@@ -4164,7 +4296,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let (wv, tenv') = check_pat (pn,ilist) tparams tenv t v in
       (WPointsTo (l, wlhs, t, wv), tenv', [])
     | PredAsn (l, p, targs, ps0, ps) ->
-      let targs = List.map (check_pure_type (pn, ilist) tparams) targs in
+      let targs = List.map (fun te -> check_pure_type (pn, ilist) tparams te Ghost) targs in
       begin fun cont ->
          match try_assoc p tenv |> option_map unfold_inferred_type with
            Some (PredType (callee_tparams, ts, inputParamCount, inductiveness)) -> cont (p, false, callee_tparams, [], ts, inputParamCount)
@@ -4172,7 +4304,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           begin match resolve Ghost (pn,ilist) l p predfammap with
             Some (pname, (_, callee_tparams, arity, xs, _, inputParamCount, inductiveness)) ->
             let ts0 = match file_type path with
-              Java-> list_make arity (ObjType "java.lang.Class")
+              Java-> list_make arity (ObjType ("java.lang.Class",[]))
             | _   -> list_make arity (PtrType Void)
             in
             cont (pname, true, callee_tparams, ts0, xs, inputParamCount)
@@ -4196,9 +4328,9 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               in
               begin match try_assoc "this" tenv with
                 None -> error ()
-              | Some (ObjType cn) ->
-                let check_call family pmap =
-                  if targs <> [] then static_error l "Incorrect number of type arguments." None;
+              | Some (ObjType (cn, otargs)) ->
+                let check_call family pmap tparams =
+                  if targs <> otargs then static_error l "Incorrect number of type arguments." None;
                   if ps0 <> [] then static_error l "Incorrect number of indices." None;
                   let (wps, tenv) = check_pats (pn,ilist) l tparams tenv (List.map snd pmap) ps in
                   let index =
@@ -4237,10 +4369,23 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | InstPredAsn (l, e, g, index, pats) ->
       let (w, t) = check_expr (pn,ilist) tparams tenv (Some true) e in
       begin match unfold_inferred_type t with
-        ObjType cn ->
-        let check_call family pmap =
-          let (wpats, tenv) = check_pats (pn,ilist) l tparams tenv (List.map snd pmap) pats in
-          let index = check_expr_t (pn,ilist) tparams tenv (Some true) index (ObjType "java.lang.Class") in
+        ObjType (cn, targs) ->
+        let check_call family pmap tparams =
+          let ptps = List.map snd pmap in
+          let tpenv = 
+            if (List.length targs > 0) then (if (List.length tparams) <> (List.length targs) 
+            then static_error l (Printf.sprintf "Wrong amount of type arguments provided. Expected: %s Actual %s." (string_of_int (List.length tparams)) (string_of_int (List.length targs))) None
+            else List.map2 (fun a b -> (a,b)) tparams targs) else [] in
+          (* We know both type params and type arguments here, if possible fill them in *)
+          let rec replaceTypeParams t = match t with 
+            GhostTypeParam t -> (try List.assoc t tpenv with _ -> GhostTypeParam t)
+            | ObjType (s,ts) -> ObjType (s, List.map replaceTypeParams ts)
+            | InductiveType (s,ts) -> InductiveType (s, List.map replaceTypeParams ts)
+            | PredType (s,ts,o,i) -> PredType (s, List.map replaceTypeParams ts, o, i)
+            | PureFuncType (a,b) -> PureFuncType (replaceTypeParams a, replaceTypeParams b)
+            | t -> t  in
+          let (wpats, tenv) = check_pats (pn,ilist) l tparams tenv (List.map replaceTypeParams ptps) pats in
+          let index = check_expr_t (pn,ilist) tparams tenv (Some true) index (ObjType ("java.lang.Class", [])) in
           (WInstPredAsn (l, Some w, cn, get_class_finality cn, family, g, index, wpats), tenv, [])
         in
         let error () = static_error l (Printf.sprintf "Type '%s' does not declare such a predicate" cn) None in
@@ -4295,7 +4440,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                     | (t::ts, x::xs) ->
                       if List.mem_assoc x tenv then static_error lc ("Pattern variable '" ^ x ^ "' hides existing local variable '" ^ x ^ "'.") None;
                       let _ = if List.mem_assoc x xmap then static_error lc "Duplicate pattern variable." None in
-                      let xInfo = match unfold_inferred_type t with TypeParam x -> Some (provertype_of_type (List.assoc x tpenv)) | _ -> None in
+                      let xInfo = match unfold_inferred_type t with 
+                        GhostTypeParam x -> Some (provertype_of_type (List.assoc x tpenv)) | _ -> None in
                       iter ((x, instantiate_type tpenv t)::xmap) (xInfo::xsInfo) ts xs
                     | ([], _) -> static_error lc "Too many pattern variables." None
                     | _ -> static_error lc "Too few pattern variables." None
@@ -4315,7 +4461,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | ForallAsn (l, te, i, e) -> 
       begin match try_assoc i tenv with
         None -> 
-          let t = check_pure_type (pn,ilist) tparams te in
+          let t = check_pure_type (pn,ilist) tparams te Ghost in
           let w = check_expr_t (pn,ilist) tparams ((i, t) :: tenv) (Some true) e boolt in
           (ForallAsn(l, ManifestTypeExpr(l, t), i, w), tenv, [])
       | Some _ -> static_error l ("bound variable " ^ i ^ " hides existing local variable " ^ i) None
@@ -4576,9 +4722,10 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       structmap1
   
   let check_predinst0 predfam_tparams arity ps psymb inputParamCount (pn, ilist) tparams tenv env l p predinst_tparams fns xs body =
+    let tparams' = predinst_tparams @ tparams in
     check_tparams l tparams predinst_tparams;
     let tpenv =
-      match zip predfam_tparams (List.map (fun x -> TypeParam x) predinst_tparams) with
+      match zip predfam_tparams (List.map (fun x -> GhostTypeParam x) predinst_tparams) with
         None -> static_error l "Number of type parameters does not match predicate family." None
       | Some bs -> bs
     in
@@ -4588,13 +4735,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         None -> static_error l "Incorrect number of parameters." None
       | Some pxs -> pxs
     in
-    let tparams' = predinst_tparams @ tparams in
     let xs =
       let rec iter2 xm pxs =
         match pxs with
           [] -> List.rev xm
         | (t0, (te, x))::xs -> 
-          let t = check_pure_type (pn,ilist) tparams' te in
+          let t = check_pure_type (pn,ilist) tparams' te Ghost in
           expect_type l (Some true) t (instantiate_type tpenv t0);
           if List.mem_assoc x tenv then static_error l ("Parameter '" ^ x ^ "' hides existing local variable '" ^ x ^ "'.") None;
           if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
@@ -4651,7 +4797,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     in
     iter' predinstmap1 ps
   
-  let predinstmap = predinstmap1 @ predinstmap0
+  let predinstmap = predinstmap1 @ 
+    predinstmap0
   
   let predctormap1 =
     List.map
@@ -4679,12 +4826,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let classmap1 =
     classmap1 |> List.map
-      begin fun (cn, (lc, abstract, fin, methods, fds_opt, ctors, super, interfs, preds, pn, ilist)) ->
+      begin fun (cn, (lc, abstract, fin, methods, fds_opt, ctors, super, tpenv, interfs, preds, pn, ilist)) ->
         let preds =
           preds |> List.map
             begin function
               (g, (l, pmap, family, symb, Some body)) ->
-              let tenv = (current_class, ClassOrInterfaceName cn)::("this", ObjType cn)::pmap in
+              let tenv = (current_class, ClassOrInterfaceName cn)::("this", ObjType (cn, []))::pmap in
               let (wbody, _) = check_asn (pn,ilist) [] tenv body in
               let fixed = check_pred_precise ["this"] wbody in
               List.iter
@@ -4696,7 +4843,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             | pred -> pred
             end
         in
-        (cn, (lc, abstract, fin, methods, fds_opt, ctors, super, interfs, preds, pn, ilist))
+        (cn, (lc, abstract, fin, methods, fds_opt, ctors, super, tpenv, interfs, preds, pn, ilist))
       end
   
   (* Region: evaluation helpers; pushing and popping assumptions and execution trace elements *)
@@ -4871,16 +5018,16 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let calculate_ancestry_intfmap0 already_calculated_ancestries (clinfname, info) =
       let super_clintf =
         match info with
-          InterfaceInfo (_, _, _, _, intfs) ->
-            (intfs, false, false)
+          InterfaceInfo (_, _, _, _, intfs,_) ->
+            ((List.map (fun (f,_) -> f) intfs), false, false)
       in
       calculate_ancestry_from_direct_ancesters_info already_calculated_ancestries clinfname super_clintf
     in
     let calculate_ancestry_intfmap1 already_calculated_ancestries (clinfname, info) =
       let super_clintf =
         match info with
-          (_, _, _, _, intfs, _, _) ->
-            (intfs, false, false)
+          (_, _, _, _, intfs, _, _,_) ->
+            ((List.map (fun (f,_) -> f) intfs), false, false)
       in
       calculate_ancestry_from_direct_ancesters_info already_calculated_ancestries clinfname super_clintf
     in
@@ -4889,14 +5036,16 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let iafc =
           if info.cfinal = FinalClass then true else false
         in
-        if info.csuper = "" then (info.cinterfs, true, iafc) else ((info.csuper :: info.cinterfs), true, iafc) (* super class of Java.lang.Object is registered as "" *)
+        let (csuper,passedTparams) = info.csuper in
+        if csuper = "" then ((List.map (fun (itf,_) -> itf) info.cinterfs), true, iafc) else ((csuper :: (List.map (fun (itf,_) -> itf) info.cinterfs)), true, iafc) (* super class of Java.lang.Object is registered as "" *)
       in
       calculate_ancestry_from_direct_ancesters_info already_calculated_ancestries clinfname super_clintf
     in
     let calculate_ancestry_classmap1 already_calculated_ancestries (clinfname, info) =
       let super_clintf =
         match info with
-          (_, _, fin, _, _, _, spr, intfs, _, _, _) ->
+          (_, _, fin, _, _, _, (spr,passedTparams), _, intfs, _, _, _) ->
+            let intfs = (List.map (fun (itf,_) -> itf) intfs) in
             let iafc =
               if fin = FinalClass then true else false
             in
@@ -4949,7 +5098,10 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         calculate_all_ancestries anc_intfmap0_intfmap1 classmap0 calculate_ancestry_classmap0
       in
       let anc_intfmap0_intfmap1_classmap0_classmap1 =
-        calculate_all_ancestries anc_intfmap0_intfmap1_classmap0 classmap1 calculate_ancestry_classmap1
+        calculate_all_ancestries 
+          anc_intfmap0_intfmap1_classmap0 
+          classmap1 
+          calculate_ancestry_classmap1
       in
       anc_intfmap0_intfmap1_classmap0_classmap1
     in
@@ -5158,7 +5310,7 @@ let check_if_list_is_defined () =
 
   let rec prover_type_term l tp = 
     match tp with
-      ObjType(n) -> 
+      ObjType(n, _) -> 
       begin match try_assoc n classterms with
         None -> (match try_assoc n interfaceterms with None -> static_error l ("unknown prover_type_expr for: " ^ (string_of_type tp)) None | Some(t) -> t)
       | Some(t) -> t
@@ -5370,10 +5522,10 @@ let check_if_list_is_defined () =
       if ass_term = None then static_error l "String literals are not allowed in ghost code." None;
       cont state
         begin match file_type path with
-          Java -> get_unique_var_symb "stringLiteral" (ObjType "java.lang.String")
+          Java -> get_unique_var_symb "stringLiteral" (ObjType ("java.lang.String", []))
         | _ -> get_unique_var_symb "stringLiteral" (PtrType (Int (Signed, 0)))
         end
-    | WMethodCall (l, "java.lang.Object", "getClass", [], [target], Instance) ->
+    | WMethodCall (l, "java.lang.Object", "getClass", [], [target], Instance, []) ->
       ev state target $. fun state t ->
       cont state (ctxt#mk_app get_class_symbol [t])
     | WPureFunCall (l, g, targs, args) ->
@@ -5584,7 +5736,7 @@ let check_if_list_is_defined () =
                   List.map
                     (fun ((pat, term), typ) ->
                      match unfold_inferred_type typ with
-                       TypeParam x -> (pat, convert_provertype term ProverInductive (provertype_of_type (List.assoc x tpenv)))
+                       GhostTypeParam x -> (pat, convert_provertype term ProverInductive (provertype_of_type (List.assoc x tpenv)))
                      | _ -> (pat, term)
                     )
                     penv
@@ -5647,7 +5799,7 @@ let check_if_list_is_defined () =
                     (fun ((x, term), (name, typ)) ->
                      let term =
                      match unfold_inferred_type typ with
-                       TypeParam x -> convert_provertype term ProverInductive (provertype_of_type (List.assoc x tpenv))
+                       GhostTypeParam x -> convert_provertype term ProverInductive (provertype_of_type (List.assoc x tpenv))
                      | _ -> term
                      in
                      (x, term)
@@ -5661,7 +5813,7 @@ let check_if_list_is_defined () =
            cs
        in
        ctxt#set_fpclauses fsym i clauses
-     | (g, (l, t, pmap, None, w, pn, ilist, fsym)) ->
+         | (g, (l, t, pmap, None, w, pn, ilist, fsym)) ->
        ctxt#begin_formal;
        let env = imap (fun i (x, tp) -> let pt = typenode_of_type tp in (pt, (x, ctxt#mk_bound i pt))) pmap in
        let tps = List.map fst env in

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -3313,14 +3313,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           (* Replace the type parameters with their concrete type*)
           let rec replace_type t = match t with
             RealTypeParam t -> begin try List.assoc t targenv with Not_found -> static_error l 
-            (Printf.sprintf "Type arguments for %s.%s with type param %s not provided. Class_targs: %s and class_tparams: %s. function binding: %s \n"
-              tn
-              g
-              t
-              (String.concat ", " (List.map string_of_type class_targs))
-              (String.concat ", " class_tparams)
-              (if fb = Instance then "Instance" else "static")
-            ) None end
+            (Printf.sprintf "Type arguments for %s.%s with type param %s not provided." tn g t) None end
             | ArrayType t -> ArrayType (replace_type t)
             | ObjType (n,ts) -> ObjType (n, List.map replace_type ts)
             | t -> t in

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -979,9 +979,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       not (List.mem erasedSign erased_implemented_methods)) erased_inherited_unimplemented_methods @ abstract_methods
   
   let () =
-    if not is_jarspec then
-    classmap1 |> List.iter begin 
-    function (cn, {cl; cabstract}) ->
+    if not is_jarspec then classmap1 |> List.iter begin function (cn, {cl; cabstract}) ->
       if not cabstract then begin
         match unimplemented_class_methods (cn, []) false with
           [] -> ()

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -9,6 +9,8 @@ open Parser
 open Verifast0
 open Verifast1
 open Assertions
+(*open SExpressions
+open SExpressionEmitter*)
 
 module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
@@ -38,7 +40,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | ExprCallExpr (l, e, es) -> flatmap expr_assigned_variables (e::es)
     | WPureFunCall (l, g, targs, args) -> flatmap expr_assigned_variables args
     | WPureFunValueCall (l, e, es) -> flatmap expr_assigned_variables (e::es)
-    | WMethodCall (l, cn, m, pts, args, mb) -> flatmap expr_assigned_variables args
+    | WMethodCall (l, cn, m, pts, args, mb, sign) -> flatmap expr_assigned_variables args
     | NewArray (l, te, e) -> expr_assigned_variables e
     | NewArrayWithInitializer (l, te, es) -> flatmap expr_assigned_variables es
     | IfExpr (l, e1, e2, e3) -> expr_assigned_variables e1 @ expr_assigned_variables e2 @ expr_assigned_variables e3
@@ -111,7 +113,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
 
   let current_thread_name = "currentThread"
   let current_thread_type = intType
-  
+
   (* Region: function contracts *)
   
   let functypemap1 =
@@ -180,7 +182,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let tpenv =
       match zip tparams tparams0 with
         None -> static_error l (msg ^ "Type parameter counts do not match.") None
-      | Some bs -> List.map (fun (x, x0) -> (x, TypeParam x0)) bs
+      | Some bs -> List.map (fun (x, x0) -> (x, GhostTypeParam x0)) bs
     in
     begin
       match (rt, rt0) with
@@ -271,7 +273,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     if terminates && k <> Regular then static_error l "Terminates clause not allowed here." None;
     check_tparams l tparams0 tparams;
     let tparams1 = tparams0 @ tparams in
-    let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) tparams1 rt) in
+    let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) tparams1 rt Ghost) in
     let xmap =
       let rec iter xm xs =
         match xs with
@@ -279,7 +281,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | (te, x)::xs ->
           if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
           if List.mem_assoc x tenv0 then static_error l ("Parameter '" ^ x ^ "' hides existing variable '" ^ x ^ "'.") None;
-          let t = check_pure_type (pn,ilist) tparams1 te in
+          let t = check_pure_type (pn,ilist) tparams1 te Ghost in
           let t =
             match t with
               ArrayType elemType | StaticArrayType (elemType, _) when language = CLang -> PtrType elemType
@@ -320,7 +322,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           match resolve Real (pn,ilist) l ftn functypemap with
             None -> static_error l "No such function type." None
           | Some (ftn, (lft, gh, fttparams, rt0, ftxmap0, xmap0, pre0, post0, terminates0, ft_predfammaps)) ->
-            let fttargs = List.map (check_pure_type (pn,ilist) []) fttargs in
+            let fttargs = List.map (fun te -> check_pure_type (pn,ilist) [] te Ghost) fttargs in
             let fttpenv =
               match zip fttparams fttargs with
                 None -> static_error l "Incorrect number of function type type arguments" None
@@ -420,47 +422,54 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let interfmap1 =
     List.map
-      begin fun (ifn, (l, fieldmap, specs, preds, interfs, pn, ilist)) ->
+      begin fun (ifn, (l, fieldmap, specs, preds, interfs, pn, ilist, tparams)) ->
         let mmap =
         let rec iter mmap meth_specs =
           match meth_specs with
             [] -> List.rev mmap
-          | Meth (lm, gh, rt, n, ps, co, body, binding, _, _)::meths ->
-            if body <> None then static_error lm "Interface method cannot have body" None;
-            if binding = Static then static_error lm "Interface method cannot be static" None;
+          | Meth (lm, gh, rt, n, ps, co, body, binding, _, _, tparams)::meths ->
             let xmap =
               let rec iter xm xs =
                 match xs with
                  [] -> List.rev xm
                | (te, x)::xs ->
                  if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
-                 let t = check_pure_type (pn,ilist) [] te in
+                 let t = check_pure_type (pn,ilist) tparams te Real in
                  iter ((x, t)::xm) xs
               in
               iter [] ps
             in
             let sign = (n, List.map snd (List.tl xmap)) in
             if List.mem_assoc sign mmap then static_error lm "Duplicate method" None;
-            let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) [] rt) in
+            let erasedSign = (n, List.map (fun t -> match t with 
+              RealTypeParam _ -> ObjType ("java.lang.Object",[])
+              | t -> t) (List.map snd xmap)) in
+            let erasedMmap = List.map (fun ((n,ts),minfo) -> 
+              let erasedTypes = List.map (fun t -> match t with 
+                RealTypeParam _ -> ObjType ("java.lang.Object", []) 
+                | t -> t) ts in
+              ((n,erasedTypes),minfo)) mmap in
+            if List.mem_assoc erasedSign erasedMmap then static_error lm "Duplicate method after erasure." None;
+            let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) tparams rt Real) in
             let (pre, pre_tenv, post, epost, terminates) =
               match co with
                 None -> static_error lm ("Non-fixpoint function must have contract: "^n) None
               | Some (pre, post, epost, terminates) ->
-                let (pre, tenv) = check_asn (pn,ilist) [] ((current_thread_name, current_thread_type)::xmap) pre in
+                let (pre, tenv) = check_asn (pn,ilist) [] ((current_thread_name, current_thread_type)::(xmap)) pre in
                 let postmap = match rt with None -> tenv | Some rt -> ("result", rt)::tenv in
                 let (post, _) = check_asn (pn,ilist) [] postmap post in
                 let epost = List.map (fun (tp, epost) -> 
                   let (epost, _) = check_asn (pn,ilist) [] tenv epost in
-                  let tp = check_pure_type (pn,ilist) [] tp in
+                  let tp = check_pure_type (pn,ilist) [] tp Ghost in
                   (tp, epost)
                 ) epost in
                 (pre, tenv, post, epost, terminates)
             in
-            iter ((sign, ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, Public, true))::mmap) meths
+            iter ((sign, ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, Public, true, tparams))::mmap) meths
         in
         iter [] specs
         in
-        (ifn, InterfaceInfo (l, fieldmap, mmap, preds, interfs))
+        (ifn, InterfaceInfo (l, fieldmap, mmap, preds, interfs, tparams))
       end
       interfmap1
   
@@ -468,10 +477,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     Printf.sprintf "%s(%s)" mn (String.concat ", " (List.map string_of_type ts))
   
   let () = (* Check interfaces in .java files against their specifications in .javaspec files. *)
-    interfmap1 |> List.iter begin function (i, InterfaceInfo (l1,fields1,meths1,preds1,interfs1)) ->
+    interfmap1 |> List.iter begin function (i, InterfaceInfo (l1,fields1,meths1,preds1,interfs1,tparams1)) ->
       match try_assoc i interfmap0 with
       | None -> ()
-      | Some (InterfaceInfo (l0,fields0,meths0,preds0,interfs0)) ->
+      | Some (InterfaceInfo (l0,fields0,meths0,preds0,interfs0, tparams0)) ->
         let rec match_fields fields0 fields1 =
           match fields0 with
             [] -> if fields1 <> [] then static_error l1 ".java file does not correct implement .javaspec file: interface declares more fields" None
@@ -486,10 +495,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let rec match_meths meths0 meths1=
           match meths0 with
             [] -> if meths1 <> [] then static_error l1 ".java file does not correctly implement .javaspec file: interface declares more methods" None
-          | (sign, ItfMethodInfo (lm0,gh0,rt0,xmap0,pre0,pre_tenv0,post0,epost0,terminates0,v0,abstract0))::meths0 ->
+          | (sign, ItfMethodInfo (lm0,gh0,rt0,xmap0,pre0,pre_tenv0,post0,epost0,terminates0,v0,abstract0, tparams0))::meths0 ->
             match try_assoc sign meths1 with
               None-> static_error l1 (".java file does not correctly implement .javaspec file: interface does not declare method " ^ string_of_sign sign) None
-            | Some (ItfMethodInfo (lm1,gh1,rt1,xmap1,pre1,pre_tenv1,post1,epost1,terminates1,v1,abstract1)) ->
+            | Some (ItfMethodInfo (lm1,gh1,rt1,xmap1,pre1,pre_tenv1,post1,epost1,terminates1,v1,abstract1, tparams1)) ->
               let (mn, _) = sign in
               check_func_header_compat lm1 ("Method '" ^ mn ^ "'") "Method specification check" [] (func_kind_of_ghostness gh1,[],rt1, xmap1,false, pre1, post1, epost1, terminates1) (func_kind_of_ghostness gh0, [], rt0, xmap0, false, [], [], pre0, post0, epost0, terminates1);
               match_meths meths0 (List.remove_assoc sign meths1)
@@ -500,19 +509,43 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let interfmap = (* checks overriding methods in interfaces *)
     let rec iter map0 map1 =
-      let interf_specs_for_sign sign itf =
-                    let InterfaceInfo (_, fields, meths, _,  _) = List.assoc itf map1 in
-                    match try_assoc sign meths with
-                      None -> []
-                    | Some spec -> [(itf, spec)]
+      let interf_specs_for_sign sign (itf, passedTypes) =
+        let InterfaceInfo (_, fields, meths, _, _, tparams) = List.assoc itf map1 in
+        let innterTparamEnv = List.map2 (fun a b -> (a,b)) tparams passedTypes in
+        let eraseSign = (fun (n,args) -> (n, List.map (fun arg -> match arg with
+          RealTypeParam(t) -> ObjType("java.lang.Object", [])
+          | t -> t) args)) in
+        let erasedMeths = List.map (fun (sign,info) -> (eraseSign sign,info)) meths (*Erase the signs of the super methods *)
+        in
+          match try_assoc (eraseSign sign) erasedMeths with
+            None -> []
+            (* Update specs to properly apply the childs tparams *)
+            | Some ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', tparams') ->
+              (*Map type params to the scope of the child class *)
+              let rt' = match rt' with 
+                Some(RealTypeParam t) -> let outerType = List.assoc t innterTparamEnv in Some(outerType)
+                | t -> t in
+              let xmap' = List.map (
+                fun (name,t) -> match t with
+                  RealTypeParam(t) -> (name, let outerType = List.assoc t innterTparamEnv in outerType)
+                  | t -> (name,t)
+                ) xmap' in
+              let spec = ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', tparams') in
+              [(itf, spec)]
       in
       match map0 with
         [] -> map1
-      | (i, InterfaceInfo (l,fields,meths,preds,interfs)) as elem::rest ->
-        List.iter (fun (sign, ItfMethodInfo (lm,gh,rt,xmap,pre,pre_tenv,post,epost,terminates,v,abstract)) ->
-          let superspecs = List.flatten (List.map (fun i -> (interf_specs_for_sign sign i)) interfs) in
-          List.iter (fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract')) ->
-            if rt <> rt' then static_error lm "Return type does not match overridden method" None;
+      | (i, InterfaceInfo (l,fields,meths,preds,interfs, tparams)) as elem::rest ->
+        List.iter (fun (sign, ItfMethodInfo (lm,gh,rt,xmap,pre,pre_tenv,post,epost,terminates,v,abstract, tparams)) ->
+          let superspecs = List.flatten (List.map (fun i -> interf_specs_for_sign sign i) interfs) in
+          List.iter (fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', tparams')) ->
+            if rt <> rt' then 
+              static_error lm ("Return type (" 
+              ^ (match rt with None-> "void" | Some(rt) -> string_of_type rt) 
+              ^ ") does not match overridden method(" 
+              ^ (match rt' with None -> "void" | Some(rt') -> string_of_type rt') 
+              ^ ")"
+              ) None;
             if gh <> gh' then
                   begin match gh with
                     Ghost -> static_error lm "A lemma method cannot implement or override a non-lemma method." None
@@ -566,21 +599,45 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let rank_counter = ref 0
 
+  let rec erased_type t =
+    match t with 
+    RealTypeParam t | GhostTypeParam t -> ObjType("java.lang.Object",[])
+    | ObjType (s,ts) -> ObjType (s,List.map erased_type ts)
+    | t -> t
+
   let classmap1 =
     let rec iter classmap1_done classmap1_todo =
-      let interf_specs_for_sign sign itf =
-        let InterfaceInfo (_, _, meths, _,  _) = List.assoc itf interfmap in
-        match try_assoc sign meths with
-          None -> []
-        | Some spec -> [(itf, spec)]
+      let interf_specs_for_sign sign (itf, passedTypes) =
+        let InterfaceInfo (_, fields, meths, _, _, tparams) = List.assoc itf interfmap in
+        let innterTparamEnv = List.map2 (fun a b -> (a,b)) tparams passedTypes in
+        let eraseSign = (fun (n,args) -> (n, List.map (fun arg -> match arg with
+          RealTypeParam(t) -> ObjType("java.lang.Object", [])
+          | t -> t) args)) in
+        let erasedMeths = List.map (fun (sign,info) -> (eraseSign sign,info)) meths (*Erase the signs of the super methods *)
+        in
+          match try_assoc (eraseSign sign) erasedMeths with
+            None -> []
+            (* Update specs to properly apply the childs tparams *)
+            | Some ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', tparams') ->
+              (*Map type params to the scope of the child class *)
+              let rt' = match rt' with 
+                Some(RealTypeParam t) -> let outerType = List.assoc t innterTparamEnv in Some(outerType)
+                | t -> t in
+              let xmap' = List.map (
+                fun (name,t) -> match t with
+                  RealTypeParam(t) -> (name, let outerType = List.assoc t innterTparamEnv in outerType)
+                  | t -> (name,t)
+                ) xmap' in
+              let spec = ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', tparams') in
+              [(itf, spec)]
       in
-      let rec super_specs_for_sign sign cn itfs =
+      let rec super_specs_for_sign sign (cn,_) itfs =
         class_specs_for_sign sign cn @ flatmap (interf_specs_for_sign sign) itfs
       and class_specs_for_sign sign cn =
         if cn = "" then [] else
         let (super, interfs, mmap) =
           match try_assoc cn classmap1_done with
-            Some (l, abstract, fin, mmap, fds, constr, super, interfs, preds, pn, ilist) -> (super, interfs, mmap)
+            Some (l, abstract, fin, mmap, fds, constr, super, tpenv, interfs, preds, pn, ilist) -> (super, interfs, mmap)
           | None ->
             match try_assoc cn classmap0 with
               Some {csuper; cinterfs; cmeths} -> (csuper, cinterfs, cmeths)
@@ -588,33 +645,41 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         in
         let specs =
           match try_assoc sign mmap with
-          | Some (MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, _, abstract)) -> [(cn, ItfMethodInfo (lm, gh, rt, xmap, pre_dyn, pre_tenv, post_dyn, epost_dyn, terminates, v, abstract))]
+          | Some (MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, _, abstract, tparams)) -> [(cn, ItfMethodInfo (lm, gh, rt, xmap, pre_dyn, pre_tenv, post_dyn, epost_dyn, terminates, v, abstract, tparams))]
           | _ -> []
         in
-        specs @ super_specs_for_sign sign super interfs
+        specs @ super_specs_for_sign sign 
+        super 
+        interfs
       in
       match classmap1_todo with
         [] -> List.rev classmap1_done
-      | (cn, (l, abstract, fin, meths, fds, constr, super, interfs, preds, pn, ilist))::classmap1_todo ->
+      | (cn, (l, abstract, fin, meths, fds, constr, super, tpenv, interfs, preds, pn, ilist))::classmap1_todo ->
         let cont cl = iter (cl::classmap1_done) classmap1_todo in
         let rec iter mmap meths =
           match meths with
-            [] -> cont (cn, (l, abstract, fin, List.rev mmap, fds, constr, super, interfs, preds, pn, ilist))
-          | Meth (lm, gh, rt, n, ps, co, ss, fb, v,abstract)::meths ->
+            [] -> cont (cn, (l, abstract, fin, List.rev mmap, fds, constr, super, tpenv, interfs, preds, pn, ilist))
+          | Meth (lm, gh, rt, n, ps, co, ss, fb, v,abstract, tparams)::meths ->
             let xmap =
                 let rec iter xm xs =
                   match xs with
                    [] -> List.rev xm
                  | (te, x)::xs -> if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
-                     let t = check_pure_type (pn,ilist) [] te in
+                     let t = check_pure_type (pn,ilist) tparams te Real in
                      iter ((x, t)::xm) xs
                 in
                 iter [] ps
             in
             let xmap1 = match fb with Static -> xmap | Instance -> let _::xmap1 = xmap in xmap1 in
-            let sign = (n, List.map snd xmap1) in
+            let sign = (n,List.map snd xmap1) in
             if List.mem_assoc sign mmap then static_error lm "Duplicate method." None;
-            let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) [] rt) in
+            (* Apply type erasure to sign that is used to check for duplicate methods after erasure*)
+            let erasedSign = (n, List.map erased_type (List.map snd xmap1)) in
+            let erasedMmap = List.map (fun ((n,ts),minfo) -> 
+              let erasedTypes = List.map erased_type ts in
+              ((n,erasedTypes),minfo)) mmap in
+            if List.mem_assoc erasedSign erasedMmap then static_error lm "Duplicate method after erasure." None;
+            let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn,ilist) tparams rt Real) in
             let co =
               match co with
                 None -> None
@@ -624,7 +689,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 let (wpost, _) = check_asn (pn,ilist) [] postmap post in
                 let wepost = List.map (fun (tp, epost) -> 
                   let (wepost, _) = check_asn (pn,ilist) [] ((current_class, ClassOrInterfaceName cn)::(current_thread_name, current_thread_type)::xmap) epost in
-                  let tp = check_pure_type (pn,ilist) [] tp in
+                  let tp = check_pure_type (pn,ilist) tpenv tp Real in
                   (tp, wepost)
                 ) epost in
                 let (wpre_dyn, wpost_dyn, wepost_dyn) = if fb = Static then (wpre, wpost, wepost) else (dynamic_of wpre, dynamic_of wpost, List.map (fun (tp, wepost) -> (tp, dynamic_of wepost)) wepost) in
@@ -633,13 +698,16 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let super_specs = if fb = Static then [] else super_specs_for_sign sign super interfs in
             if not is_jarspec then
             List.iter
-              begin fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract')) ->
+              begin fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', tparams')) ->
                 if gh <> gh' then
                   begin match gh with
                     Ghost -> static_error lm "A lemma method cannot implement or override a non-lemma method." None
                   | Real -> static_error lm "A non-lemma method cannot implement or override a lemma method." None
                   end;
-                if rt <> rt' then static_error lm "Return type does not match overridden method" None;
+                let string_of_rt rt = match rt with Some(t) -> string_of_type t | _ -> "void" in
+                let erased_rt rt = match rt with Some(t) -> Some(erased_type t) | None -> None in
+                if (erased_rt rt) <> (erased_rt rt') then static_error lm 
+                  (Printf.sprintf "Return type does not match overridden method for class %s. expected: %s actual: %s. " cn (string_of_rt (erased_rt rt)) (string_of_rt (erased_rt rt'))) None;
                 match co with
                   None -> ()
                 | Some (pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates) ->
@@ -661,13 +729,13 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 Some spec -> spec
               | None ->
                 match super_specs with
-                  (tn, ItfMethodInfo (_, _, _, xmap', pre', pre_tenv', post', epost', terminates', _, _))::_ ->
+                  (tn, ItfMethodInfo (_, _, _, xmap', pre', pre_tenv', post', epost', terminates', _, _, _))::_ ->
                   if not (List.for_all2 (fun (x, t) (x', t') -> x = x') xmap xmap') then static_error lm (Printf.sprintf "Parameter names do not match overridden method in %s" tn) None;
                   (pre', pre_tenv', post', epost', pre', post', epost', terminates')
                 | [] -> static_error lm "Method must have contract" None
             in
             let ss = match ss with None -> None | Some ss -> Some (Some ss) in
-            iter ((sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, super_specs <> [], abstract))::mmap) meths
+            iter ((sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, super_specs <> [], abstract, tparams))::mmap) meths
         in
         iter [] meths
     in
@@ -675,18 +743,18 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let classmap1 =
     List.map
-      begin fun (cn, (l, abstract, fin, meths, fds, ctors, super, interfs, preds, pn, ilist)) ->
+      begin fun (cn, (l, abstract, fin, meths, fds, ctors, super, tpenv, interfs, preds, pn, ilist)) ->
         let rec iter cmap ctors =
           match ctors with
-            [] -> (cn, {cl=l; cabstract=abstract; cfinal=fin; cmeths=meths; cfds=fds; cctors=List.rev cmap; csuper=super; cinterfs=interfs; cpreds=preds; cpn=pn; cilist=ilist})
-            | Cons (lm, ps, co, ss, v)::ctors ->
+            [] -> (cn, {cl=l; cabstract=abstract; cfinal=fin; cmeths=meths; cfds=fds; cctors=List.rev cmap; csuper=super; ctpenv=tpenv; cinterfs=interfs; cpreds=preds; cpn=pn; cilist=ilist})
+            | Cons (lm, ps, co, ss, v, tparams)::ctors ->
               let xmap =
                 let rec iter xm xs =
                   match xs with
                    [] -> List.rev xm
                  | (te, x)::xs ->
                    if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
-                   let t = check_pure_type (pn,ilist) [] te in
+                   let t = check_pure_type (pn,ilist) tparams te Real in
                    iter ((x, t)::xm) xs
                 in
                 iter [] ps
@@ -698,18 +766,18 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                   None -> static_error lm "Constructor must have contract" None
                 | Some (pre, post, epost, terminates) ->
                   let (wpre, tenv) = check_asn (pn,ilist) [] ((current_class, ClassOrInterfaceName cn)::(current_thread_name, current_thread_type)::xmap) pre in
-                  let postmap = ("this", ObjType(cn))::tenv in
+                  let postmap = ("this", ObjType(cn, []))::tenv in
                   let (wpost, _) = check_asn (pn,ilist) [] postmap post in
                   let wepost = List.map (fun (tp, epost) -> 
                     let (wepost, _) = check_asn (pn,ilist) [] tenv epost in
-                    let tp = check_pure_type (pn,ilist) [] tp in
+                    let tp = check_pure_type (pn,ilist) [] tp Ghost in
                     (tp, wepost)
                   ) epost in
                   (wpre, tenv, wpost, wepost, terminates)
               in
               let ss' = match ss with None -> None | Some ss -> Some (Some ss) in
                let epost: (type_ * asn) list = epost in
-              iter ((sign, CtorInfo (lm, xmap, pre, pre_tenv, post, epost, terminates, ss', v))::cmap) ctors
+              iter ((sign, CtorInfo (lm, xmap, pre, pre_tenv, post, epost, terminates, ss', v, tparams))::cmap) ctors
         in
         iter [] ctors
       end
@@ -722,14 +790,14 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let rec iter classmap1_done classmap1_todo =
       match classmap1_todo with
         [] -> List.rev classmap1_done
-      | (cn, ({cl=l; cfds=fds; cctors=cmap; csuper=super} as cls)) as c::classmap1_todo ->
+      | (cn, ({cl=l; cfds=fds; cctors=cmap; csuper=(super,passedTparams)} as cls)) as c::classmap1_todo ->
         let c =
           if cmap <> [] then c else
           (* Check if superclass has zero-arg ctor *)
           begin fun cont ->
             let {cctors=cmap'} = assoc2 super classmap1_done classmap0 in
             match try_assoc [] cmap' with
-              Some (CtorInfo (l'', xmap, pre, pre_tenv, post, epost, terminates, body, _)) ->
+              Some (CtorInfo (l'', xmap, pre, pre_tenv, post, epost, terminates, body, _, tparams)) ->
               let epost: (type_ * asn) list = epost in
               cont pre pre_tenv post epost terminates body
             | None -> c
@@ -763,7 +831,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let xmap = [] in
             let ss = Some (Some (([], l), rank)) in
             let vis = Public in
-            (sign, CtorInfo (l, xmap, super_pre, (current_class, ClassOrInterfaceName cn)::super_pre_tenv, post, [], super_terminates, ss, vis))
+            (sign, CtorInfo (l, xmap, super_pre, (current_class, ClassOrInterfaceName cn)::super_pre_tenv, post, [] , super_terminates, ss, vis, []))
           in
           (cn, {cls with cctors=[default_ctor]})
         in
@@ -812,11 +880,11 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec iter meths0 meths1=
               match meths0 with
                 [] -> meths1
-              | (sign0, MethodInfo (lm0,gh0,rt0,xmap0,pre0,pre_tenv0,post0,epost0,pre_dyn0,post_dyn0,epost_dyn0,terminates0,ss0,fb0,v0,_,abstract0)) as elem::rest ->
+              | (sign0, MethodInfo (lm0,gh0,rt0,xmap0,pre0,pre_tenv0,post0,epost0,pre_dyn0,post_dyn0,epost_dyn0,terminates0,ss0,fb0,v0,_,abstract0, tparams0)) as elem::rest ->
                 let epost0: (type_ * asn) list = epost0 in
                 match try_assoc sign0 meths1 with
                   None-> iter rest (elem::meths1)
-                | Some (MethodInfo (lm1,gh1,rt1,xmap1,pre1,pre_tenv1,post1,epost1,pre_dyn1,post_dyn1,epost_dyn1,terminates1,ss1,fb1,v1,_,abstract1)) -> 
+                | Some (MethodInfo (lm1,gh1,rt1,xmap1,pre1,pre_tenv1,post1,epost1,pre_dyn1,post_dyn1,epost_dyn1,terminates1,ss1,fb1,v1,_,abstract1, tparams1)) -> 
                   let epost1: (type_ * asn) list = epost1 in
                   let (mn, _) = sign0 in
                   check_func_header_compat lm1 ("Method '" ^ mn ^ "'") "Method implementation check" []
@@ -831,16 +899,16 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec iter constr0 constr1=
               match constr0 with
                 [] -> constr1
-              | (sign0, CtorInfo (lm0,xmap0,pre0,pre_tenv0,post0,epost0,terminates0,ss0,v0)) as elem::rest ->
+              | (sign0, CtorInfo (lm0,xmap0,pre0,pre_tenv0,post0,epost0,terminates0,ss0,v0, tparams0)) as elem::rest ->
                 let epost0: (type_ * asn) list = epost0 in
                 match try_assoc sign0 constr1 with
                   None-> iter rest (elem::constr1)
-                | Some (CtorInfo (lm1,xmap1,pre1,pre_tenv1,post1,epost1,terminates1,ss1,v1)) ->
+                | Some (CtorInfo (lm1,xmap1,pre1,pre_tenv1,post1,epost1,terminates1,ss1,v1, tparams1)) ->
                   let epost1: (type_ * asn) list = epost1 in
                   let rt= None in
                   check_func_header_compat lm1 ("Class '" ^ cn ^ "'") "Constructor implementation check" []
-                    (Regular,[],rt, ("this", ObjType cn)::xmap1,false, pre1, post1, epost1, terminates1)
-                    (Regular, [], rt, ("this", ObjType cn)::xmap0, false, [], [], pre0, post0, epost0, terminates0);
+                    (Regular,[],rt, ("this", ObjType (cn,[]))::xmap1,false, pre1, post1, epost1, terminates1)
+                    (Regular, [], rt, ("this", ObjType (cn, []))::xmap0, false, [], [], pre0, post0, epost0, terminates0);
                   if ss0=None then cons_impl:=(cn,lm0)::!cons_impl;
                   iter rest constr1
             in
@@ -865,7 +933,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             begin function
               (f, ({ft; fbinding=Instance; finit=Some e} as fd)) ->
               let check_expr_t (pn,ilist) tparams tenv e tp = check_expr_t_core functypemap funcmap classmap interfmap (pn,ilist) tparams tenv None e tp in
-              let tenv = [(current_class, ClassOrInterfaceName cn); ("this", ObjType cn); (current_thread_name, current_thread_type)] in
+              let tenv = [(current_class, ClassOrInterfaceName cn); ("this", ObjType (cn,[])); (current_thread_name, current_thread_type)] in
               let w = check_expr_t (pn,ilist) [] tenv e ft in
               (f, {fd with finit=Some w})
             | fd -> fd
@@ -889,10 +957,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       in  
       let rec get_overrides cn =
         if cn = "java.lang.Object" then [] else
-        let {cmeths; csuper} = List.assoc cn classmap in
+        let {cmeths; csuper=(csuper,passedTparams)} = List.assoc cn classmap in
         let overrides =
           flatmap
-            begin fun (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract)) ->
+            begin fun (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, tparams)) ->
               if is_override || pre != pre_dyn || post != post_dyn then [(cn, sign)] else []
             end
             cmeths
@@ -910,24 +978,30 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       end
     end
 
-  let rec interface_methods itf =
-    let InterfaceInfo (l, fds, meths, preds, supers) = List.assoc itf interfmap in
-    List.map (fun (sign, _) -> (sign, ("interface", itf))) meths @ flatmap interface_methods supers
+  let rec interface_methods (itf, passedTparams) =
+    let InterfaceInfo (l, fds, meths, preds, supers, tparams) = List.assoc itf interfmap in
+    List.map (fun (sign, _) -> 
+      (sign, ("interface", itf))) meths @ flatmap interface_methods supers
   
-  let rec unimplemented_class_methods cn trust_cabstract =
+  let rec unimplemented_class_methods (cn,passedTparams) trust_cabstract =
     if cn = "" then [] else
     let {cmeths; csuper; cinterfs; cabstract} = List.assoc cn classmap in
     if trust_cabstract && not cabstract then [] else
     let inherited_unimplemented_methods = unimplemented_class_methods csuper true @ flatmap interface_methods cinterfs in
-    let abstract_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, true)) -> [sign, ("class", cn)] | _ -> []) cmeths in
-    let implemented_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, false)) -> [sign] | _ -> []) cmeths in
-    List.filter (fun (sign, _) -> not (List.mem sign implemented_methods)) inherited_unimplemented_methods @ abstract_methods
+    let erased_inherited_unimplemented_methods = List.map (fun ((mn,ts),info) -> ((mn, List.map erased_type ts), info)) inherited_unimplemented_methods in
+    let abstract_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, true, tparams)) -> [sign, ("class", cn)] | _ -> []) cmeths in
+    let implemented_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, false, tparams)) -> [sign] | _ -> []) cmeths in
+    let erased_implemented_methods = List.map (fun (mn,ts) -> (mn,List.map erased_type ts)) implemented_methods in
+    List.filter (fun ((mn,ts), _) -> 
+      let erasedSign = (mn, List.map erased_type ts) in
+      not (List.mem erasedSign erased_implemented_methods)) erased_inherited_unimplemented_methods @ abstract_methods
   
   let () =
     if not is_jarspec then
-    classmap1 |> List.iter begin function (cn, {cl; cabstract}) ->
+    classmap1 |> List.iter begin 
+    function (cn, {cl; cabstract}) ->
       if not cabstract then begin
-        match unimplemented_class_methods cn false with
+        match unimplemented_class_methods (cn, []) false with
           [] -> ()
         | (sign, (k, tn))::_ -> static_error cl (Printf.sprintf "This class must implement method %s declared in %s %s or must be declared abstract." (string_of_sign sign) k tn) None
       end
@@ -956,13 +1030,13 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             []-> ()
           | (n,lm0)::_ -> static_error lm0 ("Method not in specs: "^n) None
           )
-      | Class(l,abstract,fin,cn,meths,fds,cons,super,inames,preds)::rest ->
+      | Class(l,abstract,fin,cn,meths,fds,cons,super,tparams, inames,preds)::rest ->
           inheritance_check cn l;
           let check_meths meths meths_impl=
             let rec iter mlist meths_impl=
               match mlist with
                 [] -> meths_impl
-              | Meth(lm,gh,rt,n,ps,co,None,fb,v,abstract)::rest ->
+              | Meth(lm,gh,rt,n,ps,co,None,fb,v,abstract, tparams)::rest ->
                 if List.mem (n,lm) meths_impl then
                   let meths_impl'= remove (fun (x,l0) -> x=n && lm=l0) meths_impl in
                   iter rest meths_impl'
@@ -975,7 +1049,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec iter clist cons_impl=
               match clist with
                 [] -> cons_impl
-              | Cons (lm,ps, co,None,v)::rest ->
+              | Cons (lm,ps, co,None,v, tparams)::rest ->
                 if List.mem (cn,lm) cons_impl then
                   let cons_impl'= remove (fun (x,l0) -> x=cn && lm=l0) cons_impl in
                   iter rest cons_impl'
@@ -1414,7 +1488,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let assume_instanceof l t tp cont =
     match tp with
-    | ObjType obj ->
+    | ObjType (obj,_) ->
         if not (ctxt#query (ctxt#mk_not (ctxt#mk_eq t (ctxt#mk_intlit 0)))) then
         assert_false [] [] l "Can't produce instanceof for a value that might be null." None;
         assume (ctxt#mk_app instanceof_symbol [t; (prover_type_term l tp)]) cont
@@ -1498,8 +1572,18 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | TermPat t -> cont h env t
     in
     let tpenv =
-      match zip callee_tparams targs with
-        None -> static_error l "Incorrect number of type arguments." None
+      (* If no type arguments are provided, we are dealing with a raw type *)
+      if targs = [] then List.map (fun tparam -> (tparam, ObjType("java.lang.Object",[]))) callee_tparams
+      else match zip callee_tparams targs with
+        None ->
+            begin
+            match zip callee_tparams targs with
+              None -> static_error l ("Incorrect number of type arguments. tparams: " ^
+              (String.concat ", " callee_tparams)
+              ^ " and targs: " 
+              ^ (String.concat ", " (List.map string_of_type targs))) None
+              | Some tpenv -> tpenv 
+            end
       | Some tpenv -> tpenv
     in
     let ys: string list = List.map (function (p, t) -> p) ps in
@@ -1945,12 +2029,12 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     match e with
     | Upcast (w, _, _) -> eval_h_core readonly h env w cont
     | CastExpr (lc, ManifestTypeExpr (_, tp), (WFunCall (l, "malloc", [], [SizeofExpr (ls, te)]) as e)) ->
-      let t = check_pure_type (pn,ilist) tparams te in
+      let t = check_pure_type (pn,ilist) tparams te Real in
       expect_type lc (Some pure) (PtrType t) tp;
       verify_expr readonly h env xo e cont
     | WFunCall (l, "malloc", [], [Operation (lmul, Mul, ([e; SizeofExpr (ls, te)] | [SizeofExpr (ls, te); e]))]) ->
       if pure then static_error l "Cannot call a non-pure function from a pure context." None;
-      let elemTp = check_pure_type (pn,ilist) tparams te in
+      let elemTp = check_pure_type (pn,ilist) tparams te Ghost in
       let w, tp = check_expr (pn,ilist) tparams tenv e in
       begin match tp with
         Int (_, _) -> ()
@@ -1983,7 +2067,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         end
     | WFunCall (l, "malloc", [], [SizeofExpr (ls, te)]) ->
       if pure then static_error l "Cannot call a non-pure function from a pure context." None;
-      let t = check_pure_type (pn,ilist) tparams te in
+      let t = check_pure_type (pn,ilist) tparams te Ghost in
       let resultType = PtrType t in
       let result = get_unique_var_symb_non_ghost (match xo with None -> (match t with StructType tn -> tn | _ -> "address") | Some x -> x) resultType in
       let cont h = cont h env result in
@@ -2049,17 +2133,27 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           check_call targs h args $. fun h env retval ->
           cont (chunk::h) env retval
       end
-    | NewObject (l, cn, args) ->
+    | NewGenericObject (l, cn, args, targs) ->
       inheritance_check cn l;
       if pure then static_error l "Object creation is not allowed in a pure context" None;
-      let {cctors} = List.assoc cn classmap in
+      let {cctors; ctpenv} = List.assoc cn classmap in
       let args' = List.map (fun e -> check_expr (pn,ilist) tparams tenv e) args in
       let argtps = List.map snd args' in
-      let consmap' = List.filter (fun (sign, _) -> is_assignable_to_sign (Some pure) argtps sign) cctors in
+      if targs <> [] && (List.length targs) <> (List.length ctpenv) 
+        then static_error l "Invalid amount of type arguments provided" None;
+      (* No support for the diamond notation yet, so we always have the types explicitly provided *)
+      let targtps = List.map (fun targexpr -> check_pure_type (pn,ilist) tparams targexpr Real) targs in
+      let consmap' =
+        let consWithErasedSigns = List.map (fun (sign,cinfo) -> (*Iterate ovr constructors*)
+          (List.map (fun tp -> match tp with (*Iterate over arguments*)
+            RealTypeParam t -> ObjType("java.lang.Object",[])
+              | t -> t) sign, cinfo)) cctors in
+        List.filter (fun (sign, _) -> is_assignable_to_sign (Some pure) argtps sign) consWithErasedSigns
+      in
       begin match consmap' with
         [] -> static_error l "No matching constructor" None
-      | [(sign, CtorInfo (lm, xmap, pre, pre_tenv, post, epost, terminates, ss, v))] ->
-        let obj = get_unique_var_symb (match xo with None -> "object" | Some x -> x) (ObjType cn) in
+      | [(sign, CtorInfo (lm, xmap, pre, pre_tenv, post, epost, terminates, ss, v, tparams))] ->
+        let obj = get_unique_var_symb (match xo with None -> "object" | Some x -> x) (ObjType (cn, targtps)) in
         assume_neq obj (ctxt#mk_intlit 0) $. fun () ->
         assume_eq (ctxt#mk_app get_class_symbol [obj]) (List.assoc cn classterms) $. fun () ->
         let is_upcall =
@@ -2067,14 +2161,47 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             Some (Some (_, rank)), RealMethodInfo (Some rank') -> rank < rank'
           | _ -> true
         in
-        check_correct h None None [] args (lm, [], None, xmap, ["this", obj], pre, post, Some(epost), terminates, Static) is_upcall (Some cn) (fun h env _ -> cont h env obj)
+        check_correct h None None targtps args (lm, tparams, None, xmap, ["this", obj], pre, post, Some(epost), terminates, Static) is_upcall (Some cn) (fun h env _ -> cont h env obj)
       | _ -> static_error l "Multiple matching overloads" None
       end
-    | WMethodCall (l, tn, m, pts, args, fb) when m <> "getClass" ->
-      let (lm, gh, rt, xmap, pre, post, epost, terminates, is_upcall, target_class, fb', v) =
+    | NewObject (l, cn, args) ->
+      inheritance_check cn l;
+      if pure then static_error l "Object creation is not allowed in a pure context" None;
+      let {cctors; ctpenv} = List.assoc cn classmap in
+      let args' = List.map (fun e -> check_expr (pn,ilist) tparams tenv e) args in
+      let argtps = List.map snd args' in
+      let cctors = (* Possible raw type, apply type erasure to constructors signs. *)
+        List.map (fun (sign,info) -> (List.map (fun t -> match t with 
+          RealTypeParam t -> ObjType("java.lang.Object",[])
+          | t -> t) sign, info)) cctors in
+      let consmap' =  
+        List.filter (fun (sign, _) -> is_assignable_to_sign (Some pure) argtps sign) cctors in
+      begin match consmap' with
+        [] -> static_error l "No matching constructor" None
+      | [(sign, CtorInfo (lm, xmap, pre, pre_tenv, post, epost, terminates, ss, v, tparams))] ->
+        (* Since any parameterised type that ends up here is raw, we can simulate this by making all type arguments java.lang.Object *)
+        let targs = List.map (fun _ -> ObjType("java.lang.Object",[])) tparams in
+        let xmap = (* Apply type erasure to parameters and return type *)
+          List.map (fun (name,t) -> match t with
+            RealTypeParam t -> (name, ObjType("java.lang.Object", []))
+            | t -> (name,t)) xmap in
+        let obj = get_unique_var_symb (match xo with None -> "object" | Some x -> x) (ObjType (cn, targs)) in
+        assume_neq obj (ctxt#mk_intlit 0) $. fun () ->
+        assume_eq (ctxt#mk_app get_class_symbol [obj]) (List.assoc cn classterms) $. fun () ->
+        let is_upcall =
+          match ss, leminfo with
+            Some (Some (_, rank)), RealMethodInfo (Some rank') -> rank < rank'
+          | _ -> true
+        in
+        check_correct h None None targs args (lm, tparams, None, xmap, ["this", obj], pre, post, Some(epost), terminates, Static) is_upcall (Some cn) (fun h env _ -> cont h env obj)
+      | _ -> static_error l "Multiple matching overloads" None
+      end
+    | WMethodCall (l, tn, m, pts, args, fb, targs) when m <> "getClass" ->
+      let (lm, gh, rt, xmap, pre, post, epost, terminates, is_upcall, target_class, fb', v, tparams) =
         match try_assoc tn classmap with
-          Some {cfinal; cmeths} ->
-          let MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract) = List.assoc (m, pts) cmeths in
+        Some {cfinal; cmeths} ->
+          let MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, tparams) = 
+            List.assoc (m, pts) cmeths in
           let can_be_overridden = fb = Instance && cfinal = ExtensibleClass && v <> Private in 
           let is_upcall =
             not can_be_overridden &&
@@ -2084,18 +2211,19 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             | _ -> false
           in
           let target_class = if can_be_overridden then None else Some tn in
-          (lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, is_upcall, target_class, fb, v)
+          (lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, is_upcall, target_class, fb, v, tparams)
         | _ ->
-          let InterfaceInfo (_, _, methods, _, _) = List.assoc tn interfmap in
-          let ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract) = List.assoc (m, pts) methods in
-          (lm, gh, rt, xmap, pre, post, epost, terminates, false, None, Instance, v)
+          let InterfaceInfo (_, _, methods, _, _, _) = List.assoc tn interfmap in
+          let ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract, tparams) = 
+            List.assoc (m, pts) methods in
+          (lm, gh, rt, xmap, pre, post, epost, terminates, false, None, Instance, v, tparams)
       in
       if gh = Real && pure then static_error l "Method call is not allowed in a pure context" None;
       if gh = Ghost then begin
         if not pure then static_error l "A lemma method call is not allowed in a non-pure context." None;
         if leminfo_is_lemma leminfo then static_error l "Lemma method calls in lemmas are currently not supported (for termination reasons)." None
       end;
-      check_correct h xo None [] args (lm, [], rt, xmap, [], pre, post, Some epost, terminates, v) is_upcall target_class cont
+      check_correct h xo None targs args (lm, tparams, rt, xmap, [], pre, post, Some epost, terminates, v) is_upcall target_class cont
     | WSuperMethodCall(l, supercn, m, args, (lm, gh, rt, xmap, pre, post, epost, terminates, rank, v)) ->
       if gh = Real && pure then static_error l "Method call is not allowed in a pure context" None;
       if gh = Ghost then begin
@@ -2121,7 +2249,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       end;
       check_correct h xo (Some g) targs es (lg, tparams, tr, ps, funenv, pre, post, None, terminates, v) true None cont
     | NewArray(l, tp, e) ->
-      let elem_tp = check_pure_type (pn,ilist) tparams tp in
+      let elem_tp = check_pure_type (pn,ilist) tparams tp Real in
       let w = check_expr_t (pn,ilist) tparams tenv e intType in
       eval_h h env w $. fun h env lv ->
       if not (ctxt#query (ctxt#mk_le (ctxt#mk_intlit 0) lv)) then assert_false h env l "array length might be negative" None;
@@ -2132,7 +2260,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         assume (mk_app all_eq_symb [elems; ctxt#mk_boxed_int (ctxt#mk_intlit 0)]) $. fun () ->
           new_array h env l elem_tp lv elems
     | NewArrayWithInitializer(l, tp, es) when language = Java ->
-      let elem_tp = check_pure_type (pn,ilist) tparams tp in
+      let elem_tp = check_pure_type (pn,ilist) tparams tp Real in
       let ws = List.map (fun e -> check_expr_t (pn,ilist) tparams tenv e elem_tp) es in
       evhs h env ws $. fun h env vs ->
       let elems = mk_list elem_tp vs in
@@ -2142,7 +2270,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       begin match file_type path with
         Java ->
         (* TODO: support UTF-8 *)
-        let value = get_unique_var_symb "stringLiteral" (ObjType "java.lang.String") in
+        let value = get_unique_var_symb "stringLiteral" (ObjType ("java.lang.String", [])) in
         let (_, _, _, _, chars_of_string_symb) = List.assoc "java.lang.charsOfString" purefuncmap in
         assume_neq value (ctxt#mk_intlit 0) $. fun () ->
         assume_eq (mk_app chars_of_string_symb [value]) (mk_char_list_of_c_string (String.length s) s) $. fun () ->
@@ -2157,10 +2285,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         assume (ctxt#mk_eq (mk_char_list_of_c_string (String.length s) s) cs) $. fun () ->
         cont (Chunk ((string_symb, true), [], coef, [value; cs], None)::h) env value
       end
-    | WOperation (l, Add, [e1; e2], ObjType "java.lang.String") ->
+    | WOperation (l, Add, [e1; e2], ObjType ("java.lang.String", [])) ->
       eval_h h env e1 $. fun h env v1 ->
       eval_h h env e2 $. fun h env v2 ->
-      let value = get_unique_var_symb "string" (ObjType "java.lang.String") in
+      let value = get_unique_var_symb "string" (ObjType ("java.lang.String", [])) in
       assume_neq value (ctxt#mk_intlit 0) $. fun () ->
       cont h env value
     | WRead (l, e, fparent, fname, frange, false (* is static? *), fvalue, fghost) ->

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -111,7 +111,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
 
   let current_thread_name = "currentThread"
   let current_thread_type = intType
-
+  
   (* Region: function contracts *)
   
   let functypemap1 =
@@ -591,8 +591,6 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let rank_counter = ref 0
 
-  
-
   let classmap1 =
     let rec iter classmap1_done classmap1_todo =
       let interf_specs_for_sign sign (itf, passedTypes) =
@@ -636,9 +634,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           | Some (MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, _, abstract)) -> [(cn, ItfMethodInfo (lm, gh, rt, xmap, pre_dyn, pre_tenv, post_dyn, epost_dyn, terminates, v, abstract))]
           | _ -> []
         in
-        specs @ super_specs_for_sign sign 
-        super 
-        interfs
+        specs @ super_specs_for_sign sign super interfs
       in
       let string_of_rt rt = match rt with Some(t) -> string_of_type t | _ -> "void" in
       let erase_rt rt = match rt with Some(t) -> Some(erase_type t) | None -> None in
@@ -733,14 +729,14 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let rec iter cmap ctors =
           match ctors with
             [] -> (cn, {cl=l; cabstract=abstract; cfinal=fin; cmeths=meths; cfds=fds; cctors=List.rev cmap; csuper=super; ctpenv=tparams; cinterfs=interfs; cpreds=preds; cpn=pn; cilist=ilist})
-            | Cons (lm, ps, co, ss, v, meth_tparams)::ctors ->
+            | Cons (lm, ps, co, ss, v)::ctors ->
               let xmap =
                 let rec iter xm xs =
                   match xs with
                    [] -> List.rev xm
                  | (te, x)::xs ->
                    if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
-                   let t = check_pure_type (pn, ilist) (tparams@meth_tparams) Real te in
+                   let t = check_pure_type (pn, ilist) tparams Real te in
                    iter ((x, t)::xm) xs
                 in
                 iter [] ps
@@ -1035,7 +1031,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec iter clist cons_impl=
               match clist with
                 [] -> cons_impl
-              | Cons (lm,ps, co,None,v, tparams)::rest ->
+              | Cons (lm,ps, co,None,v)::rest ->
                 if List.mem (cn,lm) cons_impl then
                   let cons_impl'= remove (fun (x,l0) -> x=cn && lm=l0) cons_impl in
                   iter rest cons_impl'
@@ -2177,7 +2173,6 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           (lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, is_upcall, target_class, fb, v)
         | _ ->
           let InterfaceInfo (_, _, methods, _, _, _) = List.assoc tn interfmap in
-          
           let ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract) = 
             try List.assoc (m, pts) methods with 
             Not_found -> (* Method contains type parameters *)

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1576,8 +1576,8 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       if targs = [] then List.map (fun tparam -> (tparam, ObjType("java.lang.Object",[]))) (tparams@callee_tparams)
       else match zip (tparams@callee_tparams) targs with
         None -> static_error l (Printf.sprintf "Incorrect number of type arguments. Actual: %s Expected: %s \n"
-          (List.length (tparams@callee_tparams))
-          (List.length targs)) None
+          (string_of_int (List.length (tparams@callee_tparams)))
+          (string_of_int (List.length targs))) None
         | Some tpenv -> tpenv 
     in
     let ys: string list = List.map (function (p, t) -> p) ps in

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1575,10 +1575,9 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       (* If no type arguments are provided, we are dealing with a raw type *)
       if targs = [] then List.map (fun tparam -> (tparam, ObjType("java.lang.Object",[]))) (tparams@callee_tparams)
       else match zip (tparams@callee_tparams) targs with
-        None -> static_error l ("Incorrect number of type arguments. tparams: " ^
-          (String.concat ", " (tparams@callee_tparams))
-          ^ " and targs: " 
-          ^ (String.concat ", " (List.map string_of_type targs))) None
+        None -> static_error l (Printf.sprintf "Incorrect number of type arguments. Actual: %s Expected: %s \n"
+          (List.length (tparams@callee_tparams))
+          (List.length targs)) None
         | Some tpenv -> tpenv 
     in
     let ys: string list = List.map (function (p, t) -> p) ps in

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -10,8 +10,6 @@ open Verifast0
 open Verifast1
 open Assertions
 
-
-
 module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   include Assertions(VerifyProgramArgs)

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -2121,9 +2121,6 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             | _ -> false
           in
           let target_class = if can_be_overridden then None else Some tn in
-          (* xmap still have type parameters, build it fromm the  arguments of the method call, idem for the return type *)
-          Printf.printf "WMethodCall with tpenv: %s \n"
-            (String.concat "," (List.map (fun (tparam,targ) -> tparam ^ "->" ^ string_of_type targ) tpenv));
           let rt = match rt with Some (rt) -> Some(replace_type l tpenv rt) | None -> None in
           let xmap = List.map (fun (name,tp) -> (name, replace_type l tpenv tp)) xmap in
           (lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, is_upcall, target_class, fb, v)

--- a/tests/java/generics/BasicGenericClass.java
+++ b/tests/java/generics/BasicGenericClass.java
@@ -1,0 +1,23 @@
+public class GenericClass<T>{
+	public T field;
+	public GenericClass(T f)
+	//@ requires true;
+	//@ ensures this.field |-> f;
+	{
+		field = f;
+	}
+	
+	public void add(T arg)
+	//@ requires this.field |-> ?f;
+	//@ ensures this.field |-> arg;
+	{
+		field = arg;
+	}
+	
+	public T get()
+	//@ requires this.field |-> ?f;
+	//@ ensures this.field |-> f;
+	{
+		return field;
+	}
+}

--- a/tests/java/generics/GenericInheritance.java
+++ b/tests/java/generics/GenericInheritance.java
@@ -1,0 +1,23 @@
+// Case A: Interface implements interface
+public interface Parent<A,B>{
+	public A get1(A arg1);
+	public B get2();
+}
+
+public interface Child<C,D> extends Parent<D,C>{
+	public D get1(D arg1);
+	public C get2();
+}
+// Case B: Class implements interface
+public class ChildClass<C,D> implements Parent<D,C>{
+	public D get1(D arg1) {return null;}
+	public C get2() {return null;}
+}
+
+// Case C: Class extends class
+public abstract class AbstractParentClass<A,B> {
+	public abstract A get1(A arg1);
+}
+public class ChildClassInheritance<C,D> extends AbstractParentClass<C,D>{
+	public C get1(C arg1){return null;}
+}

--- a/tests/java/generics/GenericType.java
+++ b/tests/java/generics/GenericType.java
@@ -1,0 +1,35 @@
+public class Box<T> {
+    // T stands for "Type"
+    private T t;
+
+    public void set(T t) { this.t = t; }
+    public T get() { return t; }
+
+    public static void main(String[] args){
+        Pair<String, Integer> p1 = new OrderedPair<String, Integer>("Even", 8);
+	Pair<String, String>  p2 = new OrderedPair<String, String>("hello", "world");
+    }
+    
+    OrderedPair<String, Integer> p1 = new OrderedPair<>("Even", 8);
+    OrderedPair<String, String>  p2 = new OrderedPair<>("hello", "world");
+}
+
+public interface Pair<K, V> {
+    public K getKey();
+    public V getValue();
+}
+
+public class OrderedPair<K, V> implements Pair<K, V> {
+
+    private K key;
+    private V value;
+
+    public OrderedPair(K key, V value) {
+	this.key = key;
+	this.value = value;
+    }
+
+    public K getKey()	{ return key; }
+    public V getValue() { return value; }
+}
+

--- a/tests/java/generics/GenericType.java
+++ b/tests/java/generics/GenericType.java
@@ -6,12 +6,9 @@ public class Box<T> {
     public T get() { return t; }
 
     public static void main(String[] args){
-        Pair<String, Integer> p1 = new OrderedPair<String, Integer>("Even", 8);
+        Pair<String, Integer> p1 = new OrderedPair<String, Integer>("Even", new Integer(8));
 	Pair<String, String>  p2 = new OrderedPair<String, String>("hello", "world");
     }
-    
-    OrderedPair<String, Integer> p1 = new OrderedPair<>("Even", 8);
-    OrderedPair<String, String>  p2 = new OrderedPair<>("hello", "world");
 }
 
 public interface Pair<K, V> {

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -289,6 +289,7 @@ cd examples
       verifast -c -allow_assume -prover redux -provides "java_card_applet newmypackage.NewMyApplet 5,1,2,3,4,5,0,3,2,10,10" NewMyApplet/NewMyApplet.jarsrc
       verifast -c -allow_assume -prover redux -provides "java_card_applet mypackage.MyApplet 5,1,2,3,4,5,0,3,2,10,10" MyApplet-with-auto.java
     cd ..
+    verifast -c -disable_overflow_check GenericClass.java
     verifast_both -c -disable_overflow_check Account.java
     verifast_both -c -disable_overflow_check AbstractClasses.java
     verifast_both -c -disable_overflow_check ArrayList.java
@@ -499,6 +500,7 @@ cd tests
     cd generics
     verifast -c BasicGenericClass.java
     verifast -c GenericInheritance.java
+    verifast -c GenericType.java
     cd ..
   cd ..
 cd ..

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -251,7 +251,13 @@ cd examples
     cd channels
       verifast -prover redux -disable_overflow_check -c channels.jarsrc client.jarsrc
     cd ..
+    cd channels_raw
+      verifast -prover redux -disable_overflow_check -c channels.jarsrc client.jarsrc
+    cd ..
     cd chat
+      verifast_both -c -allow_assume chat.jarsrc
+    cd ..
+    cd chat_raw
       verifast_both -c -allow_assume chat.jarsrc
     cd ..
     cd chatbot
@@ -487,6 +493,12 @@ cd tests
     verifast_both -c -allow_should_fail test-ghost-break-from-real-loop.c
     cd context_free_pp
       verifast -c -allow_should_fail lib.c prog.c
+    cd ..
+  cd ..
+  cd java
+    cd generics
+    verifast -c BasicGenericClass.java
+    verifast -c GenericInheritance.java
     cd ..
   cd ..
 cd ..


### PR DESCRIPTION
Added the possibility to specify generics in java code. No nesting of parameterised types yet, and no support for type inference during instance creation.

Updated javaspec files:
- java.lang.javaspec
- java.util.javaspec: Use generics instead of Object

Updated examples:
- Examples/arraylist.java: Use generics
- examples/java/channels/channel.java: Added generics support
- examples/java/chat/room.java: Added generics
- examples/java/chat/session.java: Added generics
- examples/java/frontend/big_example/java7program_desugared.java: Added generics and converted Object to generics.

Added:
- examples/java/genericclass.java: a class containing several examples of how to use generics so they properly parse.

Added tests
- BasicGenericClass.java: A very simple generic class to demonstrate how to use generics.
- GenericInheritance.java: A test for proper compilation of inheritance
- GenericType.java: A test for proper use of generic Types. Source for this class is the official java tutorial.

Updated source files:
- SExpressionEmitter: Properly print the changed types (see ast.ml)
- assertions: Properly passed the type parameters along instead of empty arrays
- ast.ml: Updated several types to allow generics 
   - ObjType: Added type parameters (Could make this Option, for now unparameterised types leave this as an empty list)
   - RealTypeParam, GhostTypeParam: replace the old type parameter to differentiate between java type params and ghost type params.
   - WMethodCall: Added type arguments to a method call
   - NewObject: Added a list of type expressions to represent type arguments
   - Meth: Added type parameters. The ghostness represents in what part of the code the type param was defined
   - Inductive: Updated type parameters to include ghostness.  
   - Class: Super class and interfaces now also have a list of passed type parameters. This can be used for context switching. Also added type parameters.
   - Interface: Added type parameters and passed type params to super interfaces.
   - PredFamilyDecl, PredFamilyInstanceDecl, Func, TypedefDecl: Added ghostness to type parameters.
   - Added several helper methods for the new updated types
- explorer: small changes to accomodate for type parameters
- ast_translator: Most generics aren't supported here yet. Just updated it so everything compiles properly.
- parser.ml: Parsing generics and removed parser-based type erasure.

The following files have big changes to accomodate for the generics:
- verifast.ml
- verifast0.ml
- verifast1.ml
- verify_expr.ml

The testsuite is updated for the newly added tests. They are still insufficient and should be vastly expanded. Because of the existing examples, many bugs are caught already.


