### PR TITLE
Qualified generic method call with explicit type arguments

### DIFF
--- a/bin/rt/java.util.javaspec
+++ b/bin/rt/java.util.javaspec
@@ -216,8 +216,7 @@ public class ArrayList<E> implements List<E> {
 
 public class Arrays {
     
-    // No support for generic methods yet.
-    public static List asList(Object[] a);
+    public static <T> List<T> asList(T[] a);
         //@ requires [?f]a[..] |-> ?es;
         //@ ensures [f]a[..] |-> es &*& result.List(es);
    

--- a/examples/java/GenericClass.java
+++ b/examples/java/GenericClass.java
@@ -71,7 +71,7 @@ public class HelloWorld
   public static GenericClass<GenericClass<Foo> > genericInstance;
   
   public static void main(String[] args) 
-    //@ requires System_out(?o) &*& o != null;
+    //@ requires true;
     //@ ensures true; 
   {
     String[] sentence = {"Hello", "World"};

--- a/examples/java/GenericClass.java
+++ b/examples/java/GenericClass.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
 
 // Contains examples on how to work with generics in VeriFast.
 
@@ -73,7 +74,9 @@ public class HelloWorld
     //@ requires System_out(?o) &*& o != null;
     //@ ensures true; 
   {
-    System.out.println("Hello, World");
+    String[] sentence = {"Hello", "World"};
+	List<String> sentenceList = Arrays.<String>asList(sentence);
+	
     Foo<String> foo = new Foo<String>("test");
     GenericClass<String> simple = new GenericClass<String>("Example");
     GenericClass<GenericClass<String> > nested = new GenericClass<GenericClass<String> >(new GenericClass<String>("foo"));

--- a/examples/java/frontend/big_example/Java7Program_desugared.java
+++ b/examples/java/frontend/big_example/Java7Program_desugared.java
@@ -43,13 +43,13 @@ predicate_family_instance FoldFunc(Java7Program_desugared$1.class)(FoldFunc f, l
 
 public class Java7Program_desugared 
 {
-  public static void addAll(List l, Object[] xs) throws EmptyException /*@ ensures xs.length == 0; @*/
+  public static <T> void addAll(List<T> l, T[] xs) throws EmptyException /*@ ensures xs.length == 0; @*/
     //@ requires l.List(?l_es) &*& [?f]xs[..] |-> ?xs_es;
     //@ ensures l.List(append(l_es, xs_es)) &*& [f]xs[..] |-> xs_es &*& xs.length > 0;
   {
     if (xs.length > 0)
     {
-      List temp = Arrays.asList(xs);
+      List<T> temp = Arrays.<T>asList(xs);
       //@ close listIsCollection(temp, temp);
       l.addAll(temp);
     }
@@ -59,20 +59,20 @@ public class Java7Program_desugared
     }
   }
 
-  public static Object fold(FoldFunc f, List xs, Object acc0)
+  public static <T> T fold(FoldFunc f, List<T> xs, T acc0)
     //@ requires xs.List(?es) &*& FoldFunc(f.getClass())(f, es, acc0, ?info) &*& f != null;
     //@ ensures xs.List(es) &*& FoldFunc(f.getClass())(f, nil, result, info);
   {
-    Object acc = acc0;
+    T acc = acc0;
     
     //@ xs.listToIterable();
     {
-      Iterator iSSS = xs.iterator();
+      Iterator<T> iSSS = xs.iterator();
       while (iSSS.hasNext())
         //@ requires iSSS.Iterator((seq_of_list)(es), _, ?n) &*& FoldFunc(f.getClass())(f, drop(n, es), acc, info) &*& f != null &*& n >= 0 &*& n <= length(es);
         //@ ensures FoldFunc(f.getClass())(f, nil, acc, info) &*& iSSS.Iterator((seq_of_list)(es), _, length(es));
       {
-        Object x = iSSS.next();
+        T x = iSSS.next();
         {
           //@ drop_n_plus_one(n, es);
           acc = f.fold(acc, x);
@@ -89,14 +89,14 @@ public class Java7Program_desugared
     //@ requires true;
     //@ ensures true;
   {
-    List xs = new ArrayList(); 
+    List<Integer> xs = new ArrayList<Integer>(); 
     Integer i1 = Integer.valueOf(3);
     Integer i2 = Integer.valueOf(5);
     Integer i3 = Integer.valueOf(7);
     
     try
     {
-      addAll(xs, new Integer[]{i1, i2, i3});
+      Java7Program_desugared.<Integer>addAll(xs, new Integer[]{i1, i2, i3});
     }
     catch (EmptyException e)
     {
@@ -107,8 +107,7 @@ public class Java7Program_desugared
     FoldFunc func = new Java7Program_desugared$1();
     Integer acc = Integer.valueOf(2);
     //@ close FoldFunc(Java7Program_desugared$1.class)(func, exs, acc, cons(acc, exs));
-    Object vo = fold(func, xs, acc);
-    Integer vi = (Integer) vo;
+    Integer vi = Java7Program_desugared.<Integer>fold(func, xs, acc);
     //@ open FoldFunc(Java7Program_desugared$1.class)(_, _, _, _);
     int v = vi.intValue();
     
@@ -117,7 +116,7 @@ public class Java7Program_desugared
     //@ boolean is_thrown = false;
     try
     {
-      addAll(xs, new Integer[]{});
+      Java7Program_desugared.<Integer>addAll(xs, new Integer[]{});
     }
     catch (EmptyException e)
     {

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -726,7 +726,10 @@ and sexpr_of_super (name, targs) : sexpression =
 
 and sexpr_of_meths (meth : meth) : sexpression =
   match meth with
-  | Meth (loc, ghost, rtype, name, params, contract, body, bind, vis, abs) ->
+  | Meth (loc, ghost, rtype, name, params, contract, body, bind, vis, abs, tparams) ->
+    let sexpr_of_tparam t = 
+      Symbol t
+    in
     let sexpr_of_arg (t, id) =
       List [ Symbol id; sexpr_of_type_expr t ]
     in
@@ -743,7 +746,8 @@ and sexpr_of_meths (meth : meth) : sexpression =
     in        
     let kw = List.concat [ [ "ghos", sexpr_of_ghostness ghost
                             ; "return-type", sexpr_of_type_expr_option rtype
-                            ; "parameters", List (List.map sexpr_of_arg params) ]
+                            ; "parameters", List (List.map sexpr_of_arg params)
+                            ; "type-parameters", List (List.map sexpr_of_tparam tparams) ]
                           ; body
                           ; contract ]
     in

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -642,7 +642,8 @@ and
       ((stmt list * loc (* Close brace *)) * int (*rank*)) option * 
       method_binding * 
       visibility *
-      bool (* is declared abstract? *)
+      bool * (* is declared abstract? *)
+      string list (* tparams *)
 and
   cons = (* ?cons *)
   | Cons of

--- a/src/java_frontend/ast_translator.ml
+++ b/src/java_frontend/ast_translator.ml
@@ -439,7 +439,7 @@ and translate_static_blocks cn decls =
         counter := !counter + 1;
         let contr' = check_contract l [] [] Generated in
         let stmts' = translate_block l (Some stmts) in
-        Some([VF.Meth(l', VF.Real, None, id', [], contr', stmts', VF.Static, VF.Private, false)])
+        Some([VF.Meth(l', VF.Real, None, id', [], contr', stmts', VF.Static, VF.Private, false, [])])
       end
     | _ -> None
   in 
@@ -497,6 +497,7 @@ and translate_methods cn decls =
         debug_print ("method declaration " ^ id');
         let abs' = translate_abstractness abs in
         let access' = translate_accessibility access in
+        let tparams' = translate_tparams_as_string tparams in
         let stat' = translate_staticness stat in
         let params' = 
           let params' = List.map translate_param params in
@@ -509,7 +510,7 @@ and translate_methods cn decls =
         in
         let contr' = check_contract l anns throws autogen in
         let stmts' = translate_block l stmts in
-        Some([VF.Meth(l', ghost', ret', id', params', contr', stmts', stat', access', abs')])
+        Some([VF.Meth(l', ghost', ret', id', params', contr', stmts', stat', access', abs', tparams')])
     | _ -> None
   in 
   translate_class_decls_helper translator decls

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -124,7 +124,7 @@ module Scala = struct
     parse_method = parser
       [< '(l, Kwd "def"); '(_, Ident mn); ps = parse_paramlist; t = parse_type_ann; co = parse_contract; '(_, Kwd "=");'(_, Kwd "{"); ss = rep parse_stmt; '(closeBraceLoc, Kwd "}")>] ->
       let rt = match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t in
-      Meth (l, Real, rt, mn, ps, Some co, Some ((ss, closeBraceLoc), next_body_rank ()), Static, Public, false)
+      Meth (l, Real, rt, mn, ps, Some co, Some ((ss, closeBraceLoc), next_body_rank ()), Static, Public, false, [])
   and
     parse_paramlist = parser
       [< '(_, Kwd "("); ps = rep_comma parse_param; '(_, Kwd ")") >] -> ps
@@ -267,7 +267,7 @@ and
 and
   methods cn m=
   match m with
-    MethMember (Meth (l, gh, t, n, ps, co, ss,s,v,abstract))::ms -> Meth (l, gh, t, n, ps, co, ss,s,v,abstract)::(methods cn ms)
+    MethMember (Meth (l, gh, t, n, ps, co, ss, s, v, abstract, tparams))::ms -> Meth (l, gh, t, n, ps, co, ss, s, v, abstract, tparams)::(methods cn ms)
     |_::ms -> methods cn ms
     | []->[]
 and
@@ -311,7 +311,7 @@ and
      | [< '(l, Kwd "lemma"); t = parse_return_type; 
           '(l, Ident x); (ps, co, ss) = parse_method_rest l >] -> 
         let ps = (IdentTypeExpr (l, None, cn), "this")::ps in
-        MethMember(Meth (l, Ghost, t, x, ps, co, ss, Instance, vis, false))
+        MethMember(Meth (l, Ghost, t, x, ps, co, ss, Instance, vis, false, []))
      | [< binding = (parser [< '(_, Kwd "static") >] -> Static | [< >] -> Instance); t = parse_type; '(l, Ident x); '(_, Kwd ";") >] ->
        FieldMember [Field (l, Ghost, t, x, binding, vis, false, None)]
     end
@@ -343,6 +343,7 @@ and
      final = (fun _ -> List.mem FinalModifier modifiers);
      abstract = (fun _ -> List.mem AbstractModifier modifiers);
      vis = (fun _ -> (match (try_find (function VisibilityModifier(_) -> true | _ -> false) modifiers) with None -> Package | Some(VisibilityModifier(vis)) -> vis));
+     tparams = parse_type_params_general;
      t = parse_return_type;
      member = parser
        [< '(l, Ident x);
@@ -350,7 +351,7 @@ and
             [< (ps, co, ss) = parse_method_rest l >] ->
             let ps = if binding = Instance then (IdentTypeExpr (l, None, cn), "this")::ps 
                 else ps in
-            MethMember (Meth (l, Real, t, x, ps, co, ss, binding, vis, abstract))
+            MethMember (Meth (l, Real, t, x, ps, co, ss, binding, vis, abstract, tparams))
           | [< t = id (match t with None -> raise (ParseException (l, "A field cannot be void.")) | Some(t) -> t);
                tx = parse_array_braces t;
                init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);
@@ -1278,13 +1279,14 @@ and
       >] -> e
     | [<
         '(ldot, Kwd ".") when language = Java;
+        targs = parse_type_args ldot;
         r = parser
           [<'(lc, Kwd "class")>] -> ClassLit(ldot,x)
         | [<
             '(lf, Ident f);
             e = parser
               [<args0 = parse_patlist; (args0, args) = (parser [< args = parse_patlist >] -> (args0, args) | [< >] -> ([], args0)) >] ->
-              CallExpr (lf, f, [], args0, LitPat(Var(lx,x))::args,Instance)
+              CallExpr (lf, f, targs, args0, LitPat(Var(lx,x))::args,Instance)
             | [<>] -> Read (ldot, Var(lx,x), f)
           >]->e 
       >]-> r

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2701,7 +2701,12 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     match meths with
       [] -> ()
     | ((g, sign), MethodInfo (l, gh, rt, ps, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, sts, fb, v, _, abstract, mtparams))::meths ->
-      let allTparams = ctparams @ mtparams in
+      let allTparams = 
+        if fb = Instance then 
+          ctparams@mtparams
+        else
+          mtparams 
+      in
       if abstract && not cabstract then static_error l "Abstract method can only appear in abstract class." None;
       match sts with
         None -> let ((p,_,_),(_,_,_))= root_caller_token l in 
@@ -2730,7 +2735,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               begin fun cont ->
                 if cfin = FinalClass then assume (ctxt#mk_eq (ctxt#mk_app get_class_symbol [thisTerm]) (List.assoc cn classterms)) cont else cont ()
               end $. fun () ->
-              assume_neq thisTerm (ctxt#mk_intlit 0) (fun _ -> cont (("this", ObjType (cn, (List.map (fun tparam -> RealTypeParam tparam) allTparams)))::pre_tenv))
+              assume_neq thisTerm (ctxt#mk_intlit 0) (fun _ -> cont (("this", ObjType (cn, (List.map (fun tparam -> RealTypeParam tparam) ctparams)))::pre_tenv))
             end else cont pre_tenv
           end $. fun tenv ->
           let (sizemap, indinfo) = switch_stmt ss env in

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -499,7 +499,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let meths' = meths |> List.filter begin
         fun x ->
           match x with
-            | Meth(lm, gh, t, n, ps, co, ss,fb,v,abstract) ->
+            | Meth(lm, gh, t, n, ps, co, ss, fb, v, abstract, mtparams) ->
               match ss with
                 | None -> true
                 | Some _ -> false
@@ -649,6 +649,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * visibility
       * bool (* is override *)
       * bool (* is abstract *)
+      * string list (* type parameters *)
     type interface_method_info =
       ItfMethodInfo of
         loc
@@ -662,6 +663,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * bool (* terminates *)
       * visibility
       * bool (* is abstract *)
+      * string list (* type parameters *)
     type field_info = {
         fl: loc;
         fgh: ghostness;
@@ -2809,8 +2811,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         in
         let declared_methods =
           flatmap
-            begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract)) ->
-              if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, fb, v, abstract))] else []
+            begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, mtparams)) ->
+              if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, fb, v, abstract, mtparams))] else []
             end
             cmeths
         in
@@ -2818,8 +2820,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | None ->
       let InterfaceInfo (_, fields, meths, _, interfs, _) = List.assoc tn interfmap in
       let declared_methods = flatmap
-        begin fun ((mn', sign), ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract)) ->
-          if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre, post, epost, terminates, Instance, v, abstract))] else []
+        begin fun ((mn', sign), ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract, mtparams)) ->
+          if mn' = mn then [(sign, (tn, lm, gh, rt, xmap, pre, post, epost, terminates, Instance, v, abstract, mtparams))] else []
         end
         meths
       in
@@ -3267,8 +3269,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         if ms = [] then on_fail () else
         let argtps = List.map (fun e -> let (_, tp, _) = (check e) in tp) args in
         (* Select the real methods with the correct number of type parameters *)
-        let ms = List.map (fun (sign, (tn', lm, gh, rt, xmap, pre, post, epost, terminates, fb', v, abstract)) ->
-          let targenv = if inAnnotation <> Some(true) then List.map2 (fun a b -> (a, b)) class_tparams class_targs else []
+        let ms = List.map (fun (sign, (tn', lm, gh, rt, xmap, pre, post, epost, terminates, fb', v, abstract, mtparams)) ->
+          let targenv = if inAnnotation <> Some(true) then 
+            let targs = List.map (check_pure_type (pn,ilist) mtparams Real) targes in
+            let classTargEnv = match zip class_tparams class_targs with Some(tenv) -> tenv | None -> static_error l "The amount of type arguments for the class and the expected number of type parameters does not match." None in
+            let methodTargEnv = match zip mtparams targs with Some(tenv) -> tenv | None -> static_error l "Type arguments not correctly specified" None in
+            classTargEnv@methodTargEnv else []
           in
           (* Replace the type parameters with their concrete type*)
           let sign' = 
@@ -3444,7 +3450,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           begin try
             let m =
               List.find
-                begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract)) ->
+                begin fun ((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, mtparams)) ->
                   mn = mn' &&  is_assignable_to_sign inAnnotation argtps sign && not abstract
                 end
                 cmeths
@@ -3467,7 +3473,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | Some {csuper=(csuper, _)} ->
             begin match get_implemented_instance_method csuper mn argtps with
               None -> static_error l "No matching method." None
-            | Some(((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract))) ->
+            | Some(((mn', sign), MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, mtparams))) ->
               let tp = match rt with Some(tp) -> tp | _ -> Void in
               let rank = match ss with Some (Some (_, rank)) -> Some rank | None -> None in
               (WSuperMethodCall (l, csuper, mn, Var (l, "this") :: wargs, (lm, gh, rt, xmap, pre, post, epost, terminates, rank, v)), tp, None)

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -425,7 +425,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let rec iter mmap erased_mmap meth_specs =
           match meth_specs with
             [] -> List.rev mmap
-          | Meth (lm, gh, rt, n, ps, co, body, binding, _, _)::meths ->
+          | Meth (lm, gh, rt, n, ps, co, body, binding, _, _, mtparams)::meths ->
             if body <> None then static_error lm "Interface method cannot have body" None;
             if binding = Static then static_error lm "Interface method cannot be static" None;
             let xmap =
@@ -441,14 +441,15 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             in
             let sign = (n, List.map snd (List.tl xmap)) in
             if List.mem_assoc sign mmap then static_error lm "Duplicate method" None;
-            let erasedSign = (n, List.map erase_type (List.map snd xmap)) in
+            let erasedXmap = List.map (fun (n,tp) -> (n,erase_type tp)) xmap in
+            let erasedSign = (n, List.map snd xmap) in
             if List.mem_assoc erasedSign erased_mmap then static_error lm "Duplicate method after erasure." None;
             let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn, ilist) (tparams) Real rt) in
             let (pre, pre_tenv, post, epost, terminates) =
               match co with
                 None -> static_error lm ("Non-fixpoint function must have contract: "^n) None
               | Some (pre, post, epost, terminates) ->
-                let (pre, tenv) = check_asn (pn,ilist) [] ((current_thread_name, current_thread_type)::xmap) pre in
+                let (pre, tenv) = check_asn (pn,ilist) [] ((current_thread_name, current_thread_type)::erasedXmap) pre in
                 let postmap = match rt with None -> tenv | Some rt -> ("result", rt)::tenv in
                 let (post, _) = check_asn (pn,ilist) [] postmap post in
                 let epost = List.map (fun (tp, epost) -> 
@@ -458,7 +459,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 ) epost in
                 (pre, tenv, post, epost, terminates)
             in
-            let methodInfo = ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, Public, true) in
+            let methodInfo = ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, Public, true, mtparams) in
             iter ((sign, methodInfo)::mmap) ((erasedSign, methodInfo)::erased_mmap) meths
         in
         iter [] [] specs
@@ -489,10 +490,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let rec match_meths meths0 meths1=
           match meths0 with
             [] -> if meths1 <> [] then static_error l1 ".java file does not correctly implement .javaspec file: interface declares more methods" None
-          | (sign, ItfMethodInfo (lm0,gh0,rt0,xmap0,pre0,pre_tenv0,post0,epost0,terminates0,v0,abstract0))::meths0 ->
+          | (sign, ItfMethodInfo (lm0, gh0, rt0, xmap0, pre0, pre_tenv0, post0, epost0, terminates0, v0, abstract0, mtparams0))::meths0 ->
             match try_assoc sign meths1 with
               None-> static_error l1 (".java file does not correctly implement .javaspec file: interface does not declare method " ^ string_of_sign sign) None
-            | Some (ItfMethodInfo (lm1,gh1,rt1,xmap1,pre1,pre_tenv1,post1,epost1,terminates1,v1,abstract1)) ->
+            | Some (ItfMethodInfo (lm1, gh1, rt1, xmap1, pre1, pre_tenv1, post1, epost1, terminates1, v1, abstract1, mtparams1)) ->
               let (mn, _) = sign in
               check_func_header_compat lm1 ("Method '" ^ mn ^ "'") "Method specification check" [] (func_kind_of_ghostness gh1,[],rt1, xmap1,false, pre1, post1, epost1, terminates1) (func_kind_of_ghostness gh0, [], rt0, xmap0, false, [], [], pre0, post0, epost0, terminates1);
               match_meths meths0 (List.remove_assoc sign meths1)
@@ -503,20 +504,25 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let interf_specs_for_sign map1 sign (itf, passedTypes) =
     let InterfaceInfo (_, fields, meths, _, _, tparams) = List.assoc itf map1 in
-    let interTparamEnv = List.map2 (fun a b -> (a, b)) tparams passedTypes in
+    (* If we have tparams, but no passed types: raw type *)
+    let interTparamEnv = match tparams with 
+      [] -> [] 
+    | tparams when passedTypes = [] -> List.map (fun tparam -> (tparam, javaLangObject)) tparams
+    | tparams -> List.map2 (fun a b -> (a, b)) tparams passedTypes
+    in
     let eraseSign = (fun (n, args) -> (n, List.map erase_type args)) in
     let erasedMeths = List.map (fun (sign, info) -> (eraseSign sign, info)) meths (*Erase the signs of the super methods *)
     in
       match try_assoc (eraseSign sign) erasedMeths with
         None -> []
         (* Update specs to properly apply the childs tparams *)
-      | Some ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract') ->
+      | Some ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', mtparams') ->
         (*Map type params to the scope of the child class *)
         let rt' = match rt' with 
           Some(t) -> Some(replace_type lsuper interTparamEnv t)
         | None -> None in
         let xmap' = List.map (fun (name, t) -> (name, replace_type lsuper interTparamEnv t)) xmap' in
-        let spec = ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract') in
+        let spec = ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', mtparams') in
         [(itf, spec)]
 
   let interfmap = (* checks overriding methods in interfaces *)
@@ -524,9 +530,9 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       match map0 with
         [] -> map1
       | (i, InterfaceInfo (l, fields, meths, preds, interfs, tparams)) as elem::rest ->
-        List.iter (fun (sign, ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract)) ->
+        List.iter (fun (sign, ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract, mtparams)) ->
           let superspecs = List.flatten (List.map (fun i -> interf_specs_for_sign map1 sign i) interfs) in
-          List.iter (fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract')) ->
+          List.iter (fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', mtparams')) ->
             if rt <> rt' then 
               static_error lm ("Return type (" 
               ^ (match rt with None-> "void" | Some(rt) -> string_of_type rt) 
@@ -603,7 +609,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         in
         let specs =
           match try_assoc sign mmap with
-          | Some (MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, _, abstract)) -> [(cn, ItfMethodInfo (lm, gh, rt, xmap, pre_dyn, pre_tenv, post_dyn, epost_dyn, terminates, v, abstract))]
+          | Some (MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, _, abstract, mtparams)) -> [(cn, ItfMethodInfo (lm, gh, rt, xmap, pre_dyn, pre_tenv, post_dyn, epost_dyn, terminates, v, abstract, mtparams))]
           | _ -> []
         in
         specs @ super_specs_for_sign sign super interfs
@@ -617,13 +623,15 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let rec iter mmap erased_mmap meths =
           match meths with
             [] -> cont (cn, (l, abstract, fin, List.rev mmap, fds, constr, super, tparams, interfs, preds, pn, ilist))
-          | Meth (lm, gh, rt, n, ps, co, ss, fb, v,abstract)::meths ->
+          | Meth (lm, gh, rt, n, ps, co, ss, fb, v,abstract, mtparams)::meths ->
+            (* Only combine them for typechecking, names will never overlap and both are in scope here *)
+            let allTparams = tparams @ mtparams in
             let xmap =
                 let rec iter xm xs =
                   match xs with
                    [] -> List.rev xm
                  | (te, x)::xs -> if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
-                     let t = check_pure_type (pn,ilist) tparams Real te in
+                     let t = check_pure_type (pn,ilist) allTparams Real te in
                      iter ((x, t)::xm) xs
                 in
                 iter [] ps
@@ -634,7 +642,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             (* Apply type erasure to sign that is used to check for duplicate methods after erasure*)
             let erasedSign = (n, List.map erase_type (List.map snd xmap1)) in
             if List.mem_assoc erasedSign erased_mmap then static_error lm "Duplicate method after erasure." None;
-            let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn, ilist) tparams Real rt) in
+            let rt = match rt with None -> None | Some rt -> Some (check_pure_type (pn, ilist) allTparams Real rt) in
             let co =
               match co with
                 None -> None
@@ -653,7 +661,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let super_specs = if fb = Static then [] else super_specs_for_sign sign super interfs in
             if not is_jarspec then
             List.iter
-              begin fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract')) ->
+              begin fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', mtparams')) ->
                 if gh <> gh' then
                   begin match gh with
                     Ghost -> static_error lm "A lemma method cannot implement or override a non-lemma method." None
@@ -682,13 +690,13 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                 Some spec -> spec
               | None ->
                 match super_specs with
-                  (tn, ItfMethodInfo (_, _, _, xmap', pre', pre_tenv', post', epost', terminates', _, _))::_ ->
+                  (tn, ItfMethodInfo (_, _, _, xmap', pre', pre_tenv', post', epost', terminates', _, _, _))::_ ->
                   if not (List.for_all2 (fun (x, t) (x', t') -> x = x') xmap xmap') then static_error lm (Printf.sprintf "Parameter names do not match overridden method in %s" tn) None;
                   (pre', pre_tenv', post', epost', pre', post', epost', terminates')
                 | [] -> static_error lm "Method must have contract" None
             in
             let ss = match ss with None -> None | Some ss -> Some (Some ss) in
-            let methodInfo = MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, super_specs <> [], abstract) in
+            let methodInfo = MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, super_specs <> [], abstract, mtparams) in
             iter ((sign, methodInfo)::mmap) ((erasedSign, methodInfo)::erased_mmap) meths
         in
         iter [] [] meths
@@ -834,11 +842,11 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec iter meths0 meths1=
               match meths0 with
                 [] -> meths1
-              | (sign0, MethodInfo (lm0,gh0,rt0,xmap0,pre0,pre_tenv0,post0,epost0,pre_dyn0,post_dyn0,epost_dyn0,terminates0,ss0,fb0,v0,_,abstract0)) as elem::rest ->
+              | (sign0, MethodInfo (lm0,gh0,rt0,xmap0,pre0,pre_tenv0,post0,epost0,pre_dyn0,post_dyn0,epost_dyn0,terminates0,ss0,fb0,v0,_,abstract0, mtparams0)) as elem::rest ->
                 let epost0: (type_ * asn) list = epost0 in
                 match try_assoc sign0 meths1 with
                   None-> iter rest (elem::meths1)
-                | Some (MethodInfo (lm1,gh1,rt1,xmap1,pre1,pre_tenv1,post1,epost1,pre_dyn1,post_dyn1,epost_dyn1,terminates1,ss1,fb1,v1,_,abstract1)) -> 
+                | Some (MethodInfo (lm1,gh1,rt1,xmap1,pre1,pre_tenv1,post1,epost1,pre_dyn1,post_dyn1,epost_dyn1,terminates1,ss1,fb1,v1,_,abstract1, mtparams1)) -> 
                   let epost1: (type_ * asn) list = epost1 in
                   let (mn, _) = sign0 in
                   check_func_header_compat lm1 ("Method '" ^ mn ^ "'") "Method implementation check" []
@@ -914,7 +922,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let {cmeths; csuper=(csuper, targs)} = List.assoc cn classmap in
         let overrides =
           flatmap
-            begin fun (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract)) ->
+            begin fun (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, mtparams)) ->
               if is_override || pre != pre_dyn || post != post_dyn then [(cn, sign)] else []
             end
             cmeths
@@ -942,8 +950,8 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     if trust_cabstract && not cabstract then [] else
     let inherited_unimplemented_methods = unimplemented_class_methods csuper true @ flatmap interface_methods (List.map fst cinterfs) in
     let erased_inherited_unimplemented_methods = List.map (fun ((mn,ts),info) -> ((mn, List.map erase_type ts), info)) inherited_unimplemented_methods in
-    let abstract_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, true)) -> [sign, ("class", cn)] | _ -> []) cmeths in
-    let implemented_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, false)) -> [sign] | _ -> []) cmeths in
+    let abstract_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, true, mtparams)) -> [sign, ("class", cn)] | _ -> []) cmeths in
+    let implemented_methods = flatmap (function (sign, MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, Instance, v, is_override, false, mtparams)) -> [sign] | _ -> []) cmeths in
     let erased_implemented_methods = List.map (fun (mn,ts) -> (mn,List.map erase_type ts)) implemented_methods in
     List.filter (fun ((mn,ts), _) -> 
       let erasedSign = (mn, List.map erase_type ts) in
@@ -988,7 +996,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let rec iter mlist meths_impl=
               match mlist with
                 [] -> meths_impl
-              | Meth(lm,gh,rt,n,ps,co,None,fb,v,abstract)::rest ->
+              | Meth(lm,gh,rt,n,ps,co,None,fb,v,abstract, mtparams)::rest ->
                 if List.mem (n,lm) meths_impl then
                   let meths_impl'= remove (fun (x,l0) -> x=n && lm=l0) meths_impl in
                   iter rest meths_impl'
@@ -2108,10 +2116,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       | _ -> static_error l "Multiple matching overloads" None
       end
     | WMethodCall (l, tn, m, pts, args, fb, tpenv) when m <> "getClass" ->
-      let (lm, gh, rt, xmap, pre, post, epost, terminates, is_upcall, target_class, fb', v) =
+      let (lm, gh, rt, xmap, pre, post, epost, terminates, is_upcall, target_class, fb', v, mtparams) =
         match try_assoc tn classmap with
         Some {cfinal; cmeths} ->
-          let MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract) = List.assoc (m, pts) cmeths in
+          let MethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, pre_dyn, post_dyn, epost_dyn, terminates, ss, fb, v, is_override, abstract, mtparams) = List.assoc (m, pts) cmeths in
           let can_be_overridden = fb = Instance && cfinal = ExtensibleClass && v <> Private in 
           let is_upcall =
             not can_be_overridden &&
@@ -2123,18 +2131,19 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let target_class = if can_be_overridden then None else Some tn in
           let rt = match rt with Some (rt) -> Some(replace_type l tpenv rt) | None -> None in
           let xmap = List.map (fun (name,tp) -> (name, replace_type l tpenv tp)) xmap in
-          (lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, is_upcall, target_class, fb, v)
+          (lm, gh, rt, xmap, pre_dyn, post_dyn, epost_dyn, terminates, is_upcall, target_class, fb, v, mtparams)
         | _ ->
           let InterfaceInfo (_, _, methods, _, _, _) = List.assoc tn interfmap in
-          let ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract) = List.assoc (m, pts) methods in
-          (lm, gh, rt, xmap, pre, post, epost, terminates, false, None, Instance, v)
+          let ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract, mtparams) = List.assoc (m, pts) methods in
+          (lm, gh, rt, xmap, pre, post, epost, terminates, false, None, Instance, v, mtparams)
       in
+      let mtargs = List.map (fun tparam -> List.assoc tparam tpenv) mtparams in
       if gh = Real && pure then static_error l "Method call is not allowed in a pure context" None;
       if gh = Ghost then begin
         if not pure then static_error l "A lemma method call is not allowed in a non-pure context." None;
         if leminfo_is_lemma leminfo then static_error l "Lemma method calls in lemmas are currently not supported (for termination reasons)." None
       end;
-      check_correct h xo None [] args (lm, [], rt, xmap, [], pre, post, Some epost, terminates, v) is_upcall target_class cont
+      check_correct h xo None mtargs args (lm, mtparams, rt, xmap, [], pre, post, Some epost, terminates, v) is_upcall target_class cont
     | WSuperMethodCall(l, supercn, m, args, (lm, gh, rt, xmap, pre, post, epost, terminates, rank, v)) ->
       if gh = Real && pure then static_error l "Method call is not allowed in a pure context" None;
       if gh = Ghost then begin

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -510,10 +510,8 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let interf_specs_for_sign map1 sign (itf, passedTypes) =
     let InterfaceInfo (_, fields, meths, _, _, tparams) = List.assoc itf map1 in
-    (* If we have tparams, but no passed types: raw type *)
     let interTparamEnv = match tparams with 
       [] -> [] 
-    | tparams when passedTypes = [] -> List.map (fun tparam -> (tparam, javaLangObject)) tparams
     | tparams -> List.map2 (fun a b -> (a, b)) tparams passedTypes
     in
     let eraseSign = (fun (n, args) -> (n, List.map erase_type args)) in
@@ -537,7 +535,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         [] -> map1
       | (i, InterfaceInfo (l, fields, meths, preds, interfs, tparams)) as elem::rest ->
         List.iter (fun (sign, ItfMethodInfo (lm, gh, rt, xmap, pre, pre_tenv, post, epost, terminates, v, abstract, mtparams)) ->
-          let superspecs = List.flatten (List.map (fun i -> interf_specs_for_sign map1 sign i) interfs) in
+          let superspecs = List.flatten (List.map (interf_specs_for_sign map1 sign) interfs) in
           List.iter (fun (tn, ItfMethodInfo (lsuper, gh', rt', xmap', pre', pre_tenv', post', epost', terminates', vis', abstract', mtparams')) ->
             if rt <> rt' then 
               static_error lm ("Return type (" 

--- a/tests/java/generics/QualifiedGenericMethodCall.java
+++ b/tests/java/generics/QualifiedGenericMethodCall.java
@@ -1,0 +1,21 @@
+import java.util.Arrays;
+
+public class QualifiedGenericMethodCall {
+	public static <T,V> V usefulMethod(T arg, V arg2)
+	//@ requires true;
+	//@ ensures true;
+	{
+		return arg2;
+	}
+	
+	public static void main(String[] args) 
+	//@ requires true;
+	//@ ensures true;
+	{
+		// Qualified call to static parameterised method:
+		// Type arguments explicitly provided.
+		Integer[] a = {new Integer(1), new Integer(2)};
+		Boolean b = new Boolean(true);
+		QualifiedGenericMethodCall.<Integer[], Boolean>usefulMethod(a, b);
+	}
+}

--- a/tests/java/generics/QualifiedGenericMethodCall.java
+++ b/tests/java/generics/QualifiedGenericMethodCall.java
@@ -1,6 +1,7 @@
 import java.util.Arrays;
 
 public class QualifiedGenericMethodCall {
+
 	public static <T,V> V usefulMethod(T arg, V arg2)
 	//@ requires true;
 	//@ ensures true;
@@ -17,5 +18,23 @@ public class QualifiedGenericMethodCall {
 		Integer[] a = {new Integer(1), new Integer(2)};
 		Boolean b = new Boolean(true);
 		QualifiedGenericMethodCall.<Integer[], Boolean>usefulMethod(a, b);
+		
+		Integer c = new Integer(3);
+		
+		Bar myBar = new Bar();
+		myBar.<Integer, Boolean>foo(c,b);
 	}
+}
+
+public class Bar {
+    public <T> void foo(int x, T y) 
+    //@ requires true;
+    //@ ensures true;
+    {  
+    	this.<Integer,T>foo(x,y);
+    }
+    public <T, U> void foo(T x, U y)
+    //@ requires true;
+    //@ ensures true;
+    {  }
 }

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -501,6 +501,7 @@ cd tests
     verifast -c BasicGenericClass.java
     verifast -c GenericInheritance.java
     verifast -c GenericType.java
+    verifast -c QualifiedGenericMethodCall.java
     cd ..
   cd ..
 cd ..


### PR DESCRIPTION
Added the possibility of creating methods that have local type arguments. These methods can only be called as a qualified call and if the type arguments are provided.

<Targ>call(); will not parse correctly
Utility.<Targ>call(); will verify correct
Utility.call(); will throw an error that insufficient type arguments are provided.