### PR TITLE
Make the realloc contract nicer

### DIFF
--- a/bin/malloc.h
+++ b/bin/malloc.h
@@ -35,13 +35,13 @@ void free(void *array);
 
 void *realloc(void *array, size_t newSize);
     //@ requires malloc_block(array, ?size) &*& chars(array, size, ?cs);
-    /*@
-    ensures
-        result == 0 ?
-            malloc_block(array, size) &*& chars(array, size, cs)
-        :
-            malloc_block(result, newSize) &*& chars(result, newSize, ?newCs) &*&
-            take(size <= newSize ? size : newSize, cs) == take(size <= newSize ? size : newSize, newCs);
+    /*@ ensures
+        result == 0 ? malloc_block(array, size) &*& chars(array, size, cs)
+        : malloc_block(result, newSize)
+        &*& chars(result, _, take(newSize,cs))
+        &*& newSize <= size ? emp
+            : chars(result + size, newSize-size, _);
     @*/
+    /*@ terminates; @*/
 
 #endif

--- a/bin/malloc.h
+++ b/bin/malloc.h
@@ -35,13 +35,17 @@ void free(void *array);
 
 void *realloc(void *array, size_t newSize);
     //@ requires malloc_block(array, ?size) &*& chars(array, size, ?cs);
-    /*@ ensures
-        result == 0 ? malloc_block(array, size) &*& chars(array, size, cs)
-        : malloc_block(result, newSize)
-        &*& chars(result, _, take(newSize,cs))
-        &*& newSize <= size ? emp
-            : chars(result + size, newSize-size, _);
+    /*@
+    ensures
+        result == 0 ?
+            malloc_block(array, size) &*& chars(array, size, cs)
+        :
+            malloc_block(result, newSize) &*& chars(result, _, take(newSize, cs)) &*&
+            newSize <= size ?
+                emp
+            :
+                chars(result + size, newSize - size, _);
     @*/
-    /*@ terminates; @*/
+    //@ terminates;
 
 #endif


### PR DESCRIPTION
I ran into some difficulty using the existing `realloc` contract contract -- this change makes it simpler to use.
 - The `newSize <= size` case is explicit. Using `take(newSize,cs)` is also fine if `newSize > size` -- `take(newSize,cs) == cs`.
 - If `newSize > size`, the extra space is returned in a distinct `chars(...)`. This makes growing a buffer simpler -- if your heap looks like `malloc_block(buffer,cap) &*& buffer[..len] |-> cs &*& buffer[len+1..cap] |-> _`, then calling realloc when `len+1 == cap` no longer requires `chars_split` to get the heap back into shape.
 - `realloc()` is now labelled as `terminates`.