### PR TITLE
Prioritize the old value of `x` over the current value of `old_x`.

### DIFF
--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -1591,14 +1591,23 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       end;
       let bs' = List.map (fun x -> (x, get_unique_var_symb_ x (List.assoc x tenv) (List.mem x ghostenv))) xs in
       let env'' =
-        flatmap
+        (flatmap
           begin fun (x, t) ->
             if List.mem x xs then
-              [("old_" ^ x, t); (x, List.assoc x bs')]
+                [("old_" ^ x, t)]
             else
-              [(x, t)]
+                []
           end
-          env''
+          env'')
+        @
+        (List.map
+          begin fun (x, t) ->
+            if List.mem x xs then
+                (x, List.assoc x bs')
+            else
+              (x, t)
+          end
+          env'')
       in
       produce_asn [] h' ghostenv'' env'' post real_unit None None $. fun h' _ _ ->
       let env' = bs' @ env' in

--- a/tests/issue206.c
+++ b/tests/issue206.c
@@ -1,0 +1,61 @@
+// https://github.com/verifast/verifast/issues/206
+
+int foo_good()
+    /*@ requires true; @*/
+    /*@ ensures  result == 3*7*6; @*/
+    /*@ terminates; @*/
+{
+    int x = 0;
+    int i,j,k;
+
+    for(i = 0; i < 6; ++i)
+        /*@ requires i >= 0 &*& i <= 6 &*& x + 3*7*(6-i) < 100000; @*/
+        /*@ ensures x == old_x + 3*7*(i - old_i); @*/
+        /*@ decreases 6-i; @*/
+    {
+        for(j = 0; j < 7; ++j)
+            /*@ requires j >= 0 &*& j <= 7 &*& x + 3*(7-j) < 100000; @*/
+            /*@ ensures x == old_x + 3*(j - old_j); @*/
+            /*@ decreases 7-j; @*/
+        {
+            for(k = 0; k < 3; ++k)
+                /*@ requires k >= 0 &*& k <= 3 &*& x + (3-k) < 100000; @*/
+                /*@ ensures  old_x + (3-old_k) == x; @*/
+                /*@ decreases 3-k; @*/
+            {
+                ++x;
+            }
+        }
+    }
+    return x;
+}
+
+int foo_bad()
+    /*@ requires true; @*/
+    /*@ ensures  result == 0; @*/
+    /*@ terminates; @*/
+{
+    int x = 0;
+    int i,j,k;
+
+    for(i = 0; i < 6; ++i)
+        /*@ requires i >= 0 &*& i <= 6 &*& x + 3*7*(6-i) < 100000; @*/
+        /*@ ensures  old_x == x; @*/
+        /*@ decreases 6-i; @*/
+    {
+        for(j = 0; j < 7; ++j)
+            /*@ requires j >= 0 &*& j <= 7 &*& x + 3*(7-j) < 100000; @*/
+            /*@ ensures  old_x == x; @*/ //~ should_fail
+            /*@ decreases 7-j; @*/
+        {
+            for(k = 0; k < 3; ++k)
+                /*@ requires k >= 0 &*& k <= 3 &*& x + (3-k) < 100000; @*/
+                /*@ ensures  old_x + (3-old_k) == x; @*/
+                /*@ decreases 3-k; @*/
+            {
+                ++x;
+            }
+        }
+    }
+    return x;
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -417,6 +417,7 @@ cd tutorial_solutions
   verifast_both students.c
 cd ..
 cd tests
+  verifast -c -allow_should_fail issue206.c
   verifast -c -allow_should_fail two_should_fails.c
   verifast -c -allow_should_fail div_mod_negative_dividend.c
   verifast -c -prover z3v4.5 prod_func_ptr_chunk_ftargs_convert_provertype.c


### PR DESCRIPTION
Fixes https://github.com/verifast/verifast/issues/206