### PR TITLE
Support sizeof(bool) and bools_inv

### DIFF
--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -71,6 +71,7 @@
 .provides ./prelude.h#ullongs_inv
 .provides ./prelude.h#shorts_inv
 .provides ./prelude.h#ushorts_inv
+.provides ./prelude.h#bools_inv
 .provides ./prelude.h#pointers_inv
 .provides ./prelude.h#pointers_limits
 .provides ./prelude.h#pointers_split

--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -329,6 +329,10 @@ predicate bools(bool *p, int count; list<bool> vs) =
     :
         boolean(p, ?v) &*& bools(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0);
 
+lemma_auto void bools_inv();
+    requires [?f]bools(?p, ?count, ?vs);
+    ensures [f]bools(p, count, vs) &*& count == length(vs);
+
 predicate pointers(void **pp, int count; list<void *> ps) =
     count == 0 ?
         ps == nil

--- a/examples/mcas/bitops_ex.vfmanifest
+++ b/examples/mcas/bitops_ex.vfmanifest
@@ -50,6 +50,7 @@
 .requires CRT/nat.gh#pow_nat_nonnegative
 .requires CRT/nat.gh#succ_int
 .requires CRT/prelude.h#body_chars_to_string
+.requires CRT/prelude.h#bools_inv
 .requires CRT/prelude.h#character_to_u_character
 .requires CRT/prelude.h#chars_inv
 .requires CRT/prelude.h#chars_join

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -5005,7 +5005,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let rec sizeof l t =
     match t with
       Void -> ctxt#mk_intlit 1
-    | Bool -> rank_size_term 1
+    | Bool -> rank_size_term 0
     | Int (_, k) -> rank_size_term k
     | PtrType _ -> ctxt#mk_intlit (1 lsl ptr_rank)
     | StructType sn -> struct_size l sn

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -5005,6 +5005,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let rec sizeof l t =
     match t with
       Void -> ctxt#mk_intlit 1
+    | Bool -> rank_size_term 1
     | Int (_, k) -> rank_size_term k
     | PtrType _ -> ctxt#mk_intlit (1 lsl ptr_rank)
     | StructType sn -> struct_size l sn


### PR DESCRIPTION
This is necessary and sufficient to make the following program verify:

```c
#include <stdbool.h>
#include <stdlib.h>

void x(bool* bs)
//@ requires bools(bs, ?c, ?lst);
//@ ensures bools(bs, c, lst);
{
        //@ assert length(lst) == c;
}

int main(int argc, char** argv)
//@ requires true;
//@ ensures true;
{
        bool* bs = malloc(10 * sizeof(bool));
        if (bs == 0) return 1;
        //@ assert malloc_block_bools(bs, 10);
        //@ assert bools(bs, 10, ?bs_list);
        //@ assert length(bs_list) == 10;
        x(bs);
        free(bs);
        return 0;
}
```