### PR TITLE
Add '#pragma once' support

### DIFF
--- a/src/parser.ml
+++ b/src/parser.ml
@@ -35,7 +35,7 @@ let c_keywords = [
   "struct"; "bool"; "char"; "sizeof"; "#"; "##"; "include"; "ifndef";
   "define"; "endif"; "&"; "goto"; "uintptr_t"; "intptr_t"; "INT_MIN"; "INT_MAX";
   "UINTPTR_MAX"; "enum"; "static"; "signed"; "unsigned"; "long";
-  "const"; "volatile"; "register"; "ifdef"; "elif"; "undef";
+  "const"; "volatile"; "register"; "ifdef"; "elif"; "undef"; "pragma";
   "SHRT_MIN"; "SHRT_MAX"; "USHRT_MAX"; "UINT_MAX";
   "CHAR_MIN"; "CHAR_MAX"; "UCHAR_MAX";
   "LLONG_MIN"; "LLONG_MAX"; "ULLONG_MAX";

--- a/tests/preprocessor_pragma/once_top.c
+++ b/tests/preprocessor_pragma/once_top.c
@@ -1,0 +1,2 @@
+#include "once_top.h"
+#include "once_top.h"

--- a/tests/preprocessor_pragma/once_top.h
+++ b/tests/preprocessor_pragma/once_top.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// this line will cause an error if the pragma directive is not respected when including this file a second time
+int x = 0;

--- a/tests/preprocessor_pragma/run.mysh
+++ b/tests/preprocessor_pragma/run.mysh
@@ -1,0 +1,1 @@
+verifast -c once_top.c

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -441,6 +441,9 @@ cd tests
   cd preprocessor_if
     mysh < run.mysh
   cd ..
+  cd preprocessor_pragma
+    mysh < run.mysh
+  cd ..
   verifast -c nodecl_and_semicolon.c
   verifast_both -c test-pattern-match-constructor-subtyping.c
   verifast_both -c test-octal-number.c


### PR DESCRIPTION
This avoids the need to wrap each header in ifdef/define/endif.

I added support only at the beginning of a file; technically, `#pragma once` can appear anywhere in the file with the same effect (GCC and Clang both support this), but this is unlikely to happen in real code and I didn't see an obvious way to handle it in VeriFast's preprocessor, so I added an error in that case instead.