### PR TITLE
Makefile: Fix Z3_DLL_DIR when Z3 is installed using OPAM

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -104,8 +104,14 @@ ifndef NOZ3
 endif
 Z3V4DOT5PRESENT=false
 ifdef Z3V4DOT5
-  Z3_OCAML ?= $(shell ocamlfind query -qe Z3 || ocamlfind query z3)# It's Z3 when installed using `make install` and z3 when installed using OPAM
-  Z3_DLL_DIR ?= $(Z3_OCAML)/../..
+  # It's Z3 when installed using `make install` and z3 when installed using OPAM
+  Z3_OCAML ?= $(shell ocamlfind query -qe Z3)
+  ifeq ($(Z3_OCAML),)
+    Z3_OCAML := $(shell ocamlfind query z3)
+    Z3_DLL_DIR ?= $(Z3_OCAML)
+  else
+    Z3_DLL_DIR ?= $(Z3_OCAML)/../..
+  endif
   Z3DEPS := z3$(Z3VERSION)prover.cmx verifastPluginZ3$(Z3VERSION).ml verifastPluginReduxZ3$(Z3VERSION).ml verifastPluginZ3$(Z3VERSION)Smtlib.ml
   ifeq ($(OS), Darwin)
     Z3DEPS := $(Z3DEPS) ../lib/libz3.dylib


### PR DESCRIPTION
This is a version of #158 that doesn't break the manual install case.

With this, the following script is enough to install everything needed to make VeriFast on Ubuntu 18.04, outsourcing the dependency-building part to opam:

```
sudo apt-get update

# I can't get z3 to build in parallel with opam 1.x whereas opam 2.x allows it, which is a _lot_ faster
# On Ubuntu >=20.04 this is not needed since the default opam is 2.x
sudo apt-get install -y --no-install-recommends software-properties-common
sudo add-apt-repository -y -u ppa:avsm/ppa

# opam's z3 needs python2.7, m4, libgmp-dev
# opam's camlp4 needs camlp4-extra
# opam's lablgtk needs libgtk2.0-dev, gtksourceview2.0-dev
sudo apt-get install -y --no-install-recommends \
                     ocaml opam \
                     g++ python2.7 m4 libgmp-dev `# for opam's z3` \
                     camlp4-extra `# for opam's camlp4` \
                     libgtk2.0-dev gtksourceview2.0-dev `# for opam's lablgtk`

# If running in a Docker container, add `--disable-sandboxing` to opam init
opam init -y
eval $(opam config env)

# z3 must be 4.8.1 since that's the latest version that ships libz3.so, which VeriFast needs
# conf-gtksourceview is required for lablgtk to contain GSourceView2, which VeriFast needs
opam install -y num z3.4.8.1 camlp4 conf-gtksourceview lablgtk
```