### PR TITLE
Check oversized left-shifts as well

### DIFF
--- a/tests/errors/shift_errors.c
+++ b/tests/errors/shift_errors.c
@@ -12,6 +12,13 @@ long long shift_left_excessive_amount()
   return 1LL << 63; //~ should_fail
 }
 
+unsigned long long unsigned_shift_left_excessive_amount()
+//@ requires true;
+//@ ensures true;
+{
+  return /*@ truncating @*/ (1ULL << 64); //~ should_fail
+}
+
 long long shift_left_negative_value()
 //@ requires true;
 //@ ensures true;


### PR DESCRIPTION
6.5.7.3 of C99:
> The integer promotions are performed on each of the operands. The type of the result is
that of the promoted left operand. If the value of the right operand is negative or is
greater than or equal to the width of the promoted left operand, the behavior is undefined.

So we need to check the width regardless of the signedness of the type.