### PR TITLE
Support void casts

### DIFF
--- a/examples/void_ignore.c
+++ b/examples/void_ignore.c
@@ -1,0 +1,6 @@
+void foo(int x)
+//@ requires true;
+//@ ensures true;
+{
+	(void) x;
+}

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -2507,6 +2507,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | (InductiveType (_, _) as tp, AnyType) -> if not (type_satisfies_contains_any_constraint true tp) then static_error l (msg ^ "Cannot cast type " ^ string_of_type tp ^ " to 'any' because it contains 'any' in a negative position.") None
     | (InductiveType (i1, args1), InductiveType (i2, args2)) when i1 = i2 ->
       List.iter2 (expect_type_core l msg inAnnotation) args1 args2
+    | (_, Void) -> ()
     | _ -> if unify t t0 then () else static_error l (msg ^ "Type mismatch. Actual: " ^ string_of_type t ^ ". Expected: " ^ string_of_type t0 ^ ".") None
   
   let expect_type l (inAnnotation: bool option) t t0 = expect_type_core l "" inAnnotation t t0

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -391,6 +391,7 @@ cd examples
   cd vacid-0
     ifz3 verifast -c -disable_overflow_check Problem3.c
   cd ..
+  verifast_both -c void_ignore.c
 cd ..
 cd tutorial_solutions
   verifast_both -c -disable_overflow_check account.c


### PR DESCRIPTION
These are used to suppress "unused parameter" compiler warnings.