### PR TITLE
Support _Noreturn static functions

### DIFF
--- a/examples/noreturn.c
+++ b/examples/noreturn.c
@@ -1,0 +1,24 @@
+_Noreturn void external_func(void);
+//@ requires emp;
+//@ ensures false;
+
+_Noreturn static void static_proxy_func(void)
+//@ requires emp;
+//@ ensures false;
+{
+	external_func();
+}
+
+_Noreturn inline void inline_proxy_func(void)
+//@ requires emp;
+//@ ensures false;
+{
+	external_func();
+}
+
+_Noreturn static inline void static_inline_proxy_func(void)
+//@ requires emp;
+//@ ensures false;
+{
+	external_func();
+}

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -458,6 +458,10 @@ and
 | [< '(l, Kwd "__always_inline") >] -> ()
 | [< >] -> ()
 and
+  parse_static_visibility = parser
+  [< '(l, Kwd "static") >] -> Private
+| [< >] -> Public
+and
   parse_enum_body = parser
   [< '(_, Kwd "{");
      elems = rep_comma (parser [< '(_, Ident e); init = opt (parser [< '(_, Kwd "="); e = parse_expr >] -> e) >] -> (e, init));
@@ -509,7 +513,7 @@ and
   >] -> check_function_for_contract d
 | [< '(_, Kwd "static"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Private >] -> check_function_for_contract d
 | [< '(_, Kwd "extern"); t = parse_return_type; d = parse_func_rest Regular t Public >] -> check_function_for_contract d
-| [< '(_, Kwd "_Noreturn"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t Public >] ->
+| [< '(_, Kwd "_Noreturn"); v = parse_static_visibility; _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t v >] ->
   let ds = check_function_for_contract d in
   begin match ds with
     [Func (l, k, tparams, t, g, ps, gc, ft, Some (pre, post), terminates, ss, static, v)] ->

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -391,6 +391,7 @@ cd examples
   cd vacid-0
     ifz3 verifast -c -disable_overflow_check Problem3.c
   cd ..
+  verifast_both -c noreturn.c
 cd ..
 cd tutorial_solutions
   verifast_both -c -disable_overflow_check account.c


### PR DESCRIPTION
I added tests for the combinations of static and inline with _Noreturn while I was at it.