### PR TITLE
Improve sizeof handling, including packed structures

### DIFF
--- a/examples/sizeof/packed.c
+++ b/examples/sizeof/packed.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+struct x {
+	uint64_t a;
+	uint8_t b;
+} __attribute__((packed));
+
+struct y {
+	struct x value;
+};
+
+void foo(void)
+//@ requires emp;
+//@ ensures emp;
+{
+	// Proper size
+	//@ assert sizeof(struct x) == 9;
+
+	// No offset inside
+	struct x value;
+	//@ assert (char*) &(value.b) == (char*) &value + sizeof(uint64_t);
+
+	// No padding
+	struct y* allocated = malloc(sizeof(struct y));
+	if (allocated != NULL) {
+		//@ leak malloc_block_y(allocated);
+		//@ leak x_a(&(allocated->value), _);
+		//@ leak x_b(&(allocated->value), _);
+	}
+}

--- a/examples/sizeof/struct.c
+++ b/examples/sizeof/struct.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+
+struct x {
+	uint64_t a;
+	uint64_t b;
+};
+
+void foo(void)
+//@ requires emp;
+//@ ensures emp;
+{
+	//@ assert sizeof(struct x) >= 0;
+	//@ assert sizeof(struct x) <= SIZE_MAX;
+
+	// The compiler can add alignment or padding, so this may not be true
+	//@ assert sizeof(struct x) == 16; //~ should_fail
+}

--- a/examples/usbkbd/src/linux/input.h
+++ b/examples/usbkbd/src/linux/input.h
@@ -81,6 +81,13 @@ typedef input_event_t_no_pointer* input_event_t;
 //@ predicate input_event_t_ghost_param(input_event_t_no_pointer *cb1, input_event_t cb2) = is_input_event_t_no_pointer(cb1) == true &*& cb1 == cb2;
 
 
+struct input_id {
+	__u16 bustype;
+	__u16 vendor;
+	__u16 product;
+	__u16 version;
+};
+
 struct input_dev {
 	char *name; //"The dev->name should be set before registering the input device by the input device driver" -- input-programming.txt
 	char* phys; // Should this be initialized by the driver or can it remain equal to 0? We currently assume the latter.
@@ -347,13 +354,6 @@ static inline void input_report_rel(struct input_dev *dev, unsigned int code, in
 void input_sync(struct input_dev *dev);
 	//@ requires [?f]input_dev_reportable(dev, ?userdata); // XXX hm I thought they synchronize but I should recheck this.
 	//@ ensures [f]input_dev_reportable(dev, userdata);
-
-struct input_id {
-	__u16 bustype;
-	__u16 vendor;
-	__u16 product;
-	__u16 version;
-};
 
 
 // Event types:

--- a/examples/usbkbd/src/linux/usb.h
+++ b/examples/usbkbd/src/linux/usb.h
@@ -203,6 +203,18 @@ void usb_deregister(struct usb_driver *driver);
 	&*& probe_disconnect_userdata(probe, disconnect)();
 @*/
 
+struct usb_host_endpoint {
+	struct usb_endpoint_descriptor          desc;
+	//struct usb_ss_ep_comp_descriptor        ss_ep_comp;
+	//struct list_head                urb_list;
+	//void                            *hcpriv;
+	//struct ep_device                *ep_dev;        /* For sysfs info */
+	//
+	//unsigned char *extra;   /* Extra descriptors */
+	//int extralen;
+	//int enabled;
+};
+
 
 struct usb_device {
 	struct usb_host_endpoint ep0;
@@ -1147,19 +1159,6 @@ struct usb_interface {
 //	atomic_t pm_usage_cnt;		/* usage counter for autosuspend */
 //	struct work_struct reset_ws;	/* for resets in atomic context */
 	struct device dev;
-};
-
-
-struct usb_host_endpoint {
-	struct usb_endpoint_descriptor          desc;
-	//struct usb_ss_ep_comp_descriptor        ss_ep_comp;
-	//struct list_head                urb_list;
-	//void                            *hcpriv;
-	//struct ep_device                *ep_dev;        /* For sysfs info */
-	//
-	//unsigned char *extra;   /* Extra descriptors */
-	//int extralen;
-	//int enabled;
 };
 
 

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -118,7 +118,7 @@ and sexpr_of_inferred_type_state = function
   | EqConstraint t -> List [ Symbol "inferred-type-state-eq-constraint"; sexpr_of_type_ t ]
 
 let rec sexpr_of_type_expr : type_expr -> sexpression = function
-  | StructTypeExpr (_, name, _) ->
+  | StructTypeExpr (_, name, _, _) ->
       List [ Symbol "type-expr-struct"; sexpr_of_option (fun s -> Symbol s) name ]
   | UnionTypeExpr (_, name, _) ->
       List [ Symbol "type-expr-union"; sexpr_of_option (fun s -> Symbol s) name ]
@@ -152,6 +152,9 @@ let rec sexpr_of_type_expr : type_expr -> sexpression = function
 let sexpr_of_type_expr_option : type_expr option -> sexpression = function
   | Some t -> sexpr_of_type_expr t
   | None   -> Symbol "nil"
+
+let sexpr_of_attr : struct_attr -> sexpression = function
+  | Packed -> Symbol "packed"
 
 let sexpr_of_field (Field (loc, ghostness, type_expr, name, binding, visibility, final, expr)) : sexpression =
   build_list
@@ -860,15 +863,19 @@ and sexpr_of_decl (decl : decl) : sexpression =
   match decl with
     | Struct (loc,
               name,
-              None) ->
-        List [ Symbol "declare-struct"
-             ; Symbol name ]
+              None,
+              attrs) ->
+        build_list [ Symbol "declare-struct"
+                   ; Symbol name ]
+                   [ "attrs", sexpr_of_list ~head:(Some (Symbol "attrs")) sexpr_of_attr attrs ]
     | Struct (loc,
               name,
-              Some fields) ->
+              Some fields,
+              attrs) ->
         build_list [ Symbol "define-struct"
                    ; Symbol name ]
-                   [ "fields", sexpr_of_list ~head:(Some (Symbol "fields")) sexpr_of_field fields ]
+                   [ "fields", sexpr_of_list ~head:(Some (Symbol "fields")) sexpr_of_field fields
+                   ; "attrs", sexpr_of_list ~head:(Some (Symbol "attrs")) sexpr_of_attr attrs ]
     | Func (loc,
             kind,
             tparams,

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -235,7 +235,7 @@ type int_literal_lsuffix = NoLSuffix | LSuffix | LLSuffix
 
 (** Types as they appear in source code, before validity checking and resolution. *)
 type type_expr = (* ?type_expr *)
-    StructTypeExpr of loc * string option * field list option
+    StructTypeExpr of loc * string option * field list option * struct_attr list
   | UnionTypeExpr of loc * string option * field list option
   | EnumTypeExpr of loc * string option * (string * expr option) list option
   | PtrTypeExpr of loc * type_expr
@@ -697,7 +697,7 @@ and
   | ExtensibleClass
 and
   decl = (* ?decl *)
-    Struct of loc * string * field list option
+    Struct of loc * string * field list option * struct_attr list
   | Union of loc * string * field list option
   | Inductive of  (* inductief data type regel-naam-type parameters-lijst van constructors*)
       loc *
@@ -829,6 +829,9 @@ and
   | MethMember of meth
   | ConsMember of cons
   | PredMember of instance_pred_decl
+and
+  struct_attr =
+  | Packed
 
 let func_kind_of_ghostness gh =
   match gh with
@@ -1008,7 +1011,7 @@ let stmt_iter f s = stmt_fold (fun _ s -> f s) () s
 let type_expr_loc t =
   match t with
     ManifestTypeExpr (l, t) -> l
-  | StructTypeExpr (l, sn, _) -> l
+  | StructTypeExpr (l, sn, _, _) -> l
   | UnionTypeExpr (l, un, _) -> l
   | IdentTypeExpr (l, _, x) -> l
   | ConstructedTypeExpr (l, x, targs) -> l

--- a/src/explorer.ml
+++ b/src/explorer.ml
@@ -282,7 +282,7 @@ let _ =
 
     let rec string_of_type_expr (type_expr: type_expr): string =
       match type_expr with
-        | StructTypeExpr(_, name_opt, _) -> (match name_opt with Some name -> name | _ -> "")
+        | StructTypeExpr(_, name_opt, _, _) -> (match name_opt with Some name -> name | _ -> "")
         | EnumTypeExpr(_, name_opt, _) -> (match name_opt with Some name -> name | _ -> "")
         | PtrTypeExpr(_, type_expr_in) -> string_of_type_expr type_expr_in ^ " *"
         | ArrayTypeExpr(_, type_expr_in) -> string_of_type_expr type_expr_in ^ "[]"
@@ -440,10 +440,10 @@ let _ =
 
       let rec check_type_expr_equal (type_expr: type_expr) (pattern_type_expr: type_expr): bool =
         match type_expr with
-          | StructTypeExpr(_, name_opt, _) -> 
+          | StructTypeExpr(_, name_opt, _, _) -> 
             begin
               match pattern_type_expr with
-                | StructTypeExpr(_, pattern_name_opt, _) ->
+                | StructTypeExpr(_, pattern_name_opt, _, _) ->
                   begin
                     match name_opt with
                       | Some name -> (match pattern_name_opt with Some(pattern_name) when name = pattern_name -> true | None -> false) 

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -393,6 +393,10 @@ cd examples
   cd ..
   verifast_both -c noreturn.c
   verifast_both -c void_ignore.c
+  cd sizeof
+    verifast_both -c -allow_should_fail struct.c
+    verifast_both -c packed.c
+  cd ..
 cd ..
 cd tutorial_solutions
   verifast_both -c -disable_overflow_check account.c


### PR DESCRIPTION
I hope you're not getting tired of my pull requests 😬 

I have code that uses struct arrays and wanted to be able to reason about converting an array of chars to an array of structs, which requires knowing what size the structs are (or adding runtime checks, but that's annoying), and that can only be done if they're packed since otherwise the compiler is free to insert padding (and thus one cannot even reason about >1 struct since e.g. `2 * sizeof(struct xyz)` could overflow).

This PR does the following:
- Add an assumption that `sizeof` returns a value `<= SIZE_MAX`
- Add support for `__attribute__((packed))` (see `examples/sizeof/packed.c`)
- Fix the `usbkbd` example, as it was declaring members of types that were only defined later (which is illegal in C)
- Add an assumption that `float` and `double` are 4 and 8 bytes respectively, i.e., IEEE-754.

That last point is maybe a bit controversial, but I think assuming IEEE-754 is reasonable? Otherwise I could change the code to only care about field sizes if the struct is packed, and just not support floats/doubles in packed structs.

By the way, the `usbkbd` example cannot compile with GCC due to the presence of nested comments, which VeriFast handles fine but are not in the C spec. Is there some other compiler that can handle these, or is this example a VeriFast-only thing?