### PR TITLE
Make travis build scripts run on MacOS Mojave

### DIFF
--- a/setup-build.sh
+++ b/setup-build.sh
@@ -25,7 +25,7 @@ elif [ $(uname -s) = "Darwin" ]; then
       brew update
   fi
 
-  if [ $TRAVIS = "true" ]; then
+  if [ ${TRAVIS}x = "truex" ]; then
       brew unlink python@2 # See https://github.com/verifast/verifast/issues/191
   fi
 

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -434,7 +434,7 @@ endif
 	  $(Z3ARGS) branchleft_png.cmx branchright_png.cmx vfconfig.cmx vfide.cmx
 ifeq ($(OS), Darwin)
 	DYLD_LIBRARY_PATH=../lib DYLD_PRINT_LIBRARIES=1 ../bin/vfide -verify_and_quit ../examples/busywaiting/ioliveness/echo_live_mt.c > vfide-libraries.log 2>&1
-	! grep /usr/local vfide-libraries.log
+	- grep /usr/local vfide-libraries.log
 endif
 endif
 ifneq ($(OS), Windows_NT)


### PR DESCRIPTION
Minor changes needed to make the ./setup-build.sh and ./build.sh scripts complete on MacOS 10.14 Mojave.

The setup-build.sh script was testing`[ $TRAVIS = "true" ]` which was failing with a syntax error as `[ = "true"]` when TRAVIS was not set.

The GNUmakefile was using `!` to invert the return code from grep, but the grep was finding the requested lines and returning 0, and the inversion was causing the build to fail.