### PR TITLE
Support for bytecode compilation?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /bin/*.exe
 /bin/*.dll
 /bin/*.so
+/bin/*.bc
 /bin/assoclist.vfmanifest
 /bin/java_card_applet
 /bin/main_class
@@ -134,5 +135,6 @@ examples/crypto/lib/polarssl
 
 _opam
 .vscode
+.merlin
 
 .DS_Store

--- a/src/.depend
+++ b/src/.depend
@@ -1,105 +1,186 @@
 # These dependencies are automatically generated.
 # Do not edit by hand. To generate, run 'make depend'.
-Mynum_slow.cmx :
+SExpressionEmitter.cmo : util.cmo SExpressions.cmi ast.cmo \
+    SExpressionEmitter.cmi
 SExpressionEmitter.cmx : util.cmx SExpressions.cmx ast.cmx \
     SExpressionEmitter.cmi
-SExpressionEmitter.cmi : SExpressions.cmi ast.cmx
+SExpressionEmitter.cmi : SExpressions.cmi ast.cmo
+SExpressions.cmo : SExpressions.cmi
 SExpressions.cmx : SExpressions.cmi
 SExpressions.cmi :
+assertions.cmo : verifast1.cmo verifast0.cmo util.cmo stats.cmo \
+    proverapi.cmo linux/Perf.cmo parser.cmo ast.cmo
 assertions.cmx : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
-    proverapi.cmx win/Perf.cmx parser.cmx ast.cmx
+    proverapi.cmx linux/Perf.cmx parser.cmx ast.cmx
+ast.cmo : util.cmo
 ast.cmx : util.cmx
+branchleft_png.cmo :
 branchleft_png.cmx :
+branchright_png.cmo :
 branchright_png.cmx :
+combineprovers.cmo : proverapi.cmo
 combineprovers.cmx : proverapi.cmx
+dlsymtool.cmo :
 dlsymtool.cmx :
+explorer.cmo : util.cmo parser.cmo lexer.cmo ast.cmo
 explorer.cmx : util.cmx parser.cmx lexer.cmx ast.cmx
+java_card_applet.cmo :
 java_card_applet.cmx :
+java_frontend/annotation_type_checker.cmo : java_frontend/misc.cmo \
+    java_frontend/general_ast.cmo java_frontend/communication.cmo \
+    java_frontend/ast_reader.cmo java_frontend/annotation_type_checker.cmi
 java_frontend/annotation_type_checker.cmx : java_frontend/misc.cmx \
     java_frontend/general_ast.cmx java_frontend/communication.cmx \
     java_frontend/ast_reader.cmx java_frontend/annotation_type_checker.cmi
-java_frontend/annotation_type_checker.cmi : java_frontend/general_ast.cmx \
-    java_frontend/communication.cmx
+java_frontend/annotation_type_checker.cmi : java_frontend/general_ast.cmo \
+    java_frontend/communication.cmo
+java_frontend/ast_reader.cmo : java_frontend/misc.cmo \
+    java_frontend/general_ast.cmo
 java_frontend/ast_reader.cmx : java_frontend/misc.cmx \
     java_frontend/general_ast.cmx
+java_frontend/ast_translator.cmo : parser.cmo java_frontend/misc.cmo \
+    lexer.cmo java_frontend/general_ast.cmo java_frontend/ast_writer.cmo \
+    ast.cmo
 java_frontend/ast_translator.cmx : parser.cmx java_frontend/misc.cmx \
     lexer.cmx java_frontend/general_ast.cmx java_frontend/ast_writer.cmx \
     ast.cmx
+java_frontend/ast_writer.cmo : java_frontend/general_ast.cmo
 java_frontend/ast_writer.cmx : java_frontend/general_ast.cmx
+java_frontend/communication.cmo : java_frontend/misc.cmo \
+    java_frontend/ast_reader.cmo
 java_frontend/communication.cmx : java_frontend/misc.cmx \
     java_frontend/ast_reader.cmx
+java_frontend/general_ast.cmo : java_frontend/misc.cmo
 java_frontend/general_ast.cmx : java_frontend/misc.cmx
+java_frontend/java_frontend.cmo : java_frontend/misc.cmo \
+    java_frontend/general_ast.cmo java_frontend/communication.cmo \
+    java_frontend/ast_writer.cmo java_frontend/ast_reader.cmo \
+    java_frontend/java_frontend.cmi
 java_frontend/java_frontend.cmx : java_frontend/misc.cmx \
     java_frontend/general_ast.cmx java_frontend/communication.cmx \
     java_frontend/ast_writer.cmx java_frontend/ast_reader.cmx \
     java_frontend/java_frontend.cmi
-java_frontend/java_frontend.cmi : java_frontend/general_ast.cmx \
+java_frontend/java_frontend.cmi : java_frontend/general_ast.cmo \
+    java_frontend/annotation_type_checker.cmi
+java_frontend/java_frontend_bridge.cmo : util.cmo parser.cmo \
+    java_frontend/misc.cmo lexer.cmo java_frontend/java_frontend.cmi \
+    java_frontend/general_ast.cmo java_frontend/ast_writer.cmo \
+    java_frontend/ast_translator.cmo ast.cmo \
     java_frontend/annotation_type_checker.cmi
 java_frontend/java_frontend_bridge.cmx : util.cmx parser.cmx \
     java_frontend/misc.cmx lexer.cmx java_frontend/java_frontend.cmx \
     java_frontend/general_ast.cmx java_frontend/ast_writer.cmx \
     java_frontend/ast_translator.cmx ast.cmx \
     java_frontend/annotation_type_checker.cmx
+java_frontend/misc.cmo :
 java_frontend/misc.cmx :
-lexer.cmx : util.cmx stats.cmx win/Perf.cmx ast.cmx
+json.cmo :
+json.cmx :
+json_tests.cmo : json.cmo
+json_tests.cmx : json.cmx
+lexer.cmo : util.cmo stats.cmo linux/Perf.cmo ast.cmo
+lexer.cmx : util.cmx stats.cmx linux/Perf.cmx ast.cmx
+linux/Perf.cmo :
 linux/Perf.cmx :
+linux/Stopwatch.cmo : linux/Stopwatch.cmi
 linux/Stopwatch.cmx : linux/Stopwatch.cmi
 linux/Stopwatch.cmi :
+main_class.cmo :
 main_class.cmx :
-mynum.cmx :
-mysh.cmx : vfconfig.cmx
-parser.cmx : util.cmx win/Stopwatch.cmx stats.cmx win/Perf.cmx lexer.cmx \
+mysh.cmo :
+mysh.cmx :
+parser.cmo : util.cmo linux/Stopwatch.cmi stats.cmo linux/Perf.cmo lexer.cmo \
+    ast.cmo
+parser.cmx : util.cmx linux/Stopwatch.cmx stats.cmx linux/Perf.cmx lexer.cmx \
     ast.cmx
+proverapi.cmo :
 proverapi.cmx :
+record_backtrace.cmo :
 record_backtrace.cmx :
-redux.cmx : win/Stopwatch.cmx simplex.cmx proverapi.cmx win/Perf.cmx
+redux.cmo : linux/Stopwatch.cmi simplex.cmi proverapi.cmo linux/Perf.cmo
+redux.cmx : linux/Stopwatch.cmx simplex.cmx proverapi.cmx linux/Perf.cmx
+shape_analysis/changelog.cmo : util.cmo ast.cmo
 shape_analysis/changelog.cmx : util.cmx ast.cmx
+shape_analysis/shape_analysis_backend.cmo : shape_analysis/changelog.cmo
 shape_analysis/shape_analysis_backend.cmx : shape_analysis/changelog.cmx
+shape_analysis/shape_analysis_frontend.cmo : \
+    shape_analysis/shape_analysis_backend.cmo parser.cmo \
+    shape_analysis/changelog.cmo ast.cmo
 shape_analysis/shape_analysis_frontend.cmx : \
     shape_analysis/shape_analysis_backend.cmx parser.cmx \
     shape_analysis/changelog.cmx ast.cmx
-simplex.cmx : util.cmx win/Stopwatch.cmx simplex.cmi
+simplex.cmo : util.cmo linux/Stopwatch.cmi simplex.cmi
+simplex.cmx : util.cmx linux/Stopwatch.cmx simplex.cmi
 simplex.cmi :
+smtlib.cmo : util.cmo
 smtlib.cmx : util.cmx
+smtlibprover.cmo : util.cmo smtlib.cmo proverapi.cmo
 smtlibprover.cmx : util.cmx smtlib.cmx proverapi.cmx
-stats.cmx : util.cmx win/Stopwatch.cmx win/Perf.cmx ast.cmx
-stopwatch_test.cmx : win/Stopwatch.cmx
+stats.cmo : util.cmo linux/Stopwatch.cmi linux/Perf.cmo ast.cmo
+stats.cmx : util.cmx linux/Stopwatch.cmx linux/Perf.cmx ast.cmx
+stopwatch_test.cmo : linux/Stopwatch.cmi
+stopwatch_test.cmx : linux/Stopwatch.cmx
+tabhunter.cmo :
 tabhunter.cmx :
+util.cmo : proverapi.cmo
 util.cmx : proverapi.cmx
-verifast.cmx : verify_expr.cmx verifast1.cmx verifast0.cmx \
-    util.cmx win/Stopwatch.cmx stats.cmx proverapi.cmx win/Perf.cmx \
-    parser.cmx lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx \
-    assertions.cmx
+verifast.cmo : verify_expr.cmo verifast1.cmo verifast0.cmo util.cmo \
+    linux/Stopwatch.cmi stats.cmo proverapi.cmo linux/Perf.cmo parser.cmo \
+    lexer.cmo java_frontend/java_frontend_bridge.cmo ast.cmo assertions.cmo
+verifast.cmx : verify_expr.cmx verifast1.cmx verifast0.cmx util.cmx \
+    linux/Stopwatch.cmx stats.cmx proverapi.cmx linux/Perf.cmx parser.cmx \
+    lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx assertions.cmx
+verifast0.cmo : util.cmo ast.cmo
 verifast0.cmx : util.cmx ast.cmx
-verifast1.cmx : verifast0.cmx util.cmx stats.cmx proverapi.cmx win/Perf.cmx \
-    parser.cmx lexer.cmx java_frontend/java_frontend_bridge.cmx ast.cmx
+verifast1.cmo : verifast0.cmo util.cmo stats.cmo proverapi.cmo \
+    linux/Perf.cmo parser.cmo lexer.cmo \
+    java_frontend/java_frontend_bridge.cmo ast.cmo
+verifast1.cmx : verifast0.cmx util.cmx stats.cmx proverapi.cmx \
+    linux/Perf.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx ast.cmx
+verifastPluginCvc4.cmo : verifast.cmo smtlibprover.cmo smtlib.cmo \
+    proverapi.cmo
 verifastPluginCvc4.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
     proverapi.cmx
+verifastPluginExternalZ3.cmo : verifast.cmo smtlibprover.cmo smtlib.cmo \
+    proverapi.cmo
 verifastPluginExternalZ3.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
     proverapi.cmx
+verifastPluginRedux.cmo : verifast.cmo redux.cmo proverapi.cmo
 verifastPluginRedux.cmx : verifast.cmx redux.cmx proverapi.cmx
+verifastPluginReduxSmtlib.cmo : verifast.cmo smtlibprover.cmo smtlib.cmo \
+    redux.cmo proverapi.cmo combineprovers.cmo
 verifastPluginReduxSmtlib.cmx : verifast.cmx smtlibprover.cmx smtlib.cmx \
     redux.cmx proverapi.cmx combineprovers.cmx
+verifastPluginReduxZ3v4dot5.cmo : z3v4dot5prover.cmo verifast.cmo redux.cmo \
+    proverapi.cmo combineprovers.cmo
 verifastPluginReduxZ3v4dot5.cmx : z3v4dot5prover.cmx verifast.cmx redux.cmx \
     proverapi.cmx combineprovers.cmx
-verifastPluginZ3.cmx : z3prover.cmx verifast.cmx proverapi.cmx
-verifastPluginZ3v2.cmx : z3v2prover.cmx verifast.cmx proverapi.cmx
-verifastPluginZ3v4.cmx : z3v4prover.cmx verifast.cmx proverapi.cmx
+verifastPluginZ3v4dot5.cmo : z3v4dot5prover.cmo verifast.cmo proverapi.cmo
 verifastPluginZ3v4dot5.cmx : z3v4dot5prover.cmx verifast.cmx proverapi.cmx
+verifastPluginZ3v4dot5Smtlib.cmo : z3v4dot5prover.cmo verifast.cmo \
+    smtlibprover.cmo smtlib.cmo proverapi.cmo combineprovers.cmo
 verifastPluginZ3v4dot5Smtlib.cmx : z3v4dot5prover.cmx verifast.cmx \
     smtlibprover.cmx smtlib.cmx proverapi.cmx combineprovers.cmx
+verify_expr.cmo : verifast1.cmo verifast0.cmo util.cmo stats.cmo \
+    proverapi.cmo parser.cmo ast.cmo assertions.cmo
 verify_expr.cmx : verifast1.cmx verifast0.cmx util.cmx stats.cmx \
     proverapi.cmx parser.cmx ast.cmx assertions.cmx
+vfconsole.cmo : verifast1.cmo verifast0.cmo verifast.cmo util.cmo \
+    SExpressionEmitter.cmi linux/Perf.cmo parser.cmo lexer.cmo json.cmo \
+    java_frontend/java_frontend_bridge.cmo ast.cmo
 vfconsole.cmx : verifast1.cmx verifast0.cmx verifast.cmx util.cmx \
-    SExpressionEmitter.cmx win/Perf.cmx parser.cmx lexer.cmx \
+    SExpressionEmitter.cmx linux/Perf.cmx parser.cmx lexer.cmx json.cmx \
     java_frontend/java_frontend_bridge.cmx ast.cmx
-vfide.cmx : vfconfig.cmx verifast0.cmx verifast.cmx util.cmx \
-    shape_analysis/shape_analysis_frontend.cmx parser.cmx \
-    lexer.cmx java_frontend/java_frontend_bridge.cmx branchright_png.cmx \
+vfide.cmo : verifast0.cmo verifast.cmo util.cmo \
+    shape_analysis/shape_analysis_frontend.cmo parser.cmo lexer.cmo \
+    java_frontend/java_frontend_bridge.cmo branchright_png.cmo \
+    branchleft_png.cmo ast.cmo
+vfide.cmx : verifast0.cmx verifast.cmx util.cmx \
+    shape_analysis/shape_analysis_frontend.cmx parser.cmx lexer.cmx \
+    java_frontend/java_frontend_bridge.cmx branchright_png.cmx \
     branchleft_png.cmx ast.cmx
+vfstrip.cmo :
 vfstrip.cmx :
-z3prover.cmx : proverapi.cmx win/Perf.cmx
-z3v2prover.cmx : proverapi.cmx win/Perf.cmx
-z3v4dot5prover.cmx : proverapi.cmx win/Perf.cmx
-z3v4prover.cmx : proverapi.cmx win/Perf.cmx
-vfconsole.cmx : json.cmx
+z3v4dot5prover.cmo : util.cmo proverapi.cmo linux/Perf.cmo
+z3v4dot5prover.cmx : util.cmx proverapi.cmx linux/Perf.cmx

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -146,7 +146,7 @@ endif
 
 clean::
 	rm -Rf ../lib
-	-rm ../bin/libz3.dll
+	-rm -f ../bin/libz3.dll
 
 ../lib/libgtksourceview-2.0.0.dylib:
 	mkdir -p ../lib
@@ -204,9 +204,13 @@ else
   NUMCPU ?= $(shell cat /proc/cpuinfo | grep 'processor' | wc -l)
 endif
 
-# Always include debug information. This seems necessary to prevent vfide crashes on OS X (see https://dnetcode.cs.kuleuven.be/issues/1975).
-# Also, this is necessary to get stack traces.
-OCAMLCFLAGS += -g -w p
+# Variable $OCAMLCFLAGS specifies options for the optimizing native code
+# compiler `ocamlopt`.
+#
+# Always include debug information. This seems necessary to prevent vfide
+# crashes on OS X (see https://dnetcode.cs.kuleuven.be/issues/1975). Also, this
+# is necessary to get stack traces.
+OCAMLCFLAGS += -g -w p -warn-error FSU
 ifeq ($(OS), Linux)
   # See https://github.com/verifast/verifast/issues/145
   OCAMLCFLAGS += -runtime-variant _pic
@@ -258,10 +262,11 @@ clean::
 
 #------------------------------- Shorthands ---------------------------------#
 
-SET_LDD = export CAML_LD_LIBRARY_PATH="$$CAML_LD_LIBRARY_PATH:$$GTKSOURCEVIEW_LIBS"
-SET_ENV = export PATH="$(CWD)/../bin/:$(OCAMLBIN):$$PATH"; \
-          export $(LDLPATHVAR)="$(LDLPATH):$$$(LDLPATHVAR)"
-COMPILE = ocamlfind ocamlopt $(OCAMLCFLAGS)
+SET_LDD    = export CAML_LD_LIBRARY_PATH="$$CAML_LD_LIBRARY_PATH:$$GTKSOURCEVIEW_LIBS"
+SET_ENV    = export PATH="$(CWD)/../bin/:$(OCAMLBIN):$$PATH"; \
+             export $(LDLPATHVAR)="$(LDLPATH):$$$(LDLPATHVAR)"
+COMPILE    = ocamlfind ocamlopt $(OCAMLCFLAGS)
+COMPILE_BC = ocamlfind ocamlc $(OCAMLCFLAGS)
 
 STDLIB = ../bin/crt.dll.vfmanifest
 #sequence is important, it presents dependencies in command line of VeriFast
@@ -320,6 +325,14 @@ clean::
 clean::
 	rm -f *.cmx
 	rm -f *.o
+
+%.cmo: %.ml
+	@echo "    OCAMLC " $@
+	$(COMPILE_BC) -thread $(INCLUDES) -I $(Z3_OCAML) -pp $(CAMLP4O) -o $@ -c $*.ml
+clean::
+	rm -f *.cmo
+	cd java_frontend && rm -f *.cmo
+	cd linux && rm -f *.cmo
 
 clean::
 	rm -f *.annot
@@ -454,6 +467,52 @@ ifeq ($(OS), Darwin)
 	install_name_tool -change libz3.dylib @executable_path/../lib/libz3.dylib ../bin/verifast
 endif
 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# This section is specifically related to bytecode compilation. Currently, it is
+# a bit self-contained to avoid potentially breaking changes to the rest of the
+# Makefile. It has only been tested on macOS with a local OPAM switch.
+
+# Explicit specification of objects in order; ocamldep appears to skip certain
+# cmo dependencies. 
+#
+# It would be better to share usage of this list with the optimized Verifast
+# target `../bin/verifast$(DOTEXE)`.
+VERIFAST_BC_OBJECTS = \
+	proverapi.cmo util.cmo ast.cmo stats.cmo lexer.cmo parser.cmo \
+	$(JAVA_FE_DEPS:.cmx=.cmo) \
+	verifast0.cmo verifast1.cmo assertions.cmo \
+	verify_expr.cmo verifast.cmo simplex.cmo redux.cmo combineprovers.cmo \
+	smtlib.cmo smtlibprover.cmo \
+	$(VERIFAST_PLUGINS:%=verifastPlugin%.cmo) \
+	z3v4dot5prover.cmo \
+	verifastPluginZ3v4dot5.cmo verifastPluginReduxZ3v4dot5.cmo  verifastPluginZ3v4dot5Smtlib.cmo  \
+	json.cmo vfconsole.cmo
+
+# Looking for dependency directories in the local OPAM installation.
+INCLUDE_DIR_NUM = $(shell ocamlfind query num)
+INCLUDE_DIR_THREADS = $(shell ocamlfind query threads)/threads
+INCLUDE_DIR_Z3 = $(shell ocamlfind query z3)
+INCLUDE_DIR_ZARITH = $(shell ocamlfind query zarith)
+VERIFAST_BC_INCLUDES = -I $(INCLUDE_DIR_NUM) -I $(INCLUDE_DIR_THREADS) -I $(INCLUDE_DIR_Z3) -I $(INCLUDE_DIR_ZARITH)
+# Included for the optimized target(s), but not necessary?
+# -I src \
+# -I src/java_frontend \
+# -I src/shape_analysis \
+# -I $(INCLUDE_DIR_OS) 
+
+# As I said: only tested on macOS.
+../bin/verifast.bc: linux/Perf.cma $(VERIFAST_BC_OBJECTS)
+	@echo "    OCAMLC " $@
+	$(COMPILE_BC) $(OCAMLOPT_LINKFLAGS) -warn-error F -pp ${CAMLP4O} -o $@ \
+		$(VERIFAST_BC_INCLUDES) \
+		threads.cma z3ml.cma linux/Perf.cma \
+		$(VERIFAST_BC_OBJECTS)
+clean::
+	rm -f ../bin/verifast.bc
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
 ../bin/explorer$(DOTEXE): explorer.cmx $(VERIFAST_PLUGINS:%=verifastPlugin%.cmx) $(Z3DEPS)
 	@echo "  OCAMLOPT " $@
 	$(COMPILE) $(OCAMLOPT_LINKFLAGS) -warn-error F -pp ${CAMLP4O} -o ../bin/explorer$(DOTEXE) \
@@ -572,7 +631,7 @@ cleantest::
 # Thus typing dependencies by hand is replaced by typing "make depend",
 # which is less error-prone.
 META_DEPS = \
-  $(wildcard *.ml) $(wildcard *.mli linux/*.ml linux/*.mli \
+  $(wildcard *.ml *.mli linux/*.ml linux/*.mli \
   java_frontend/*.ml java_frontend/*.mli \
   shape_analysis/*.ml shape_analysis/*.mli)
 
@@ -580,8 +639,7 @@ depend: $(META_DEPS)
 	@echo "  OCAMLDEP "
 	echo "# These dependencies are automatically generated." > .depend
 	echo "# Do not edit by hand. To generate, run 'make depend'." >> .depend
-	$(OCAMLDEP) -slash -pp ${CAMLP4O} -native $(INCLUDES) \
-	  $(META_DEPS) >> .depend
+	$(OCAMLDEP) -slash -pp ${CAMLP4O} $(INCLUDES) $(META_DEPS) >> .depend
 .PHONY: depend
 
 # Load dependency graph (made with "make depend") into GNU make.

--- a/src/java_frontend/GNUmakefile
+++ b/src/java_frontend/GNUmakefile
@@ -4,28 +4,14 @@
 # If you really want to use this makefile, just use /src/GNUmakefile and
 # provide a target of this makefile, e.g. "make java_frontend"
 
-# Note: there are dependencies to the outer Makefile (/src/GNUMakefile).
-# Note: these dependencies will overlap with the auto generated dependencies
-#       of the outer Makefile (which does no harm)
-java_frontend/misc.cmx: java_frontend/misc.ml
-java_frontend/general_ast.cmx: java_frontend/general_ast.ml java_frontend/misc.cmx
-java_frontend/ast_writer.cmx: java_frontend/ast_writer.ml java_frontend/general_ast.cmx
-java_frontend/ast_reader.cmx: java_frontend/ast_reader.ml java_frontend/general_ast.cmx
-java_frontend/communication.cmx: java_frontend/communication.ml java_frontend/ast_reader.cmx
-java_frontend/annotation_type_checker.cmi: java_frontend/annotation_type_checker.mli java_frontend/communication.cmx
-java_frontend/annotation_type_checker.cmx: java_frontend/annotation_type_checker.ml java_frontend/annotation_type_checker.cmi java_frontend/general_ast.cmx
-java_frontend/java_frontend.cmi: java_frontend/java_frontend.mli java_frontend/annotation_type_checker.cmx java_frontend/general_ast.cmx
-java_frontend/java_frontend.cmx: java_frontend/java_frontend.ml java_frontend/java_frontend.cmi java_frontend/ast_reader.cmx java_frontend/ast_writer.cmx java_frontend/communication.cmx
-
-java_frontend/ast_translator.cmx: java_frontend/ast_translator.ml java_frontend/java_frontend.cmx java_frontend/general_ast.cmx parser.cmx
-java_frontend/java_frontend_bridge.cmx: java_frontend/java_frontend_bridge.ml java_frontend/ast_translator.cmx java_frontend/java_frontend.cmx parser.cmx
-
 # Note: only 1 CPU allowed for this test because ASTServer currently can only
 #       hande one request at a time
 test_java_front: build test_plugin
 	$(SET_ENV); \
 	cd ../examples/java/frontend; ../../../bin/mysh -cpus 1 < frontend.mysh
 
+# TODO: get rid of SExpressions.cmx SExpressionEmitter.cmx, what are they doing here?
+# TODO: get rid of including JAVA_FE_DEPS in JAVA_FE_INCLS?
 JAVA_FE_DEPS = java_frontend/misc.cmx java_frontend/general_ast.cmx \
   java_frontend/ast_reader.cmx java_frontend/ast_writer.cmx \
   java_frontend/communication.cmx java_frontend/annotation_type_checker.cmx \

--- a/src/linux/GNUmakefile
+++ b/src/linux/GNUmakefile
@@ -2,13 +2,6 @@
 # /src/GNUmakefile
 # /src/GNUmakefile includes this one.
 
-
-ifdef BYTECODE
-  PERF_OUT=Perf.cma
-else
-  PERF_OUT=Perf.cmxa
-endif
-
 ifdef DEBUG
   OCAML_DEBUG_FLAG = -g
 endif
@@ -36,12 +29,13 @@ linux/Perf.cmx: linux/Perf.ml
 	@echo "  OCAMLOPT " $@
 	cd linux ; ${OCAMLOPT} -c Perf.ml
 
-linux/Perf.cmxa: linux/Perf.cmx linux/Stopwatch.cmi linux/Stopwatch.cmx
+linux/Perf.cmxa: linux/Perf.cmx linux/Stopwatch.cmi linux/Stopwatch.cmx linux/libPerf_cobjs.a
 	@echo "  OCAMLOPT " $@
-	cd linux ; ${OCAMLOPT} $(OCAML_DEBUG_FLAG) -a -o $(PERF_OUT) Stopwatch.cmx Perf.cmx -cclib -lPerf_cobjs
+	cd linux ; ${OCAMLOPT} $(OCAML_DEBUG_FLAG) -a -o Perf.cmxa Stopwatch.cmx Perf.cmx -cclib -lPerf_cobjs
 
-# These targets are actually also built when building linux/Perf.cmxa.
-linux/Perf.a: linux/Perf.cmxa
+linux/Perf.cma: linux/Perf.cmo linux/Stopwatch.cmi linux/Stopwatch.cmo linux/caml_stopwatch.o 
+	@echo "    OCAMLC " $@
+	cd linux ; ${OCAMLC} $(OCAML_DEBUG_FLAG) -a -o Perf.cma -custom linux/caml_stopwatch.o Stopwatch.cmo Perf.cmo
 
 clean::
 	rm -f linux/*.a linux/*.o linux/*.cm*


### PR DESCRIPTION
Bytecode compilation allows visual debugging, e.g. in VS Code using earlybird.

This PR partially re-establishes bytecode compilation support in the Makefiles, without too many changes to the other stuff in there. Bytecode compilation is only supported for the core Verifast command line tool; and it has only been tested with a local OPAM switch and on macOS. The byte code target ("../bin/verifast.bc") is not included in the main targets (build; test; default).

The way things are set up, none of these changes should affect any other aspect of the build. But before doing anything else, let's first see whether the CI server agrees with this claim.

The disadvantage of this approach is that adding a module to verifast requires changes in multiple places of the Makefile.