### PR TITLE
Stack (de)allocation

### DIFF
--- a/src/cxx_frontend/cxx_ast_translator.ml
+++ b/src/cxx_frontend/cxx_ast_translator.ml
@@ -302,9 +302,9 @@ module Make (Args: Cxx_fe_sig.CXX_TRANSLATOR_ARGS) : Cxx_fe_sig.Cxx_Ast_Translat
   and transl_var_init (i: R.Decl.Var.VarInit.t): VF.expr =
     let open R.Decl.Var.VarInit in
     let init_expr = init_get i |> transl_expr in 
-    match style_get i with
-    | R.Decl.Var.InitStyle.CInit -> init_expr
-    | _ -> error (VF.expr_loc init_expr) "Only c-style initialization is supported at the moment."
+    match style_get i with 
+    | R.Decl.Var.InitStyle.ListInit -> error (VF.expr_loc init_expr) "List initialization is not supported yet."
+    | _ -> init_expr
 
   and transl_var (var: R.Decl.Var.t): VF.type_expr * string * VF.expr option =
     let open R.Decl.Var in

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1597,9 +1597,9 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let consume_c_object l addr tp h consumePaddingChunk cont =
     consume_c_object_core l real_unit_pat addr tp h consumePaddingChunk $. fun chunks h value -> cont h
 
-  let produce_cxx_object l coef addr ty eval_h check_ctor_call init produce_padding_chunk h env cont =
+  let produce_cxx_object l coef addr ty eval_h check_ctor_call init allow_ghost_fields produce_padding_chunk h env cont =
     match ty, init with 
-    | UnionType _, _ -> static_error l "Union construction is not supported yet." None 
+    | UnionType _, _ when dialect = Some Cxx -> static_error l "Union construction is not supported yet." None 
     | StructType struct_name, Expr (WCxxConstruct (lc, mangled_name, _, args)) ->
       let ctor_info = try_assoc mangled_name cxx_ctor_map in
       if ctor_info = None then static_error l "No matching constructor is defined explicitly." None;
@@ -1614,23 +1614,14 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       else
         cont h env
     | _ ->
-      produce_c_object l coef addr ty eval_h init false produce_padding_chunk h env cont
-    (* | _ ->
-      begin fun cont ->
-        match init with 
-        | Default -> cont h env int_zero_term
-        | Expr e -> eval_h h env e cont
-        | Unspecified -> cont h env @@ get_unique_var_symb "value" ty
-      end @@ fun h env value ->
-      produce_points_to_chunk l h ty coef addr value @@ fun h ->
-      cont h env *)
+      produce_c_object l coef addr ty eval_h init allow_ghost_fields produce_padding_chunk h env cont
 
   let consume_cxx_object l coefpat addr ty check_dtor_call consume_padding_chunk h env cont =
-    match ty with 
-    | UnionType _ -> static_error l "Union destruction is not supported yet." None 
-    | StructType struct_name ->
+    match ty, dialect with 
+    | UnionType _, Some Cxx -> static_error l "Union destruction is not supported yet." None 
+    | StructType struct_name, Some Cxx ->
       let dtor_info = try_assoc struct_name cxx_dtor_map in 
-      if dtor_info = None then static_error l "No matching destructor is defined explicitely." None;
+      if dtor_info = None then static_error l "No matching destructor is defined explicitly." None;
       let Some (ld, pre, pre_tenv, post, terminates, body_opt) = dtor_info in 
       if body_opt = None then register_prototype_used ld (cxx_dtor_name struct_name) None;
       check_dtor_call l pre post terminates h env @@ fun h env _ ->
@@ -1641,7 +1632,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       else 
         cont h env
     | _ ->
-      consume_points_to_chunk rules h [] [] [] l ty real_unit coefpat addr dummypat @@ fun _ h _ _ _ env _ ->
+      consume_c_object_core l coefpat addr ty h consume_padding_chunk @@ fun _ h _ -> 
       cont h env
 
   let assume_is_of_type l t tp cont =
@@ -2343,7 +2334,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       in 
       let verify_call loc args params pre post terminates h env cont = verify_call funcmap eval_h loc (pn, ilist) xo None [] args ([], None, params, ["this", result], pre, post, None, terminates, Static) false false None leminfo sizemap h [] tenv ghostenv env cont @@ fun _ _ _ _ _ -> assert false in
       assume_neq result real_zero @@ fun () ->
-      produce_cxx_object l real_unit result ty eval_h verify_call init false h env @@ fun h env ->
+      produce_cxx_object l real_unit result ty eval_h verify_call init false false h env @@ fun h env ->
       begin
         match ty with 
         | StructType struct_name ->

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1602,7 +1602,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | UnionType _, _ -> static_error l "Union construction is not supported yet." None 
     | StructType struct_name, Some (WCxxConstruct (lc, mangled_name, _, args)) ->
       let ctor_info = try_assoc mangled_name cxx_ctor_map in
-      if ctor_info = None then static_error l "Default constructors have to be defined explicitly." None;
+      if ctor_info = None then static_error l "No matching constructor is defined explicitly." None;
       let Some (lc, params, pre, pre_tenv, post, terminates, body_opt) = ctor_info in 
       if body_opt = None then register_prototype_used lc mangled_name None;
       let args = args |> List.map @@ fun e -> SrcPat (LitPat e) in
@@ -1627,7 +1627,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | UnionType _ -> static_error l "Union destruction is not supported yet." None 
     | StructType struct_name ->
       let dtor_info = try_assoc struct_name cxx_dtor_map in 
-      if dtor_info = None then static_error l "Default destructors have to be defined explicitely." None;
+      if dtor_info = None then static_error l "No matching destructor is defined explicitely." None;
       let Some (ld, pre, pre_tenv, post, terminates, body_opt) = dtor_info in 
       if body_opt = None then register_prototype_used ld (cxx_dtor_name struct_name) None;
       check_dtor_call l pre post terminates h env @@ fun h env _ ->

--- a/tests/cxx/c_copy/globals.cpp
+++ b/tests/cxx/c_copy/globals.cpp
@@ -1,0 +1,53 @@
+static int x;
+
+struct Counter {
+    int f;
+
+    Counter(int f) : f(f)
+    //@ requires true;
+    //@ ensures this->f |-> f;
+    {}
+    
+    Counter() : f(2)
+    //@ requires true;
+    //@ ensures this->f |-> 2;
+    {}
+
+    ~Counter()
+    //@ requires this->f |-> _;
+    //@ ensures true;
+    {}
+};
+
+static Counter *c;
+
+static Counter cc;
+
+void m()
+    //@ requires integer(&x, 7) &*& pointer(&c, ?ctr) &*& Counter_f(ctr, ?v) &*& Counter_f(&cc, _);
+    //@ ensures integer(&x, 8) &*& pointer(&c, ctr) &*& Counter_f(ctr, v + 1) &*& Counter_f(&cc, 10);
+{
+    int y = x;
+    x = y + 1;
+    c->f = c->f + 1;
+    cc.f = 10;
+}
+
+int main() //@ : main_full(globals)
+    //@ requires module(globals, true);
+    //@ ensures true;
+{
+    //@ open_module();
+    int x0 = x;
+
+    //@ assert (x0 == 0);
+    x = 7;
+    Counter *ctr = new Counter(42);
+    c = ctr;
+    m();
+    int ctr_f = ctr->f;
+    //@ assert (ctr_f == 43) &*& Counter_f(&cc, 10);
+
+    delete ctr;
+    //@ leak integer(&x, _) &*& pointer(&c, _) &*& struct_Counter_padding(&cc) &*& Counter_f(&cc, _);
+}

--- a/tests/cxx/java_like/Account.h
+++ b/tests/cxx/java_like/Account.h
@@ -23,6 +23,13 @@ public:
     {
     	//@ close AccountPred(this, 0);
     }
+    
+    ~Account()
+    //@ requires AccountPred(this, _);
+    //@ ensures true;
+    {
+        //@ open AccountPred(this, _);
+    }
 
     int getBalance() const;
     //@ requires AccountPred(this, ?b);

--- a/tests/cxx/java_like/Stack.h
+++ b/tests/cxx/java_like/Stack.h
@@ -17,12 +17,23 @@ predicate nodes(Stack::Node *node; int value, Stack::Node *next, int count, int 
 
 /*@
 predicate StackPred(Stack *stack, int count, int sum) =
+    stack != 0 &*&
     stack->head |-> ?head &*&
     (
         head == 0
             ? count == 0 &*& sum == 0
             : new_block_Stack::Node(head) &*& nodes(head, _, _, count, sum) &*& count > 0
     );
+@*/
+
+/*@
+lemma_auto void StackPred_inv()
+    requires [?f]StackPred(?stack, ?count, ?sum);
+    ensures [f]StackPred(stack, count, sum) &*& stack != 0;
+{
+    open [f]StackPred(stack, count, sum);
+    close [f]StackPred(stack, count, sum);
+}
 @*/
 
 class Stack {

--- a/tests/cxx/java_like/account_client.cpp
+++ b/tests/cxx/java_like/account_client.cpp
@@ -4,20 +4,14 @@ int main()
 //@ requires true;
 //@ ensures true;
 {
-    Account *a = new Account;
-    a->deposit(1000);
+    Account a;
+    Account b;
     
-    Account *b = new Account;
-    b->deposit(2000);
+    a.deposit(1000);
+    b.deposit(2000);
+    a.transferTo(&b, 500);
     
-    a->transferTo(b, 500);
-    
-    int ba = a->getBalance();
-    int bb = b->getBalance();
+    int ba = a.getBalance();
+    int bb = b.getBalance();
     //@ assert (ba == 500 && bb == 2500);
-    
-    //@ leak AccountPred(a, _);
-    //@ leak AccountPred(b, _);
-    //@ leak new_block_Account(a);
-    //@ leak new_block_Account(b);
 }

--- a/tests/cxx/java_like/stack_client.cpp
+++ b/tests/cxx/java_like/stack_client.cpp
@@ -4,10 +4,9 @@ int main()
 //@ requires true;
 //@ ensures true;
 {
-    Stack *s = new Stack;
-    s->push(10);
-    s->push(20);
-    int twenty = s->pop();
-    int ten = s->pop();
-    delete s;
+    Stack s;
+    s.push(10);
+    s.push(20);
+    int twenty = s.pop();
+    int ten = s.pop();
 }

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -558,6 +558,7 @@ cd tests
 cd ..
   cd cxx
     cd c_copy
+        verifast_both -disable_overflow_check globals.cpp
         verifast -c typedef_enum_with_body.cpp
         verifast -c nodecl_and_semicolon.cpp
         verifast -c -allow_should_fail div_mod_negative_dividend.cpp


### PR DESCRIPTION
- Constructor contract is checked when an object is allocated on the stack
- Destructor contract is checked when an object is deallocated on the stack (or goes out of scope)