### PR TITLE
Truncating expressions and fixed-width integer types

### DIFF
--- a/bin/stdint.h
+++ b/bin/stdint.h
@@ -1,6 +1,20 @@
 #ifndef STDINT_H
 #define STDINT_H
 
+#ifdef __VF_CXX_CLANG_FRONTEND__
+
+typedef __UINT8_TYPE__   uint8_t;
+typedef __UINT16_TYPE__  uint16_t;
+typedef __UINT32_TYPE__  uint32_t;
+typedef __UINT64_TYPE__  uint64_t;
+
+typedef __INT8_TYPE__   int8_t;
+typedef __INT16_TYPE__  int16_t;
+typedef __INT32_TYPE__  int32_t;
+typedef __INT64_TYPE__  int64_t;
+
+#else
+
 typedef __int8   int8_t;
 typedef __int16  int16_t;
 typedef __int32  int32_t;
@@ -12,6 +26,8 @@ typedef unsigned __int16  uint16_t;
 typedef unsigned __int32  uint32_t;
 typedef unsigned __int64  uint64_t;
 typedef unsigned __int128 uint128_t;
+
+#endif
 
 #define INT8_MIN (-127 - 1)
 #define INT8_MAX 127

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -260,7 +260,7 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
     | ClassLit (_, cn) ->
         List [ Symbol "expr-class-lit"; Symbol cn ]
     | TruncatingExpr (loc, e) ->
-        build_list [ Symbol "expr-truncating"; sexpr_of_expr expr ] []
+        build_list [ Symbol "expr-truncating"; sexpr_of_expr e ] []
     | Operation (loc, op, exprs) ->
         build_list
           [ Symbol "expr-op"; sexpr_of_operator op ]

--- a/src/cxx_frontend/ast_exporter/Annotation.h
+++ b/src/cxx_frontend/ast_exporter/Annotation.h
@@ -14,12 +14,13 @@ class Annotation {
   std::string _text;
   bool _isContractClauseLike;
   bool _isNewSeq;
+  bool _isTruncating;
 
 public:
   Annotation(clang::SourceRange &range, llvm::StringRef text,
-             bool isContractClause, bool isNewSeq)
+             bool isContractClause, bool isTruncating, bool isNewSeq)
       : _range(range), _text(text), _isContractClauseLike(isContractClause),
-        _isNewSeq(isNewSeq) {}
+        _isTruncating(isTruncating), _isNewSeq(isNewSeq) {}
 
 public:
   clang::SourceRange getRange() const { return _range; }
@@ -34,11 +35,16 @@ public:
   bool isContractClauseLike() const { return _isContractClauseLike; }
 
   /**
-   * wether or not this annotation starts a new sequence of annotations. I.e.,
-   * the lines between this annotation and the previous one do not only contain
-   * comments and/or white space.
+   * @return wether or not this annotation starts a new sequence of annotations.
+   * I.e., the lines between this annotation and the previous one do not only
+   * contain comments and/or white space.
    */
   bool isNewSeq() const { return _isNewSeq; }
+
+  /**
+   * @return wether or not this annotation is a truncating expression.
+   */
+  bool isTruncating() const { return _isTruncating; }
 };
 
 /**

--- a/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.h
+++ b/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.h
@@ -23,13 +23,16 @@ class ContextFreePPCallbacks : public clang::PPCallbacks {
     explicit PPDiags(clang::Preprocessor &PP) : _PP(PP) {}
 
     void reportMacroDivergence(const clang::Token &macroNameTok,
+                               const std::string &macroName,
                                const clang::MacroDefinition &MD);
 
     void reportCtxSensitiveMacroExp(const clang::Token &macroNameTok,
+                                    const std::string &macroName,
                                     const clang::MacroDefinition &MD,
                                     const clang::SourceRange &range);
 
     void reportUndefIsolatedMacro(const clang::Token &macroNameTok,
+                                  const std::string &macroName,
                                   const clang::MacroDefinition &MD);
   };
 
@@ -43,10 +46,16 @@ class ContextFreePPCallbacks : public clang::PPCallbacks {
   void checkDivergence(const clang::Token &macroNameToken,
                        const clang::MacroDefinition &MD);
 
+  std::string getMacroName(const clang::Token &macroNameToken) const;
+
+  bool macroAllowed(const std::string &macroName) const;
+
 public:
-  explicit ContextFreePPCallbacks(InclusionContext &context, clang::Preprocessor &PP,
+  explicit ContextFreePPCallbacks(InclusionContext &context,
+                                  clang::Preprocessor &PP,
                                   const std::vector<std::string> &whiteList)
-      : _context(context), _PP(PP), _whiteList(whiteList.begin(), whiteList.end()), _diags(PP) {
+      : _context(context), _PP(PP),
+        _whiteList(whiteList.begin(), whiteList.end()), _diags(PP) {
     auto mainEntry = SM().getFileEntryForID(SM().getMainFileID());
     _context.startInclusion(*mainEntry);
   }

--- a/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
@@ -1,5 +1,6 @@
 #include "AstSerializer.h"
 #include "clang/AST/Decl.h"
+#include "FixedWidthInt.h"
 
 namespace vf {
 
@@ -17,7 +18,8 @@ void DeclSerializer::serializeParams(
     if (typeInfo) {
       _serializer.serializeTypeLoc(type, typeInfo->getTypeLoc());
     } else {
-      _serializer.serializeTypeWithRange(type, p->getType().getTypePtr(), {});
+      //   _serializer.serializeTypeWithRange(type, p->getType().getTypePtr(),
+      // {});
     }
     if (p->hasDefaultArg()) {
       auto def = param.initDefault();
@@ -33,9 +35,8 @@ void DeclSerializer::serializeFuncDecl(stubs::Decl::Function::Builder &builder,
   builder.setName(decl->getQualifiedNameAsString());
   builder.setMangledName(mangledName.str());
   auto result = builder.initResult();
-  auto returnRange = decl->getReturnTypeSourceRange();
-  _serializer.serializeTypeWithRange(result, decl->getReturnType().getTypePtr(),
-                                     returnRange);
+  _serializer.serializeTypeLoc(result,
+                               decl->getFunctionTypeLoc().getReturnLoc());
 
   auto paramsBuilder = builder.initParams(decl->param_size());
   serializeParams(paramsBuilder, decl->parameters());
@@ -87,9 +88,7 @@ bool DeclSerializer::VisitVarDecl(const clang::VarDecl *decl) {
   var.setName(decl->getQualifiedNameAsString());
 
   auto ty = var.initType();
-  _serializer.serializeTypeWithRange(
-      ty, decl->getType().getTypePtr(),
-      {decl->getTypeSpecStartLoc(), decl->getTypeSpecEndLoc()});
+  _serializer.serializeTypeLoc(ty, decl->getTypeSourceInfo()->getTypeLoc());
 
   if (decl->hasInit()) {
     auto init = var.initInit();
@@ -161,6 +160,8 @@ bool DeclSerializer::VisitCXXRecordDecl(const clang::CXXRecordDecl *decl) {
     size_t nbDecls(0);
 
     for (auto d : decl->decls()) {
+      if (d->isImplicit())
+        continue;
       if (llvm::isa<clang::FieldDecl>(d)) {
         ++nbFields;
       } else {
@@ -175,6 +176,8 @@ bool DeclSerializer::VisitCXXRecordDecl(const clang::CXXRecordDecl *decl) {
     nbDecls = 0;
 
     for (auto d : decl->decls()) {
+      if (d->isImplicit())
+        continue;
       if (auto *field = llvm::dyn_cast<clang::FieldDecl>(d)) {
         auto builder = fieldsBuilder[nbFields++];
         auto locBuilder = builder.initLoc();
@@ -199,7 +202,7 @@ void DeclSerializer::serializeMethodDecl(stubs::Decl::Method::Builder &builder,
   builder.setImplicit(decl->isImplicit());
   if (!isStatic) {
     auto thisType = builder.initThis();
-    _serializer.serializeType(thisType, decl->getThisObjectType().getTypePtr());
+    _serializer.serializeQualType(thisType, decl->getThisObjectType());
   }
 
   auto func = builder.initFunc();
@@ -259,7 +262,6 @@ bool DeclSerializer::VisitCXXDestructorDecl(
 
   auto parent = dtor.initParent();
   serializeRecordRef(parent, decl->getParent());
-
   return true;
 }
 
@@ -273,9 +275,30 @@ bool DeclSerializer::VisitTypedefNameDecl(const clang::TypedefNameDecl *decl) {
   def.setName(decl->getQualifiedNameAsString());
 
   auto defType = def.initType();
-  _serializer.serializeTypeLoc(defType,
-                               decl->getTypeSourceInfo()->getTypeLoc());
+  auto typeLoc = decl->getTypeSourceInfo()->getTypeLoc();
 
+  auto typeExpandsFromSystemMacro =
+      getSourceManager().isInSystemMacro(typeLoc.getBeginLoc());
+
+  if (!typeExpandsFromSystemMacro) {
+    _serializer.serializeTypeLoc(defType, typeLoc);
+    return true;
+  }
+
+  if (auto fwi = getFixedWidthFromString(decl->getName())) {
+    auto locBuilder = defType.initLoc();
+    auto descBuilder = defType.initDesc();
+
+    serializeSrcRange(locBuilder, typeLoc.getSourceRange(), getSourceManager());
+
+    auto fw = descBuilder.initFixedWidth();
+    fw.setKind(fwi->isSigned ? stubs::Type::FixedWidth::FixedWidthKind::INT
+                             : stubs::Type::FixedWidth::FixedWidthKind::U_INT);
+    fw.setBits(fwi->bits);
+    return true;
+  }
+
+  _serializer.serializeTypeLoc(defType, typeLoc);
   return true;
 }
 

--- a/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
@@ -16,7 +16,7 @@ void DeclSerializer::serializeParams(
     auto type = param.initType();
     auto typeInfo = p->getTypeSourceInfo();
 
-    assert(typeInfo && "Explicit parameter source info.")
+    assert(typeInfo && "Explicit parameter source info.");
 
     _serializer.serializeTypeLoc(type, typeInfo->getTypeLoc());
     if (p->hasDefaultArg()) {

--- a/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
@@ -15,12 +15,10 @@ void DeclSerializer::serializeParams(
     param.setName(declName.getAsString());
     auto type = param.initType();
     auto typeInfo = p->getTypeSourceInfo();
-    if (typeInfo) {
-      _serializer.serializeTypeLoc(type, typeInfo->getTypeLoc());
-    } else {
-      //   _serializer.serializeTypeWithRange(type, p->getType().getTypePtr(),
-      // {});
-    }
+
+    assert(typeInfo && "Explicit parameter source info.")
+
+    _serializer.serializeTypeLoc(type, typeInfo->getTypeLoc());
     if (p->hasDefaultArg()) {
       auto def = param.initDefault();
       _serializer.serializeExpr(def, p->getDefaultArg());

--- a/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
@@ -223,7 +223,7 @@ bool ExprSerializer::VisitCXXNewExpr(const clang::CXXNewExpr *expr) {
   }
 
   auto type = n.initType();
-  _serializer.serializeType(type, expr->getAllocatedType().getTypePtr());
+  _serializer.serializeQualType(type, expr->getAllocatedType());
 
   return true;
 }
@@ -249,7 +249,7 @@ bool ExprSerializer::VisitCXXConstructExpr(
   }
 
   auto type = construct.initType();
-  _serializer.serializeType(type, expr->getType().getTypePtr());
+  _serializer.serializeQualType(type, expr->getType());
 
   return true;
 }

--- a/src/cxx_frontend/ast_exporter/FixedWidthInt.h
+++ b/src/cxx_frontend/ast_exporter/FixedWidthInt.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "loc_serializer.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/Support/raw_ostream.h"
+#include <string>
+
+namespace vf {
+
+struct FixedWidthInt {
+
+  unsigned bits;
+  bool isSigned;
+
+  FixedWidthInt() = delete;
+};
+
+inline llvm::Optional<FixedWidthInt> getFixedWidthFromString(llvm::StringRef name) {
+  if (name.equals("int8_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({8, false}));
+  if (name.equals("int16_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({16, false}));
+  if (name.equals("int32_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({32, false}));
+  if (name.equals("int64_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({64, false}));
+  if (name.equals("uint8_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({8, true}));
+  if (name.equals("uint16_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({16, true}));
+  if (name.equals("uint32_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({32, true}));
+  if (name.equals("uint64_t"))
+    return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({64, true}));
+  return {};
+}
+
+}; // namespace vf

--- a/src/cxx_frontend/ast_exporter/NodeSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeSerializer.h
@@ -81,7 +81,6 @@ public:
 
 protected:
   void serializeNode(const AstNode *node, const llvm::StringRef kind) {
-    node->getSourceRange().dump(this->getSourceManager());
     if (!this->serializeDesc(node))
       this->unsupported(node->getSourceRange(), kind);
     serializeSrcRange(_locBuilder, node->getSourceRange(),

--- a/src/cxx_frontend/ast_exporter/loc_serializer.h
+++ b/src/cxx_frontend/ast_exporter/loc_serializer.h
@@ -12,6 +12,19 @@ struct LCF {
   unsigned int f;
 };
 
+/**
+ * Decompose the line, column and file unique identifier from a sourcelocation.
+ * The result will be placed in the given \p lcf if the given location \p loc is
+ * valid and not comming from a 'real' file (not a system file).
+ *
+ * @param loc source location to decompose.
+ * @param SM source manager.
+ * @param[out] lcf struct to place the line, column and file uniques identifier
+ * in.
+ * @return true if the given location \p loc was valid and could be decomposed.
+ * @return false if the given location \p was incalid and it was not possible to
+ * decompose it.
+ */
 inline bool getLCF(const clang::SourceLocation &loc,
                    const clang::SourceManager &SM, LCF &lcf) {
   auto decLoc = SM.getDecomposedLoc(SM.getSpellingLoc(loc));

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -52,15 +52,31 @@ struct Type {
     uLongLong @11;
   }
 
+  struct FixedWidth {
+    enum FixedWidthKind {
+      int @0;
+      uInt @1;
+    }
+
+    kind @0 :FixedWidthKind;
+    bits @1 :UInt8;
+  }
+
   union {
     unionNotInitialized @0 :Void;
     builtin @1 :BuiltinKind;
-    pointer @2 :Type;
-    pointerLoc @3 :TypeNode;
+    pointer @2 :TypeNode;
+    wPointer @3 :Type;
     record @4 :RecordRef;
     enumType @5 :Text;
-    lValueRef @6 :Type;
-    rValueRef @7 :Type;
+    lValueRef @6 :TypeNode;
+    wLValueRef @7 :Type;
+    rValueRef @8 :TypeNode;
+    wRValueRef @9 :Type;
+    fixedWidth @10 :FixedWidth;
+    elaborated @11 :TypeNode;
+    wElaborated @12 :Type;
+    typedef @13 :Text;
   }
 }
 
@@ -358,6 +374,7 @@ struct Expr {
     construct @12 :Construct;
     nullPtrLit @13 :Void;
     delete @14 :ExprNode;
+    truncating @15 :ExprNode;
   }
 }
 

--- a/tests/cxx/c_copy/truncating.cpp
+++ b/tests/cxx/c_copy/truncating.cpp
@@ -1,0 +1,26 @@
+#include <stdint.h>
+
+/*@
+
+lemma void truncate_int32_def(int x);
+    requires 0 <= x;
+    ensures x == ((x >> 32) << 32) + (truncating (uint32_t)x);
+
+@*/
+
+void test(long x)
+    //@ requires true;
+    //@ ensures true;
+{
+    uint32_t a = 0x10203040;
+    uint32_t b = /*@truncating@*/(a << 16);
+    
+    uint64_t al = a;
+    uint64_t bl = al << 16;
+    
+    //@ assert(b == truncating (uint32_t)bl);
+    //@ truncate_int32_def(bl);
+    //@ produce_limits(b);
+    //@ if (bl >> 32 < 0x1020) {} else if (bl >> 32 > 0x1020) {} else {}
+    //@ assert(b == 0x30400000UL);
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -563,6 +563,7 @@ cd ..
         verifast -c nodecl_and_semicolon.cpp
         verifast -c -allow_should_fail div_mod_negative_dividend.cpp
         verifast -c -disable_overflow_check tuerk.cpp
+        verifast_both -c truncating.cpp
     cd ..
     cd java_like
         verifast -disable_overflow_check Account.cpp account_client.cpp


### PR DESCRIPTION
- Support for truncating expressions (`/*@ truncating @*/`)
- Support for fixed-width integer types (`int8_t`, `uint_8t`,...) declared in `bin/stdint.h`
- Better support for source information of types. Previously, no source information was kept for *inner* types. E.g., `int` in `int *`. Now there are two separate visitors for `Type`s and `TypeLoc`s. The difference is that `TypeLoc` refers to a type that was written in the source code. `Type` can refer to any (implicit) type, like the type of `this` in a class. When serializing a `TypeLoc`, all source information is kept, also for *inner* types. Previously, the serialization of `TypeLoc`s was simply delegated to the `TypeVisitor`, which dropped source information of inner types. This change is mainly responsible for the changes in many different files of the C++ AST exporter.