### PR TITLE
Allow multiple preprocessor directives in the same block of ghost code

### DIFF
--- a/examples/preprocessor/bad_gh_include.c
+++ b/examples/preprocessor/bad_gh_include.c
@@ -1,0 +1,18 @@
+// Test that the result of an inclusion cannot depend upon the 
+// current environment of defined macros.
+
+/*@
+#define BAR true
+@*/
+
+/*@
+#define FOO true
+#include "bad_include.gh"
+@*/
+
+int bar()
+//@ requires BAR;
+//@ ensures foo();
+{
+    return 0;
+}

--- a/examples/preprocessor/bad_include.gh
+++ b/examples/preprocessor/bad_include.gh
@@ -1,0 +1,3 @@
+#pragma once
+
+predicate foo() = /*~*/FOO;

--- a/examples/preprocessor/multiple_gh_include.c
+++ b/examples/preprocessor/multiple_gh_include.c
@@ -1,0 +1,16 @@
+//@ #include "prelude_core.gh"
+//@ #include "list.gh"
+//@ #include "listex.gh"
+
+/*@
+#include "prelude_core.gh"
+#include "list.gh"
+#include "listex.gh"
+@*/
+
+int foo()
+//@ requires true;
+//@ ensures result == 42;
+{
+    return 42;
+}

--- a/examples/preprocessor/preprocessor.mysh
+++ b/examples/preprocessor/preprocessor.mysh
@@ -6,10 +6,12 @@ verifast_both -I headertest -c headertest.c
 verifast_both -c directorytest/main.c
 verifast_both -c -disable_overflow_check preprocessor.c
 verifast_both -c -allow_should_fail bad_include.c
+verifast_both -c -allow_should_fail bad_gh_include.c
 verifast_both -c -allow_should_fail nested_bad_include.c
 verifast_both -c -allow_should_fail circular_include.c
 verifast_both -c -allow_should_fail bad_circular_include.c
 verifast_both -c -disable_overflow_check multiple_include.c
+verifast_both -c multiple_gh_include.c
 verifast_both -c  repeated_include.c
 verifast_both -c -disable_overflow_check nested_multiple_include.c
 verifast_both -c -disable_overflow_check -allow_should_fail ghost_macro.c

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1720,34 +1720,47 @@ let rec parse_include_directives (verbose: int) (enforceAnnotations: bool) (data
   let test_include_cycle l totalPath =
     if List.mem totalPath !active_headers then raise (ParseException (l, "Include cycles (even with header guards) are not supported"));
   in
-  let rec parse_include_directives_core header_names = parser
-  | [< (headers, header_name) = parse_include_directive; (headers', header_names') = parse_include_directives_core (header_name::header_names) >] 
-          -> (List.append headers headers', header_names')
-  | [< >] -> ([], header_names)
-  and parse_include_directive = 
+  let rec parse_include_directives_core header_names in_ghost_range =
+    let parse = parser
+      | [< '(_, Kwd "/*@"); (headers, header_name) = parse_include_directive true; (headers', header_names') = parse_include_directives_core (header_name::header_names) true >] 
+              -> (List.append headers headers', header_names')
+      | [< (headers, header_name) = parse_include_directive in_ghost_range; (headers', header_names') = parse_include_directives_core (header_name::header_names) in_ghost_range >] 
+              -> (List.append headers headers', header_names')
+      | [< '(_, Kwd "@*/"); (headers', header_names') = parse_include_directives_core header_names false >]
+              -> headers', header_names'
+    in
+    begin fun stream ->
+      begin match Stream.npeek 2 stream with
+      | [(_, Kwd "/*@"); (_, BeginInclude (_, _, _)) | (_, SecondaryInclude (_, _))] when not in_ghost_range ->
+        parse stream
+      | [(_, BeginInclude (_, _, _)) | (_, SecondaryInclude (_, _)); _] ->
+        parse stream
+      | [(_, Kwd "@*/"); _] when in_ghost_range ->
+        parse stream
+      | [(_, Kwd "/*@"); (_, Kwd "@*/")] when not in_ghost_range ->
+        begin
+          Stream.junk stream;
+          Stream.junk stream;
+          parse_include_directives_core header_names false stream
+        end
+      | _ -> 
+        [], header_names
+      end
+    end
+  and parse_include_directive in_ghost_range = 
     let isGhostHeader header = Filename.check_suffix header ".gh" in
     parser
       [< '(l, SecondaryInclude(h, totalPath)) >] -> 
         if verbose = -1 then Printf.printf "%10.6fs: >>>> ignored secondary include: %s \n" (Perf.time()) totalPath;
         test_include_cycle l totalPath; ([], totalPath)
-    | [< (l,h,totalPath) = peek_in_ghost_range begin parser [< '(l, SecondaryInclude(h, p)) >] -> (l,h,p) end; '(_, Kwd "@*/") >] -> 
-        if verbose = -1 then Printf.printf "%10.6fs: >>>> ignored secondary include: %s \n" (Perf.time()) totalPath;
-        test_include_cycle l totalPath; ([], totalPath)
-    | [< '(l, BeginInclude(kind, h, totalPath)); (headers, header_names) = (active_headers := totalPath::!active_headers; parse_include_directives_core []); 
+    | [< '(l, BeginInclude(kind, h, totalPath)); (headers, header_names) = (active_headers := totalPath::!active_headers; parse_include_directives_core [] in_ghost_range); 
                                            ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:(isGhostHeader h); '(_, Eof); '(_, EndInclude) >] ->
                                                         if verbose = -1 then Printf.printf "%10.6fs: >>>> parsed include: %s \n" (Perf.time()) totalPath;
                                                         active_headers := List.filter (fun h -> h <> totalPath) !active_headers;
                                                         let ps = [PackageDecl(dummy_loc,"",[],ds)] in
                                                         (List.append headers [(l, (kind, h, totalPath), header_names, ps)], totalPath)
-    | [< (l,kind,h,totalPath) = peek_in_ghost_range begin parser [< '(l, BeginInclude(kind, h, p)) >] -> (l,kind,h,p) end; 
-                                                (headers, header_names) = (active_headers := totalPath::!active_headers; parse_include_directives_core []); 
-                                                ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:(isGhostHeader h); '(_, Eof); '(_, EndInclude); '(_, Kwd "@*/") >] ->
-                                                        if verbose = -1 then Printf.printf "%10.6fs: >>>> parsed include: %s \n" (Perf.time()) totalPath;
-                                                        active_headers := List.filter (fun h -> h <> totalPath) !active_headers;
-                                                        let ps = [PackageDecl(dummy_loc,"",[],ds)] in
-                                                        (List.append headers [(l, (kind, h, totalPath), header_names, ps)], totalPath)
   in
-  parse_include_directives_core []
+  parse_include_directives_core [] false
 
 let parse_c_file (path: string) (reportRange: range_kind -> loc0 -> unit) (reportShouldFail: string -> loc0 -> unit) (verbose: int) 
             (include_paths: string list) (define_macros: string list) (enforceAnnotations: bool) (dataModel: data_model option): ((loc * (include_kind * string * string) * string list * package list) list * package list) = (* ?parse_c_file *)


### PR DESCRIPTION
The parser rejects following ghost snippets **while translating** header includes:

- ```c
  /*@
  #include "bar.gh"
  #include "foo.gh"
  @*/
  ```
  The closing annotation symbol is required after the first `#include`.

- ```c
  /*@
  #define BAR 1
  @*/
  
  //@ #include "bar.gh"
  ```
  Other preprocessor directives cannot be used without using an `#include` directive in the same block of ghost code.

- ```c
  /*@
  @*/
  
  //@ #include "bar.gh"
  ```
  An `#include` directive is expected in the empty block of ghost code.

This PR enhances the parser to be able to parse these snippets.