### PR TITLE
Check for null terminator in lemma string_to_chars

### DIFF
--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -543,7 +543,7 @@ lemma_auto void chars_to_string(char *s);
 
 lemma_auto void string_to_chars(char *s);
     requires [?f]string(s, ?cs);
-    ensures [f]chars(s, length(cs) + 1, append(cs, cons('\0', nil))) &*& !mem('\0', cs);
+    ensures [f]chars(s, length(cs) + 1, append(cs, cons('\0', nil))) &*& !mem('\0', cs) &*& index_of('\0', append(cs, cons(0, nil))) == length(cs);
 
 lemma_auto void chars_separate_string(char *s);
     requires [?f]chars(s, ?n, ?cs) &*& mem('\0', cs) == true;


### PR DESCRIPTION
To the string_to_chars lemma in the post condition, added the assertion of the string having a null terminator at the end. This will satisfy the precondition of the null terminator check for chars_to_string. This addition helps when doing a string_to_chars to something and then later having a chars_to_string to convert it back.