### PR TITLE
Verify that all bases are constructed when a method is called

### DIFF
--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2293,6 +2293,22 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         cont h
     end $. fun h ->
     begin fun cont ->
+      match try_assoc "this" tenv with
+      | Some (PtrType (StructType sn)) when not pure && dialect = Some Cxx ->
+        begin match try_assoc "current_bases_constructed_fraction" env with
+        | Some current_fraction ->
+          (* produce [current_bases_constructed_fraction]X_bases_constructed(this) *)
+          let this_term = List.assoc "this" env in
+          let _, (_, _, _, _, bases_constructed_symb, _, _) = List.assoc sn bases_constructed_map in
+          with_context (Executing ([], env, l, "Producing constructed bases fraction")) @@ fun () ->
+          produce_chunk h (bases_constructed_symb, true) [] current_fraction (Some 1) [this_term] None cont
+        | None ->
+          cont h
+        end
+      | _ ->
+        cont h
+    end @@ fun h ->
+    begin fun cont ->
       verify_cont (pn,ilist) blocks_done lblenv tparams boxes true leminfo funcmap predinstmap sizemap tenv ghostenv h env epilog cont (fun _ _ -> assert false) econt
     end $. fun sizemap tenv ghostenv h env ->
     return_cont h tenv env retval
@@ -2721,9 +2737,12 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       begin fun cont ->
         match penv, dialect, in_pure_context with
         | ("this", this_term) :: _, Some Cxx, false ->
-          assume_neq this_term real_zero cont
-        | _ -> cont ()
-      end @@ fun () -> 
+          let ("this", PtrType (StructType sn)) :: _ = ps in
+          assume_neq this_term real_zero @@ fun () ->
+          cont (Some (sn, this_term))
+        | _ -> 
+          cont None
+      end @@ fun this_term_opt -> 
       produce_asn_with_post [] [] ghostenv env pre real_unit (Some (PredicateChunkSize 0)) None (fun h ghostenv env post' ->
         let post =
           match post' with
@@ -2732,11 +2751,9 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             post'
         in
         let do_return h env_post =
-          consume_asn rules [] h ghostenv env_post post true real_unit (fun _ h ghostenv env size_first ->
-            cleanup_heapy_locals (pn, ilist) closeBraceLoc h env heapy_ps varargsLastParam (fun h ->
-              check_leaks h env closeBraceLoc "Function leaks heap chunks."
-            )
-          )
+          consume_asn rules [] h ghostenv env_post post true real_unit @@ fun _ h ghostenv env size_first ->
+          cleanup_heapy_locals (pn, ilist) closeBraceLoc h env heapy_ps varargsLastParam @@ fun h ->
+          check_leaks h env closeBraceLoc "Function leaks heap chunks."
         in
         let return_cont h tenv2 env2 retval =
           match (rt, retval) with
@@ -2748,6 +2765,26 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         begin fun tcont ->
           verify_cont (pn,ilist) [] [] tparams boxes true leminfo funcmap predinstmap sizemap tenv ghostenv h env prolog tcont (fun _ _ -> assert false) (fun _ _ _ -> assert false)
         end $. fun sizemap tenv ghostenv h env ->
+        begin fun cont ->
+          match this_term_opt with
+          | Some (sn, this_term) ->
+            begin match try_assoc sn bases_constructed_map with
+            | Some (_, (_, _, _, _, bases_constructed_symb, _, _)) ->
+              (* consume [?f * 1/2]X_bases_constructed(this) *)
+              with_context (Executing ([], env, l, "Consuming constructed bases fraction")) @@ fun () ->
+              consume_chunk rules h [] [] [] l (bases_constructed_symb, true) [] real_unit dummypat (Some 1) [TermPat this_term] @@ fun consumed_chunk h coef _ _ _ _ _ ->
+              let half = real_mul l real_half coef in
+              let half_chunk = Chunk ((bases_constructed_symb, true), [], half, [this_term], None) in
+              let tenv = ("current_bases_constructed_fraction", RealType) :: tenv in
+              let ghostenv = "current_bases_constructed_fraction" :: ghostenv in 
+              let env = ("current_bases_constructed_fraction", half) :: env in
+              cont (half_chunk :: h) tenv ghostenv env
+            | None ->
+              cont h tenv ghostenv env
+            end
+          | None ->
+            cont h tenv ghostenv env
+        end @@ fun h tenv ghostenv env ->
         begin fun cont ->
           if unloadable && not in_pure_context then
             let (_, _, _, _, module_code_symb, _, _) = List.assoc "module_code" predfammap in
@@ -2785,8 +2822,14 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             produce_cxx_object l real_unit this_term this_type eval_h verify_ctor_call (Expr construct) false false h env @@ fun h _ ->
             if delegating then cont true h [] 
             else iter false init_list_rest h
-          | _ ->
-            cont false h init_list
+          | _ -> 
+            begin match try_assoc struct_name bases_constructed_map with
+            | Some (_, (_, _, _, _, bases_constructed_symb, _, _)) ->
+              produce_chunk h (bases_constructed_symb, true) [] real_unit (Some 1) [this_term] None @@ fun h ->
+              cont false h init_list
+            | None ->
+              cont false h init_list
+            end
       in
       iter true init_list h
     in
@@ -2921,6 +2964,14 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       with_context (Executing ([], env, loc, sprintf "Verifying destructor '%s'" @@ cxx_dtor_name struct_name)) @@ fun () ->
       assume_neq this_term int_zero_term @@ fun () ->
       produce_asn [] [] ghostenv env pre real_unit None None @@ fun h ghostenv env ->
+      begin fun cont ->
+        match try_assoc struct_name bases_constructed_map with
+        | Some (_, (_, _, _, _, bases_constructed_symb, _, _)) ->
+          consume_chunk rules h [] env [] loc (bases_constructed_symb, true) [] real_unit real_unit_pat (Some 1) [TermPat this_term] @@ fun _ h _ _ _ _ _ _ ->
+          cont h
+        | None ->
+          cont h
+      end @@ fun h ->
       let return_cont h tenv2 env2 retval =
         consume_fields this_term h env tenv ghostenv leminfo sizemap @@ fun h ->
         consume_bases bases h env tenv this_term ghostenv leminfo sizemap @@ fun h env tenv ->
@@ -3341,7 +3392,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         inductivemap1, purefuncmap1, predctormap1, struct_accessor_map1, malloc_block_pred_map1, new_block_pred_map1, 
         field_pred_map1, predfammap1, predinstmap1, typedefmap1, functypemap1, 
         funcmap1, boxmap, classmap1, interfmap1, classterms1, interfaceterms1, 
-        abstract_types_map1, cxx_ctor_map1, cxx_dtor_map1
+        abstract_types_map1, cxx_ctor_map1, cxx_dtor_map1, bases_constructed_map1
       )
     )
   

--- a/src/verifast0.ml
+++ b/src/verifast0.ml
@@ -140,6 +140,8 @@ let full_name pn n = if pn = "" then n else pn ^ "." ^ n
 (* prepends '~' to the given record name *)
 let cxx_dtor_name struct_name = "~" ^ struct_name
 
+let bases_constructed_pred_name sn = sn ^ "_bases_constructed"
+
 type options = {
   option_verbose: int;
   option_disable_overflow_check: bool;

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -463,9 +463,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               static_error loc "Duplicate constructor implementation." None 
           | Some (loc0, xmap0, pre0, pre_tenv0, post0, terminates0, None) ->
             if body_opt = None then static_error loc "Duplicate constructor prototype." None;
-            check_func_header_compat loc ("Constructor '" ^ struct_name ^ "'") "Constructor prototype implementation check" ["this", get_unique_var_symb_non_ghost "this" this_type] 
+            let this_term = get_unique_var_symb_non_ghost "this" this_type in
+            check_func_header_compat loc ("Constructor '" ^ struct_name ^ "'") "Constructor prototype implementation check" ["this", this_term] 
               (Regular, [], None, xmap, false, pre, post, [], terminates) 
-              (Regular, [], None, xmap0, false, [], [], pre0, post0, [], terminates0);
+              (Regular, [], None, xmap0, false, [], ["this", this_term], pre0, post0, [], terminates0);
             iter pn ilist 
               ((mangled_name, (loc, xmap, pre, pre_tenv, post, terminates, check_init_list pn ilist pre_tenv struct_name body_opt struct_name)) :: ctor_map) 
               ((mangled_name, loc0) :: ctors_implemented)
@@ -510,9 +511,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               static_error loc "Duplicate destructor implementation." None 
           | Some (loc0, pre0, pre_tenv0, post0, terminates0, None) ->
             if body_opt = None then static_error loc "Duplicate destructor prototype." None;
-            check_func_header_compat loc ("Destructor '" ^ struct_name ^ "'") "Destructor prototype implementation check" ["this", get_unique_var_symb_non_ghost "this" this_type] 
+            let this_term = get_unique_var_symb_non_ghost "this" this_type in
+            check_func_header_compat loc ("Destructor '" ^ struct_name ^ "'") "Destructor prototype implementation check" ["this", this_term] 
               (Regular, [], None, [], false, pre, post, [], terminates) 
-              (Regular, [], None, [], false, [], [], pre0, post0, [], terminates0);
+              (Regular, [], None, [], false, [], ["this", this_term], pre0, post0, [], terminates0);
             iter pn ilist 
               ((struct_name, (loc, pre, pre_tenv, post, terminates, body_opt |> option_map @@ fun b -> Some b)) :: dtor_map) 
               ((dtor_name, loc0) :: dtors_implemented)

--- a/tests/cxx/inheritance/diamond.cpp
+++ b/tests/cxx/inheritance/diamond.cpp
@@ -34,7 +34,7 @@ struct A {
 
 /*@
 predicate B_pred(B *b; int i, int a) =
-	b != 0 &*& b->b |-> i &*& A_pred(b, a);
+	b != 0 &*& B_bases_constructed(b) &*& b->b |-> i &*& A_pred(b, a);
 	
 lemma_auto void B_pred_inv()
 	requires [?f]B_pred(?b, ?i, ?a);
@@ -60,8 +60,8 @@ struct B : A {
 	}
 
 	void setB(int i)
-	//@ requires this->b |-> _;
-	//@ ensures this->b |-> i;
+	//@ requires B_bases_constructed(this) &*& this->b |-> _;
+	//@ ensures B_bases_constructed(this) &*& this->b |-> i;
 	{
 		b = i;
 	}
@@ -69,7 +69,7 @@ struct B : A {
 
 /*@
 predicate C_pred(C *c; int i, int a) =
-	c != 0 &*& c->c |-> i &*& A_pred(c, a);
+	c != 0 &*& C_bases_constructed(c) &*& c->c |-> i &*& A_pred(c, a);
 	
 lemma_auto void C_pred_inv()
 	requires [?f]C_pred(?c, ?i, ?a);
@@ -94,8 +94,8 @@ struct C : A {
 	{}
 
 	void setC(int i)
-	//@ requires this->c |-> _;
-	//@ ensures this->c |-> i;
+	//@ requires C_bases_constructed(this) &*& this->c |-> _;
+	//@ ensures C_bases_constructed(this) &*& this->c |-> i;
 	{
 		c = i;
 	}
@@ -103,7 +103,7 @@ struct C : A {
 
 /*@
 predicate D_pred(D *d; int i, int b, int c, int b_a, int c_a) =
-	d != 0 &*& d->d |-> i &*& B_pred(d, b, b_a) &*& C_pred(d, c, c_a);
+	d != 0 &*& D_bases_constructed(d) &*& d->d |-> i &*& B_pred(d, b, b_a) &*& C_pred(d, c, c_a);
 	
 lemma_auto void D_pred_inv()
 	requires [?f]D_pred(?d, ?i, ?b, ?c, ?b_a, ?c_a);
@@ -128,8 +128,8 @@ struct D : B, C {
 	{}
 
 	void setD(int i)
-	//@ requires this->d |-> _;
-	//@ ensures this->d |-> i;
+	//@ requires D_bases_constructed(this) &*& this->d |-> _;
+	//@ ensures D_bases_constructed(this) &*& this->d |-> i;
 	{
 		d = i;
 	}

--- a/tests/cxx/inheritance/multiple_inheritance.cpp
+++ b/tests/cxx/inheritance/multiple_inheritance.cpp
@@ -65,17 +65,17 @@ public:
 
 	C(int c) : A(3), B(7), _c(c), _pc(c)
 	//@ requires true;
-	//@ ensures A__a(this, 3) &*& A__pa(this, 3) &*& B__b(this, 7) &*& B__pb(this, 7) &*& this->_c |-> c &*& this->_pc |-> c &*& (struct A *) this != 0 &*& (struct B *) this != 0;
+	//@ ensures C_bases_constructed(this) &*& A__a(this, 3) &*& A__pa(this, 3) &*& B__b(this, 7) &*& B__pb(this, 7) &*& this->_c |-> c &*& this->_pc |-> c &*& (struct A *) this != 0 &*& (struct B *) this != 0;
 	{}
 	
 	~C()
-	//@ requires A__a(this, _) &*& A__pa(this, _) &*& B__b(this, _) &*& B__pb(this, _) &*& this->_c |-> _ &*& this->_pc |-> _;
+	//@ requires C_bases_constructed(this) &*& A__a(this, _) &*& A__pa(this, _) &*& B__b(this, _) &*& B__pb(this, _) &*& this->_c |-> _ &*& this->_pc |-> _;
 	//@ ensures true;
 	{}
 	
 	int foo() const
-	//@ requires this->_c |-> ?c;
-	//@ ensures this->_c |-> c &*& result == c;
+	//@ requires C_bases_constructed(this) &*& this->_c |-> ?c;
+	//@ ensures C_bases_constructed(this) &*& this->_c |-> c &*& result == c;
 	{
 		return _c;
 	}

--- a/tests/cxx/inheritance/single_inheritance.cpp
+++ b/tests/cxx/inheritance/single_inheritance.cpp
@@ -46,36 +46,36 @@ struct B : A {
     
     B(int b_i, int a_i) : A(a_i), i(b_i)
     //@ requires true;
-    //@ ensures B_pred(this, a_i, b_i);
+    //@ ensures B_bases_constructed(this) &*& B_pred(this, a_i, b_i);
     {}
     
     B(int i) : i(i)
     //@ requires true;
-    //@ ensures B_pred(this, 0, i);
+    //@ ensures B_bases_constructed(this) &*& B_pred(this, 0, i);
     {}
 
     B() : B(1, 0)
     //@ requires true;
-    //@ ensures B_pred(this, 0, 1);
+    //@ ensures B_bases_constructed(this) &*& B_pred(this, 0, 1);
     {
     }
     
     ~B()
-    //@ requires B_pred(this, ?a_i, ?b_i);
+    //@ requires B_bases_constructed(this) &*& B_pred(this, ?a_i, ?b_i);
     //@ ensures true;
     {
     }
     
     void incr()
-    //@ requires B_pred(this, ?a_i, ?b_i);
-    //@ ensures B_pred(this, a_i, b_i + 1);
+    //@ requires [?f]B_bases_constructed(this) &*& B_pred(this, ?a_i, ?b_i);
+    //@ ensures [f]B_bases_constructed(this) &*& B_pred(this, a_i, b_i + 1);
     {
     	++i;
     }
     
     void incr_a()
-    //@ requires B_pred(this, ?a_i, ?b_i);
-    //@ ensures B_pred(this, a_i + 1, b_i);
+    //@ requires [?f]B_bases_constructed(this) &*& B_pred(this, ?a_i, ?b_i);
+    //@ ensures [f]B_bases_constructed(this) &*& B_pred(this, a_i + 1, b_i);
     {
       //@ open A_pred(this, _);
       A::incr();


### PR DESCRIPTION
[C++ draft n4910](https://github.com/cplusplus/draft/releases/tag/n4910) §11.9.3 - Initializing bases and members [class.base.init]/16:

> Member functions (including virtual member functions, 11.7.3) can be called for an object under construction. (...) However, if these operations are performed in a ctor-initializer (or in a function called directly or indirectly from a ctor-initializer) before all the mem-initializers for base classes have completed, the program has undefined behavior.