### PR TITLE
Disallow reading from uninitialized fields

### DIFF
--- a/examples/abstract_io/chat_server/channels.c
+++ b/examples/abstract_io/chat_server/channels.c
@@ -268,7 +268,7 @@ channel create_channel()
     //@ assert prophecy_var(prophecyVar, p, pred, ?msgs);
     c->prophecyVar = prophecyVar;
     //@ close valid_elems(p, nil, p);
-    //@ leak c->pred |-> _ &*& c->queue |-> _ &*& c->senderTree |-> _ &*& c->prophecyVar |-> _;
+    //@ leak c->pred |-> ?_ &*& c->queue |-> ?_ &*& c->senderTree |-> ?_ &*& c->prophecyVar |-> ?_;
     //@ close channel_inv(c)();
     //@ close create_mutex_ghost_arg(channel_inv(c));
     mutex mutex = create_mutex();
@@ -276,7 +276,7 @@ channel create_channel()
     //@ close create_mutex_cond_ghost_args(mutex);
     mutex_cond cond = create_mutex_cond();
     c->cond = cond;
-    //@ leak c->mutex |-> _ &*& mutex(mutex, _) &*& c->cond |-> _ &*& mutex_cond(cond, mutex);
+    //@ leak c->mutex |-> ?_ &*& mutex(mutex, _) &*& c->cond |-> ?_ &*& mutex_cond(cond, mutex);
     return c;
     //@ close exists(true);
     //@ close sender_node(senderTree, p);

--- a/examples/barrier.c
+++ b/examples/barrier.c
@@ -179,11 +179,11 @@ predicate_ctor my_barrier_inv(struct data *d)(int k, bool exiting) =
     k == (i1 ? 1 : 0) + (i2 ? 1 : 0) &*&
     switch (p) {
         case writing_x: return
-            (i1 ? [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x1 |-> _ &*& d->i |-> _ : emp) &*&
-            (i2 ? [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x2 |-> _ : emp);
+            (i1 ? [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x1 |-> ?_ &*& d->i |-> ?_ : emp) &*&
+            (i2 ? [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x2 |-> ?_ : emp);
         case writing_y: return
-            (i1 ? [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y1 |-> _ : emp) &*&
-            (i2 ? [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y2 |-> _ &*& d->i |-> _ : emp);
+            (i1 ? [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y1 |-> ?_ : emp) &*&
+            (i2 ? [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y2 |-> ?_ &*& d->i |-> ?_ : emp);
     };
 
 @*/
@@ -191,11 +191,11 @@ predicate_ctor my_barrier_inv(struct data *d)(int k, bool exiting) =
 /*@
 
 predicate_family_instance thread_run_pre(thread1)(struct data *d, any info) =
-    [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*& [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x1 |-> _ &*& d->i |-> _ &*&
+    [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*& [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x1 |-> ?_ &*& d->i |-> ?_ &*&
     [1/3]d->barrier |-> ?barrier &*& [1/2]barrier(barrier, 2, my_barrier_inv(d));
 
 predicate_family_instance thread_run_post(thread1)(struct data *d, any info) =
-    [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*& [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x1 |-> _ &*& d->i |-> 0 &*&
+    [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*& [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x1 |-> ?_ &*& d->i |-> 0 &*&
     [1/3]d->barrier |-> ?barrier &*& [1/2]barrier(barrier, 2, my_barrier_inv(d));
 
 @*/
@@ -211,14 +211,14 @@ void thread1(struct data *d) //@ : thread_run_joinable
         predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
             n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
             [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*&
-            [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x1 |-> _ &*& d->i |-> _;
+            [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x1 |-> ?_ &*& d->i |-> ?_;
         predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> true;
         predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> false &*&
-            [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y1 |-> _;
+            [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y1 |-> ?_;
         lemma void enter(int k) : barrier_enter
             requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
             ensures
@@ -263,7 +263,7 @@ void thread1(struct data *d) //@ : thread_run_joinable
     while (N < 30)
         /*@
         invariant
-            [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> false &*& [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y1 |-> _ &*&
+            [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> false &*& [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y1 |-> ?_ &*&
             [1/2]barrier(barrier, 2, my_barrier_inv(d));
         @*/
     {
@@ -275,14 +275,14 @@ void thread1(struct data *d) //@ : thread_run_joinable
             predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
                 n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
                 [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> false &*&
-                [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y1 |-> _;
+                [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y1 |-> ?_;
             predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> true;
             predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*&
-                [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x1 |-> _ &*& d->i |-> _;
+                [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x1 |-> ?_ &*& d->i |-> ?_;
             lemma void enter(int k) : barrier_enter
                 requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
                 ensures
@@ -333,14 +333,14 @@ void thread1(struct data *d) //@ : thread_run_joinable
             predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
                 n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
                 [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*&
-                [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x1 |-> _ &*& d->i |-> _;
+                [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x1 |-> ?_ &*& d->i |-> ?_;
             predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> true;
             predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> false &*&
-                [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y1 |-> _;
+                [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y1 |-> ?_;
             lemma void enter(int k) : barrier_enter
                 requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
                 ensures
@@ -387,14 +387,14 @@ void thread1(struct data *d) //@ : thread_run_joinable
         predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
             n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
             [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> false &*&
-            [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y1 |-> _;
+            [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y1 |-> ?_;
         predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase1 |-> writing_y &*& [1/2]d->inside1 |-> true;
         predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase1 |-> writing_x &*& [1/2]d->inside1 |-> false &*&
-            [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x1 |-> _ &*& d->i |-> _;
+            [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x1 |-> ?_ &*& d->i |-> ?_;
         lemma void enter(int k) : barrier_enter
             requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
             ensures
@@ -442,11 +442,11 @@ void thread1(struct data *d) //@ : thread_run_joinable
 /*@
 
 predicate_family_instance thread_run_pre(thread2)(struct data *d, any info) =
-    [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*& [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x2 |-> _ &*&
+    [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*& [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x2 |-> ?_ &*&
     [1/3]d->barrier |-> ?barrier &*& [1/2]barrier(barrier, 2, my_barrier_inv(d));
 
 predicate_family_instance thread_run_post(thread2)(struct data *d, any info) =
-    [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*& [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x2 |-> _ &*&
+    [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*& [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x2 |-> ?_ &*&
     [1/3]d->barrier |-> ?barrier &*& [1/2]barrier(barrier, 2, my_barrier_inv(d));
 
 @*/
@@ -462,14 +462,14 @@ void thread2(struct data *d) //@ : thread_run_joinable
         predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
             n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
             [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*&
-            [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x2 |-> _;
+            [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x2 |-> ?_;
         predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> true;
         predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> false &*&
-            [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y2 |-> _ &*& d->i |-> _;
+            [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y2 |-> ?_ &*& d->i |-> ?_;
         lemma void enter(int k) : barrier_enter
             requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
             ensures
@@ -514,8 +514,8 @@ void thread2(struct data *d) //@ : thread_run_joinable
     while (m < 30)
         /*@
         invariant
-            [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> false &*& [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y2 |-> _ &*&
-            d->i |-> _ &*& [1/2]barrier(barrier, 2, my_barrier_inv(d));
+            [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> false &*& [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y2 |-> ?_ &*&
+            d->i |-> ?_ &*& [1/2]barrier(barrier, 2, my_barrier_inv(d));
         @*/
     {
         int a1 = d->x1;
@@ -526,14 +526,14 @@ void thread2(struct data *d) //@ : thread_run_joinable
             predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
                 n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
                 [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> false &*&
-                [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y2 |-> _ &*& d->i |-> _;
+                [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y2 |-> ?_ &*& d->i |-> ?_;
             predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> true;
             predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*&
-                [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x2 |-> _;
+                [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x2 |-> ?_;
             lemma void enter(int k) : barrier_enter
                 requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
                 ensures
@@ -582,14 +582,14 @@ void thread2(struct data *d) //@ : thread_run_joinable
             predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
                 n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
                 [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*&
-                [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x2 |-> _;
+                [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x2 |-> ?_;
             predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> true;
             predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
                 n == 2 &*& inv == my_barrier_inv(d) &*&
                 [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> false &*&
-                [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y2 |-> _ &*& d->i |-> _;
+                [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y2 |-> ?_ &*& d->i |-> ?_;
             lemma void enter(int k) : barrier_enter
                 requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
                 ensures
@@ -637,14 +637,14 @@ void thread2(struct data *d) //@ : thread_run_joinable
         predicate_family_instance barrier_incoming(enter)(int n, predicate(int k, bool outgoing) inv, barrier_exit *exit_) =
             n == 2 &*& inv == my_barrier_inv(d) &*& exit_ == bexit &*&
             [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> false &*&
-            [1/2]d->x1 |-> _ &*& [1/2]d->x2 |-> _ &*& d->y2 |-> _ &*& d->i |-> _;
+            [1/2]d->x1 |-> ?_ &*& [1/2]d->x2 |-> ?_ &*& d->y2 |-> ?_ &*& d->i |-> ?_;
         predicate_family_instance barrier_inside(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase2 |-> writing_y &*& [1/2]d->inside2 |-> true;
         predicate_family_instance barrier_exiting(bexit)(int n, predicate(int k, bool outgoing) inv) =
             n == 2 &*& inv == my_barrier_inv(d) &*&
             [1/2]d->phase2 |-> writing_x &*& [1/2]d->inside2 |-> false &*&
-            [1/2]d->y1 |-> _ &*& [1/2]d->y2 |-> _ &*& d->x2 |-> _;
+            [1/2]d->y1 |-> ?_ &*& [1/2]d->y2 |-> ?_ &*& d->x2 |-> ?_;
         lemma void enter(int k) : barrier_enter
             requires barrier_incoming(enter)(?n, ?inv, ?exit_) &*& inv(k, false) &*& 0 <= k &*& k < n;
             ensures
@@ -692,7 +692,7 @@ int main() //@ : main
     //@ requires true;
     //@ ensures true;
 {
-    struct data *d = malloc(sizeof(struct data));
+    struct data *d = calloc(1, sizeof(struct data));
     if (d == 0) abort();
     //@ d->inside1 = false;
     //@ d->inside2 = false;

--- a/examples/crypto_ccs/annotated_api/pk.h
+++ b/examples/crypto_ccs/annotated_api/pk.h
@@ -17,8 +17,8 @@ typedef struct pk_context pk_context;
 
 /*@
 predicate pk_context(pk_context *context) =
-  context->pk_info |-> ?info &*&
-  context->pk_ctx |-> ?ctx &*&
+  context->pk_info |-> _ &*&
+  context->pk_ctx |-> _ &*&
   struct_pk_context_padding(context)
 ;
 

--- a/examples/crypto_ccs/protocols/auth_enc/main_app.c
+++ b/examples/crypto_ccs/protocols/auth_enc/main_app.c
@@ -84,7 +84,7 @@ predicate_family_instance pthread_run_pre(receiver_t)(void *data, any info) =
   auth_enc_args_receiver(data, ?receiver) &*&
   auth_enc_args_key(data, ?key) &*&
   auth_enc_args_msg(data, ?msg) &*& 
-  auth_enc_args_length(data, _) &*& 
+  auth_enc_args_length_(data, _) &*& 
   !bad(sender) && !bad(receiver) &*&
   principal(receiver, _) &*&
   [1/2]cryptogram(key, KEY_SIZE, ?key_ccs, ?key_cg) &*&

--- a/examples/crypto_ccs/protocols/enc_and_hmac/main_app.c
+++ b/examples/crypto_ccs/protocols/enc_and_hmac/main_app.c
@@ -99,7 +99,7 @@ predicate_family_instance pthread_run_pre(receiver_t)(void *data, any info) =
   enc_and_hmac_args_enc_key(data, ?enc_key) &*&
   enc_and_hmac_args_hmac_key(data, ?hmac_key) &*&
   enc_and_hmac_args_msg(data, ?msg) &*&
-  enc_and_hmac_args_length(data, _) &*& 
+  enc_and_hmac_args_length_(data, _) &*& 
   !bad(sender) && !bad(receiver) &*&
   principal(receiver, _) &*&
   [1/2]cryptogram(enc_key, KEY_SIZE, ?enc_key_ccs, ?enc_key_cg) &*&

--- a/examples/crypto_ccs/protocols/enc_then_hmac/main_app.c
+++ b/examples/crypto_ccs/protocols/enc_then_hmac/main_app.c
@@ -99,7 +99,7 @@ predicate_family_instance pthread_run_pre(receiver_t)(void *data, any info) =
   enc_then_hmac_args_enc_key(data, ?enc_key) &*&
   enc_then_hmac_args_hmac_key(data, ?hmac_key) &*&
   enc_then_hmac_args_msg(data, ?msg) &*&
-  enc_then_hmac_args_length(data, _) &*&
+  enc_then_hmac_args_length_(data, _) &*&
   !bad(sender) && !bad(receiver) &*&
   principal(receiver, _) &*&
   [1/2]cryptogram(enc_key, KEY_SIZE, ?enc_key_ccs, ?enc_key_cg) &*&

--- a/examples/crypto_ccs/protocols/hmac_then_enc/main_app.c
+++ b/examples/crypto_ccs/protocols/hmac_then_enc/main_app.c
@@ -104,7 +104,7 @@ predicate_family_instance pthread_run_pre(receiver_t)(void *data, any info) =
   hmac_then_enc_args_enc_key(data, ?enc_key) &*&
   hmac_then_enc_args_hmac_key(data, ?hmac_key) &*&
   hmac_then_enc_args_msg(data, ?msg) &*&
-  hmac_then_enc_args_length(data, _) &*& 
+  hmac_then_enc_args_length_(data, _) &*& 
   !bad(sender) && !bad(receiver) &*&
   principal(receiver, _) &*&
   [1/2]cryptogram(enc_key, KEY_SIZE, ?enc_key_ccs, ?enc_key_cg) &*&

--- a/examples/crypto_ccs/symbolic_model/protocols/recursive_otway_rees/recursive_otway_rees.c
+++ b/examples/crypto_ccs/symbolic_model/protocols/recursive_otway_rees/recursive_otway_rees.c
@@ -440,7 +440,7 @@ struct processed_messages *server_process(struct keys *keys, struct item *msg)
   }
   else
   {
-    result = malloc(sizeof(struct processed_messages));
+    result = calloc(1, sizeof(struct processed_messages));
     if (result == 0) abort_crypto_lib("Malloc failed");
 
     //@ open [_]ror_pub(msg_i);

--- a/examples/crypto_ccs/symbolic_model/src/key_item.c
+++ b/examples/crypto_ccs/symbolic_model/src/key_item.c
@@ -153,7 +153,7 @@ int key_item_havege_random_stub(void *havege_state,
 void retreive_keys(pk_context *ctx, struct item **public, struct item **private)
   /*@ requires [?f]world(?pub, ?key_clsfy) &*&
                pk_context_with_keys(ctx, ?principal, ?count, RSA_BIT_KEY_SIZE, ?info) &*&
-               pointer(public, _) &*& pointer(private, _); @*/
+               pointer_(public, _) &*& pointer_(private, _); @*/
   /*@ ensures  [f]world(pub, key_clsfy) &*&
                pk_context_with_keys(ctx, principal, count, RSA_BIT_KEY_SIZE, info) &*&
                pointer(public, ?pub_key) &*& pointer(private, ?priv_key) &*&

--- a/examples/icap_mt_event_loop.c
+++ b/examples/icap_mt_event_loop.c
@@ -18,10 +18,11 @@ predicate_ctor I(eloop x)() =
     x->signalCount |-> ?signalCount &*& 0 <= signalCount &*&
     x->handler |-> ?h &*&
     x->dataPred |-> ?dataPred &*&
-    x->handlerData |-> ?data &*&
     h == 0 ?
+        x->handlerData |-> _ &*&
         true
     :
+        x->handlerData |-> ?data &*&
         [_]is_eloop_handler(h, x, dataPred) &*& [_]dataPred(data);
 
 predicate eloop(eloop x) =
@@ -71,7 +72,8 @@ void eloop_loop(eloop x)
         if (x->signalCount > 0) {
             x->signalCount--;
             handler = x->handler;
-            handlerData = x->handlerData;
+            if (handler)
+                handlerData = x->handlerData;
         }
         //@ close I(x)();
         release(&x->lock);

--- a/examples/insertion_sort.c
+++ b/examples/insertion_sort.c
@@ -19,7 +19,7 @@ struct list_node {
     n == 0 ? 
       true
     :
-      n->value |-> _ &*& n->next |-> ?next &*& list_pred(next);
+      n->value |-> ?nValue &*& n->next |-> ?next &*& list_pred(next);
 @*/
 
 /*@
@@ -29,7 +29,7 @@ struct list_node {
     start == end ?
       true
     :
-      start->value |-> _ &*& start->next |-> ?next &*& start != 0 &*& start != next &*& lseg_pred(next, end);
+      start->value |-> ?startValue &*& start->next |-> ?next &*& start != 0 &*& start != next &*& lseg_pred(next, end);
 @*/
 
 /*@  
@@ -68,8 +68,8 @@ struct list_node {
 /*@  
   // Lemma for adding (appending) a node to a list segment predicate
   lemma void lseg_append_node(struct list_node* lseg_start, struct list_node* lseg_end)
-    requires lseg_pred(lseg_start, lseg_end) &*& lseg_end != 0 &*& lseg_end->value |-> _ &*& lseg_end->next |-> ?next1 &*& next1->value |-> _ &*& next1->next |-> ?next2;
-    ensures lseg_pred(lseg_start, next1) &*& next1->value |-> _ &*& next1->next |-> next2;
+    requires lseg_pred(lseg_start, lseg_end) &*& lseg_end != 0 &*& lseg_end->value |-> ?endValue &*& lseg_end->next |-> ?next1 &*& next1->value |-> ?next1Value &*& next1->next |-> ?next2;
+    ensures lseg_pred(lseg_start, next1) &*& next1->value |-> next1Value &*& next1->next |-> next2;
   {
     open lseg_pred(lseg_start, lseg_end);
     if (lseg_start == lseg_end) {
@@ -145,7 +145,7 @@ void insertion_sort_core(struct list_node** pfirst)
   
   struct list_node* last_sorted = *pfirst;
   while (last_sorted->next != 0)
-    /*@ invariant pointer(pfirst, ?first) &*& first != 0 &*& lseg_pred(first, last_sorted) &*& last_sorted->value |-> _ &*& last_sorted->next |-> ?last_sorted_next &*&
+    /*@ invariant pointer(pfirst, ?first) &*& first != 0 &*& lseg_pred(first, last_sorted) &*& last_sorted->value |-> ?last_sortedValue &*& last_sorted->next |-> ?last_sorted_next &*&
                    last_sorted != 0 &*& list_pred(last_sorted_next);
     @*/
   {
@@ -162,14 +162,14 @@ void insertion_sort_core(struct list_node** pfirst)
                   (pn == pfirst ? 
                     n == first &*&
                     lseg_pred(first, last_sorted) &*&
-                    last_sorted->value |-> _ &*& last_sorted->next |-> last_sorted_next &*&
+                    last_sorted->value |-> ?last_sortedValue1 &*& last_sorted->next |-> last_sorted_next &*&
                     list_pred(last_sorted_next)
                   :
                     (pn == &(last_sorted->next) ?
-                      lseg_pred(first, last_sorted) &*& last_sorted->value |-> _ &*& last_sorted->next |-> last_sorted_next &*& list_pred(last_sorted_next)
+                      lseg_pred(first, last_sorted) &*& last_sorted->value |-> ?last_sortedValue1 &*& last_sorted->next |-> last_sorted_next &*& list_pred(last_sorted_next)
                     :
-                      lseg_pred(first, ?prev_n) &*& prev_n != 0 &*& prev_n->value |-> _ &*& pn == &(prev_n->next) &*& pointer(pn, n) &*& lseg_pred(n, last_sorted) &*&
-                      n != first &*& last_sorted->value |-> _ &*& last_sorted->next |-> last_sorted_next &*& list_pred(last_sorted_next) &*& n != last_sorted_next
+                      lseg_pred(first, ?prev_n) &*& prev_n != 0 &*& prev_n->value |-> ?prev_nValue &*& pn == &(prev_n->next) &*& pointer(pn, n) &*& lseg_pred(n, last_sorted) &*&
+                      n != first &*& last_sorted->value |-> ?last_sortedValue1 &*& last_sorted->next |-> last_sorted_next &*& list_pred(last_sorted_next) &*& n != last_sorted_next
                     )
                   );
       @*/

--- a/examples/io/in-memory/non_reusable_print_hi/print_hi.c
+++ b/examples/io/in-memory/non_reusable_print_hi/print_hi.c
@@ -191,6 +191,7 @@ int main()
   if (b == 0){
     abort();
   }
+  b->c = 0;
   //@ int id = create_gcf();
   //@ iot iot1 = iot_init;
   //@ iot ioth = iot_split_left(iot1);

--- a/examples/iter.c
+++ b/examples/iter.c
@@ -29,7 +29,7 @@ struct llist *create_llist()
 {
   struct llist *l = malloc(sizeof(struct llist));
   if (l == 0) abort();
-  struct node *n = malloc(sizeof(struct node));
+  struct node *n = calloc(1, sizeof(struct node));
   if (n == 0) abort();
   l->first = n;
   l->last = n;
@@ -69,7 +69,7 @@ void llist_add(struct llist *list, int x)
   //@ ensures llist(list, append(_v, cons(x, nil)));
 {
   struct node *l = 0;
-  struct node *n = malloc(sizeof(struct node));
+  struct node *n = calloc(1, sizeof(struct node));
   if (n == 0) {
     abort();
   }

--- a/examples/iter_with_auto.c
+++ b/examples/iter_with_auto.c
@@ -29,7 +29,7 @@ struct llist *create_llist()
 {
   struct llist *l = malloc(sizeof(struct llist));
   if (l == 0) abort();
-  struct node *n = malloc(sizeof(struct node));
+  struct node *n = calloc(1, sizeof(struct node));
   if (n == 0) abort();
   l->first = n;
   l->last = n;
@@ -65,7 +65,7 @@ void llist_add(struct llist *list, int x)
   //@ ensures llist(list, append(_v, cons(x, nil)));
 {
   struct node *l = 0;
-  struct node *n = malloc(sizeof(struct node));
+  struct node *n = calloc(1, sizeof(struct node));
   if (n == 0) {
     abort();
   }

--- a/examples/jayanti/jayanti.c
+++ b/examples/jayanti/jayanti.c
@@ -239,7 +239,7 @@ array_t create_array()
     array->fxid = start_tracking_int(&array->fx);
     array->yid = start_tracking_int(&array->y);
     array->fyid = start_tracking_int(&array->fy);
-    //@ leak array->inv |-> _ &*& array->Sid |-> _ &*& array->xid |-> _ &*& array->fxid |-> _ &*& array->yid |-> _ &*& array->fyid |-> _;
+    //@ leak array->inv |-> ?_ &*& array->Sid |-> ?_ &*& array->xid |-> ?_ &*& array->fxid |-> ?_ &*& array->yid |-> ?_ &*& array->fyid |-> ?_;
     //@ array->scan_x_state = 0;
     //@ array->scan_y_state = 0;
     //@ array->write_x_state = 0;

--- a/examples/lcset/lcset.c
+++ b/examples/lcset/lcset.c
@@ -163,7 +163,7 @@ lemma void lseg_merge3(struct node *node, int e, list<int> values10)
 }
 
 predicate set(struct set *set;) =
-    [1/2]set->head |-> ?head &*& [1/2]set->nodesList |-> _ &*& [1/2]head->value |-> _ &*& malloc_block_set(set) &*&
+    [1/2]set->head |-> ?head &*& [1/2]set->nodesList |-> _ &*& [1/2]head->value |-> ?headValue &*& malloc_block_set(set) &*&
     [1/2]set->lockCounter |-> ?lockCounter &*& ghost_counter_zero_contrib(lockCounter);
 
 predicate set_atomic(struct set *set, list<int> values) =

--- a/examples/linking/dll_uses_dll/dll1_source1.c
+++ b/examples/linking/dll_uses_dll/dll1_source1.c
@@ -10,7 +10,7 @@ struct struct_dll1
 
 /*@ predicate predicate_dll1(struct struct_dll1* s) =
       malloc_block_struct_dll1(s) &*& 
-      struct_dll1_body(s, ?value);
+      struct_dll1_body_(s, ?value);
 @*/
 
 struct struct_dll1* get_struct_dll1()

--- a/examples/linking/dll_uses_dll/dll2_source.c
+++ b/examples/linking/dll_uses_dll/dll2_source.c
@@ -10,7 +10,7 @@ struct struct_dll2
 
 /*@ predicate predicate_dll2(struct struct_dll2* s) =
       malloc_block_struct_dll2(s) &*& 
-      struct_dll2_body(s, ?value);
+      struct_dll2_body_(s, _);
 @*/
 
 struct struct_dll2* get_struct_dll2()

--- a/examples/linking/double_dll_defines/dll_source1.c
+++ b/examples/linking/double_dll_defines/dll_source1.c
@@ -10,7 +10,7 @@ struct struct_dll
 
 /*@ predicate predicate_dll(struct struct_dll* s) =
       malloc_block_struct_dll(s) &*& 
-      struct_dll_body(s, ?value);
+      struct_dll_body_(s, ?value);
 @*/
 
 void func()

--- a/examples/linking/double_dll_defines/dll_source2.c
+++ b/examples/linking/double_dll_defines/dll_source2.c
@@ -10,7 +10,7 @@ struct struct_dll
 
 /*@ predicate predicate_dll(struct struct_dll* s) =
       malloc_block_struct_dll(s) &*& 
-      struct_dll_body(s, ?value);
+      struct_dll_body_(s, ?value);
 @*/
 
 void func()

--- a/examples/mcas/atomics.c
+++ b/examples/mcas/atomics.c
@@ -271,7 +271,7 @@ predicate cas_tracker(struct cas_tracker *tracker, int count) =
     [_]popl20_atomic_space(create_cas_tracker, cas_tracker_inv(tracker));
 
 predicate is_cas_tracker(struct cas_tracker *tracker;) =
-    [_]tracker->pid |-> _ &*&
+    [_]tracker->pid |-> ?_ &*&
     [_]tracker->vs |-> _ &*&
     [_]popl20_atomic_space(create_cas_tracker, cas_tracker_inv(tracker));
 

--- a/examples/monitors/barbershop.c
+++ b/examples/monitors/barbershop.c
@@ -374,15 +374,15 @@ int main() //@ : custom_main_spec
     //@ b->gdo = gdo;
     //@ b->gcu = gcu;
     
-    //@ leak [_]b->cbarber |-> _;
-    //@ leak [_]b->cchair |-> _;
-    //@ leak [_]b->cdoor |-> _;
-    //@ leak [_]b->ccustomer |-> _;            
-    //@ leak [_]b->m |-> _;  
-    //@ leak [_]b->gba |-> _;               
-    //@ leak [_]b->gch |-> _;               
-    //@ leak [_]b->gdo |-> _;               
-    //@ leak [_]b->gcu |-> _;               
+    //@ leak [_]b->cbarber |-> ?_;
+    //@ leak [_]b->cchair |-> ?_;
+    //@ leak [_]b->cdoor |-> ?_;
+    //@ leak [_]b->ccustomer |-> ?_;            
+    //@ leak [_]b->m |-> ?_;  
+    //@ leak [_]b->gba |-> ?_;               
+    //@ leak [_]b->gch |-> ?_;               
+    //@ leak [_]b->gdo |-> ?_;               
+    //@ leak [_]b->gcu |-> ?_;               
     //@ leak [_]malloc_block_barbershop(_);
     
     //@ close init_mutex_ghost_args(barbershop(b));

--- a/examples/monitors/bounded_buffer.c
+++ b/examples/monitors/bounded_buffer.c
@@ -246,12 +246,12 @@ int main() //@ : custom_main_spec
     b->max = 1;
     //@ b->ge = ge;
     //@ b->gf = gf;    
-    //@ leak [_]b->ve |-> _;
-    //@ leak [_]b->vf |-> _;     
-    //@ leak [_]b->m |-> _;    
-    //@ leak [_]b->max |-> _; 
-    //@ leak [_]b->ge |-> _;
-    //@ leak [_]b->gf |-> _;               
+    //@ leak [_]b->ve |-> ?_ve;
+    //@ leak [_]b->vf |-> ?_vf;     
+    //@ leak [_]b->m |-> ?_m;
+    //@ leak [_]b->max |-> ?_max; 
+    //@ leak [_]b->ge |-> ?_ge;
+    //@ leak [_]b->gf |-> ?_gf;               
     //@ leak [_]malloc_block_buffer(_);
     
     //@ inc_ctr(gf);

--- a/examples/monitors/buffer.c
+++ b/examples/monitors/buffer.c
@@ -171,9 +171,9 @@ int main() //@ : custom_main_spec
   b->v = v;
   //@ b->gid = gid;
     
-  //@ leak [_]b->v |-> _;
-  //@ leak [_]b->m |-> _;
-  //@ leak [_]b->gid |-> _;
+  //@ leak [_]b->v |-> ?_;
+  //@ leak [_]b->m |-> ?_;
+  //@ leak [_]b->gid |-> ?_;
   //@ leak [_]malloc_block_buffer(_);
 
   //@ g_chrgu(v);

--- a/examples/monitors/readers_writers.c
+++ b/examples/monitors/readers_writers.c
@@ -287,10 +287,10 @@ int main() //@ : custom_main_spec
     b->vw = vw;
     b->vr = vr;
     //@ b->gw = gw;
-    //@ leak [_]b->vw |-> _;
-    //@ leak [_]b->vr |-> _;
-    //@ leak [_]b->m |-> _;    
-    //@ leak [_]b->gw |-> _;    
+    //@ leak [_]b->vw |-> ?_;
+    //@ leak [_]b->vr |-> ?_;
+    //@ leak [_]b->m |-> ?_;    
+    //@ leak [_]b->gw |-> ?_;    
     //@ leak [_]malloc_block_read_write(_);
     //@ close init_mutex_ghost_args(read_write(b));
     //@ close read_write(b)(empb,empb);

--- a/examples/queue/queue.c
+++ b/examples/queue/queue.c
@@ -65,6 +65,8 @@ struct queue *create_queue()
 {
     struct node *middle = malloc(sizeof(struct node));
     if (middle == 0) { abort(); }
+    middle->next = 0;
+    middle->value = 0;
     struct queue *queue = malloc(sizeof(struct queue));
     if (queue == 0) { abort(); }
     queue->first = middle;

--- a/examples/rcl.c
+++ b/examples/rcl.c
@@ -53,7 +53,7 @@ void error(char *msg)
 }
 
 typedef void dispose_func/*@(predicate(void *) inv)@*/(struct object *object);
-    //@ requires heap0(nil) &*& object->refCount |-> _ &*& object->class |-> _ &*& inv(object);
+    //@ requires heap0(nil) &*& object->refCount |-> ?refCount &*& object->class |-> ?class &*& inv(object);
     //@ ensures heap0(nil);
 
 struct class {

--- a/examples/shared_boxes/concurrentstack.c
+++ b/examples/shared_boxes/concurrentstack.c
@@ -372,7 +372,7 @@ lemma void junk_mem_remove(list<pair<struct node*, struct stack_client* > > junk
 }
 
 predicate is_node(pair<struct node*, struct stack_client*> p;) = 
-  fst(p) != 0 &*& fst(p)->next |-> _ &*& [1/3]fst(p)->data |-> _ &*& fst(p)->owner |-> snd(p) &*& malloc_block_node(fst(p));
+  fst(p) != 0 &*& fst(p)->next |-> ?next &*& [1/3]fst(p)->data |-> ?data &*& fst(p)->owner |-> snd(p) &*& malloc_block_node(fst(p));
   
 lemma void invalidated_hps_lemma(list<pair<struct stack_client*, client_state> > states, struct stack_client* client) 
   requires mem(client, keys(states)) == true &*& is_valid(assoc(client, states)) == true &*& is_active(assoc(client, states)) == true;
@@ -878,10 +878,10 @@ box_class stack_box(struct stack* s, predicate(list<void*>) I) {
 
 /*@
 predicate one_third_data(struct node* n;) =
-  [1/3]n->data |-> _;
+  [1/3]n->data |-> ?data;
 
 predicate two_thirds_data(struct node* n;) =
-  [2/3]n->data |-> _;
+  [2/3]n->data |-> ?data;
   
 predicate stack_client(struct stack* s, real f, predicate(list<void*>) I, struct stack_client* client) =
   [f]stack_box(?id, s, I) &*& client != 0 &*& client->rlist |-> ?rlist &*& [1/2]client->myhandle |-> ?ha &*& 
@@ -1377,6 +1377,8 @@ void phase2(struct stack* s, struct stack_client* client, struct list* plist)
       producing_handle_predicate phase2_handle(ha, client, append(newretired, tail(todos)), newretired, tail(todos), hazards);
       @*/
       //@ foreach_remove(curr, todos);
+      //@ open two_thirds_data(curr);
+      //@ open is_node(_);
       free(curr);
     }
    

--- a/examples/shared_boxes/gotsmanlock.c
+++ b/examples/shared_boxes/gotsmanlock.c
@@ -48,7 +48,7 @@ predicate locked(int* l, predicate() I) = [1/2]gbox(?id, l, I) &*& holds_lock(?h
 @*/
 
 void init(int* l)
-  //@ requires integer(l, _) &*& exists<predicate()>(?I);
+  //@ requires int_(l, _) &*& exists<predicate()>(?I);
   //@ ensures lock(l, I) &*& locked(l, I);
 {
   *l = 1;

--- a/examples/shared_boxes/gotsmanlock.h
+++ b/examples/shared_boxes/gotsmanlock.h
@@ -7,7 +7,7 @@ predicate locked(int* l, predicate() I);
 @*/
 
 void init(int* l);
-  //@ requires integer(l, _) &*& exists<predicate()>(?I);
+  //@ requires *l |-> _ &*& exists<predicate()>(?I);
   //@ ensures lock(l, I) &*& locked(l, I);
   
 void acquire(int* l);

--- a/examples/short.c
+++ b/examples/short.c
@@ -16,6 +16,7 @@ void m(int i, short s, char c)
   r = (short) i;
   struct myStruct* ms = malloc(sizeof(struct myStruct));
   if(ms == 0) abort();
+  ms->c = 0;
   ms->i = i;
   ms->s = ms->c;
   free(ms);

--- a/examples/sizeof/packed.c
+++ b/examples/sizeof/packed.c
@@ -25,7 +25,7 @@ void foo(void)
 	struct y* allocated = malloc(sizeof(struct y));
 	if (allocated != NULL) {
 		//@ leak malloc_block_y(allocated);
-		//@ leak x_a(&(allocated->value), _);
-		//@ leak x_b(&(allocated->value), _);
+		//@ leak x_a_(&(allocated->value), _);
+		//@ leak x_b_(&(allocated->value), _);
 	}
 }

--- a/examples/struct_assignment.c
+++ b/examples/struct_assignment.c
@@ -88,6 +88,9 @@ void test3()
     
     //@ { &a; &t; }
 
+    r.q = a;
+    t.p = b;
+    t.q = a;
     a = b;
     r.p = r.q;
     r.q = t.p;

--- a/examples/termination/concurrent/queues.c
+++ b/examples/termination/concurrent/queues.c
@@ -20,9 +20,9 @@ lemma void lseg_add(struct node *first)
     requires lseg(first, ?last, ?values) &*&
         last->next |-> ?next &*& last->value |-> ?value &*&
         malloc_block_node(last) &*&
-        next->next |-> ?nextNext;
+        next->next |-> _;
     ensures lseg(first, next, append(values, cons(value, nil)))
-        &*& next->next |-> nextNext;
+        &*& next->next |-> _;
 {
     open lseg(first, last, values);
     if (first == last) {

--- a/examples/tokenizer.c
+++ b/examples/tokenizer.c
@@ -15,15 +15,15 @@ struct tokenizer
 predicate Tokenizer(struct tokenizer* t;) =
   malloc_block_tokenizer(t) &*&
   t->next_char |-> ?nc &*& is_charreader(nc) == true &*&
-  t->lastread |-> _ &*&
-  t->lasttoken |-> _ &*&
+  t->lastread |-> ?lastread &*&
+  t->lasttoken |-> ?lasttoken &*&
   t->buffer |-> ?b &*& string_buffer(b, _);
 
 predicate Tokenizer_minus_buffer(struct tokenizer* t; struct string_buffer *buffer) =
   malloc_block_tokenizer(t) &*&
   t->next_char |-> ?nc &*& is_charreader(nc) == true &*&
-  t->lastread |-> _ &*&
-  t->lasttoken |-> _ &*&
+  t->lastread |-> ?lastread &*&
+  t->lasttoken |-> ?lasttoken &*&
   t->buffer |-> buffer;
 
 lemma void tokenizer_merge_buffer(struct tokenizer *tokenizer)
@@ -210,6 +210,7 @@ struct tokenizer* tokenizer_create(charreader* reader)
 	tokenizer = (struct tokenizer*) malloc( sizeof( struct tokenizer ) );
 	if ( tokenizer == 0 ) abort();
 	tokenizer->lastread = -2;
+	tokenizer->lasttoken = 0;
 	tokenizer->next_char = reader;
 	buffer = create_string_buffer();
 	tokenizer->buffer = buffer;

--- a/examples/tso/cvm0.c
+++ b/examples/tso/cvm0.c
@@ -193,7 +193,7 @@ void print_interval(void *interval)
     {
         /*@
         predicate P() = [_]object_class(interval, &interval_class);
-        predicate Q() = [_]interval_->a |-> _ &*& [_]interval_->b |-> _;
+        predicate Q() = [_]interval_->a |-> ?a &*& [_]interval_->b |-> ?b;
         lemma void body(list<object> os1, list<object> os)
             requires P() &*& subset(objects, os1) == true &*& subset(os1, os) == true &*& heap(os);
             ensures Q() &*& heap(os) &*& subset(os, os) == true &*& subset(os1, os) == true;
@@ -270,7 +270,7 @@ struct interval *create_interval(int a, int b)
     interval->a = a;
     interval->b = b;
     return interval;
-    //@ leak object_class(&interval->object, _) &*& interval->a |-> _ &*& interval->b |-> _;
+    //@ leak object_class(&interval->object, _) &*& interval->a |-> ?a_ &*& interval->b |-> ?b_;
     //@ close interval_inv(interval, nil);
 }
 

--- a/examples/unions.c
+++ b/examples/unions.c
@@ -32,11 +32,11 @@ predicate expr(expr e;) =
   malloc_block_expr(e) &*&
   e->tag |-> ?tag &*&
   tag == EXPR_TAG_LITERAL ?
-    e->info.literal.value |-> _ &*&
+    e->info.literal.value |-> ?_ &*&
     struct_literal_expr_info_padding(&e->info.literal) &*&
     chars_((void *)&e->info + sizeof(struct literal_expr_info), sizeof(union expr_info) - sizeof(struct literal_expr_info), _)
   : tag == EXPR_TAG_BINOP ?
-    e->info.binop.operator |-> _ &*&
+    e->info.binop.operator |-> ?_ &*&
     e->info.binop.leftOperand |-> ?e1 &*& expr(e1) &*&
     e->info.binop.rightOperand |-> ?e2 &*& expr(e2) &*&
     struct_binop_expr_info_padding(&e->info.binop) &*&

--- a/examples/usbkbd/src/linux/usb.h
+++ b/examples/usbkbd/src/linux/usb.h
@@ -410,7 +410,7 @@ predicate urb_private(struct urb *urb, bool initialized, struct usb_device *dev,
 	// You can't write the status yourself (so we need a fraction here).
 	// We explicitly specify some fraction size to avoid opening the
 	// struct, stealing half of the fraction, and closing the struct again.
-	[1/2]urb->status |-> _
+	[1/2]urb->status |-> ?status
 	
 	// The URB initialization function enforces dev is a proper device (when that function is called)
 	// 

--- a/examples/usbkbd/src/linux/usb/ch9.h
+++ b/examples/usbkbd/src/linux/usb/ch9.h
@@ -103,7 +103,7 @@ struct usb_endpoint_descriptor {
 // XXX hmmm I dunno if I like the way this is done here...
 /*@ predicate usb_endpoint_descriptor_data(struct usb_endpoint_descriptor *epd; __u8 bEndpointAddress) = 
 	[1/2]epd->bEndpointAddress |-> bEndpointAddress
-	&*& [1/2]epd->bInterval |-> _;
+	&*& [1/2]epd->bInterval |-> ?bInterval;
 @*/
 
 /*@ 

--- a/examples/usbkbd/src/linux/usb/input.h
+++ b/examples/usbkbd/src/linux/usb/input.h
@@ -7,6 +7,6 @@
 static inline void
 usb_to_input_id(const struct usb_device *dev, struct input_id *id);
   //@ requires usb_device(dev, ?ep0) &*& id->bustype |-> _ &*& id->vendor |-> _ &*& id->product |-> _ &*& id->version |-> _;
-  //@ ensures usb_device(dev, ep0) &*& id->bustype |-> _ &*& id->vendor |-> _ &*& id->product |-> _ &*& id->version |-> _;
+  //@ ensures usb_device(dev, ep0) &*& id->bustype |-> ?bustype &*& id->vendor |-> ?vendor &*& id->product |-> ?product &*& id->version |-> ?version;
 
 #endif

--- a/examples/usbkbd/src/usbkbd_verified.c
+++ b/examples/usbkbd/src/usbkbd_verified.c
@@ -1824,6 +1824,7 @@ fail2:
 	//@ assert dev_ == dev;
 	usb_kbd_free_mem(dev, kbd);
 	
+	//@ close usb_kbd_leds_lock(kbd, _);
 	//@ open_struct(kbd); 
 	//@ chars__to_uchars_(kbd);
 
@@ -1939,6 +1940,7 @@ static void usb_kbd_disconnect(struct usb_interface *intf) //@ : vf_usb_operatio
 		//@ assert interface_to_usbdev_ret == dev;
 		
 		//@ spin_lock_dispose(&kbd->leds_lock);
+		//@ close usb_kbd_leds_lock(kbd, _);
 		//@ open_struct(kbd);
 		//@ chars__to_uchars_(kbd);
 		//@ dispose_ghost_stuff(kbd);
@@ -2053,10 +2055,14 @@ static int /*__init*/ usb_kbd_init(void) //@ : module_setup_t(usbkbd_verified)
 	
 	// VeriFast does not support struct initialization of the form struct something = {.x = y},
 	// so we write the fields here (not exactly original code):
+	usb_kbd_id_table->idVendor = 0;
+	usb_kbd_id_table->idProduct = 0;
+	usb_kbd_id_table->bDeviceClass = 0;
 	usb_kbd_id_table->match_flags = USB_DEVICE_ID_MATCH_INT_INFO;
 	usb_kbd_id_table->bInterfaceClass = USB_INTERFACE_CLASS_HID;
 	usb_kbd_id_table->bInterfaceSubClass = USB_INTERFACE_SUBCLASS_BOOT;
 	usb_kbd_id_table->bInterfaceProtocol = USB_INTERFACE_PROTOCOL_KEYBOARD;
+	usb_kbd_id_table->driver_info = 0;
 	//@ close usb_device_id(usb_kbd_id_table, false);
 	
 	// usb_kbd_id_table[1] is all zero.

--- a/examples/usbkbd/src/usbmouse.c
+++ b/examples/usbkbd/src/usbmouse.c
@@ -385,6 +385,7 @@ static int usb_mouse_probe(struct usb_interface *intf, const struct usb_device_i
 	mouse->data = usb_alloc_coherent(dev, 8, GFP_ATOMIC, &mouse->data_dma);
 	//@ signed char* data_tmp = mouse->data;
 	if (! mouse->data) {
+		//@ close usb_mouse_data_dma(mouse, _);
 		//@ open_struct(mouse);
 		//@ chars__to_uchars_(mouse);
 		goto fail1;

--- a/tests/cxx/constructors.cpp
+++ b/tests/cxx/constructors.cpp
@@ -42,6 +42,7 @@ struct Test {
   //@ ensures TestPred(this, 1, _);
   {
     _i = 1;
+    _k = 0;
     //@ close TestPred(this, _, _);
   }
   
@@ -80,6 +81,7 @@ Test::Test(int i) : _i(i)
 //@ requires true;
 //@ ensures TestPred(this, i, _);
 {
+  _k = 0;
   //@ close TestPred(this, i, _);
 }
 

--- a/tests/cxx/operators.cpp
+++ b/tests/cxx/operators.cpp
@@ -1,7 +1,7 @@
 #include "operators.h"
 
 void IntWrapper::setInt(int i)
-//@ requires this->i |-> _;
+//@ requires this->i |-> ?v;
 //@ ensures this->i |-> i;
 {
   this->i = i;

--- a/tests/cxx/operators.h
+++ b/tests/cxx/operators.h
@@ -15,7 +15,7 @@ class IntWrapper {
   {}
 
   void setInt(int i);
-  //@ requires this->i |-> _;
+  //@ requires this->i |-> ?v;
   //@ ensures this->i |-> i;
 
   int getInt() const;

--- a/tests/uninit.c
+++ b/tests/uninit.c
@@ -49,3 +49,12 @@ void uninit_malloc_primitive()
   if (px == 0) abort();
   int x = *px; //~ should_fail
 }
+
+void uninit_struct()
+//@ requires true;
+//@ ensures true;
+{
+  struct foo *f = malloc(sizeof(struct foo));
+  if (f == 0) abort();
+  int x = f->x; //~ should_fail
+}

--- a/tutorial_solutions/foreach.c
+++ b/tutorial_solutions/foreach.c
@@ -102,7 +102,7 @@ struct vector {
     int y;
 };
 
-//@ predicate vector(struct vector *v) = v->x |-> _ &*& v->y |-> _ &*& malloc_block_vector(v);
+//@ predicate vector(struct vector *v) = v->x |-> ?x &*& v->y |-> ?y &*& malloc_block_vector(v);
 
 struct vector *create_vector(int x, int y)
     //@ requires true;

--- a/tutorial_solutions/fractions.c
+++ b/tutorial_solutions/fractions.c
@@ -32,7 +32,7 @@ predicate tree(struct tree *t, int depth) =
     t == 0 ?
         depth == 0
     :
-        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> _ &*& malloc_block_tree(t) &*&
+        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> ?value &*& malloc_block_tree(t) &*&
         tree(left, depth - 1) &*& tree(right, depth - 1);
 @*/
 
@@ -87,9 +87,9 @@ struct fold_data {
 /*@
 
 predicate_family_instance thread_run_pre(folder)(struct fold_data *data, any info) =
-    data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> _;
+    data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> ?acc;
 predicate_family_instance thread_run_post(folder)(struct fold_data *data, any info) =
-    data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> _;
+    data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> ?acc;
 
 @*/
 

--- a/tutorial_solutions/fractions0.c
+++ b/tutorial_solutions/fractions0.c
@@ -32,7 +32,7 @@ predicate tree(struct tree *t, int depth) =
     t == 0 ?
         depth == 0
     :
-        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> _ &*& malloc_block_tree(t) &*&
+        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> ?value &*& malloc_block_tree(t) &*&
         tree(left, depth - 1) &*& tree(right, depth - 1);
 @*/
 
@@ -87,9 +87,9 @@ struct fold_data {
 /*@
 
 predicate_family_instance thread_run_pre(folder)(struct fold_data *data, any info) =
-    data->tree |-> ?tree &*& tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> _;
+    data->tree |-> ?tree &*& tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> ?acc;
 predicate_family_instance thread_run_post(folder)(struct fold_data *data, any info) =
-    data->tree |-> ?tree &*& tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> _;
+    data->tree |-> ?tree &*& tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> ?acc;
 
 @*/
 

--- a/tutorial_solutions/leaks.c
+++ b/tutorial_solutions/leaks.c
@@ -22,7 +22,7 @@ struct counter {
     struct mutex *mutex;
 };
 
-//@ predicate_ctor counter(struct counter *counter)() = counter->count |-> _;
+//@ predicate_ctor counter(struct counter *counter)() = counter->count |-> ?count;
 
 struct count_pulses_data {
     struct counter *counter;
@@ -32,7 +32,7 @@ struct count_pulses_data {
 /*@
 
 predicate_family_instance thread_run_data(count_pulses)(struct count_pulses_data *data) =
-    data->counter |-> ?counter &*& data->source |-> _ &*& malloc_block_count_pulses_data(data) &*&
+    data->counter |-> ?counter &*& data->source |-> ?source &*& malloc_block_count_pulses_data(data) &*&
     [_]counter->mutex |-> ?mutex &*& [_]mutex(mutex, counter(counter));
 
 @*/

--- a/tutorial_solutions/lemma.c
+++ b/tutorial_solutions/lemma.c
@@ -13,7 +13,7 @@ predicate lseg(struct node *first, struct node *last, int count) =
         count == 0
     :
         0 < count &*& first != 0 &*&
-        first->value |-> _ &*& first->next |-> ?next &*& malloc_block_node(first) &*&
+        first->value |-> ?value &*& first->next |-> ?next &*& malloc_block_node(first) &*&
         lseg(next, last, count - 1);
 
 lemma void nodes_to_lseg_lemma(struct node *first)

--- a/tutorial_solutions/mutexes.c
+++ b/tutorial_solutions/mutexes.c
@@ -18,7 +18,7 @@ struct counter {
     struct mutex *mutex;
 };
 
-//@ predicate_ctor counter(struct counter *counter)() = counter->count |-> _;
+//@ predicate_ctor counter(struct counter *counter)() = counter->count |-> ?count;
 
 struct count_pulses_data {
     struct counter *counter;
@@ -28,7 +28,7 @@ struct count_pulses_data {
 /*@
 
 predicate_family_instance thread_run_data(count_pulses)(struct count_pulses_data *data) =
-    data->counter |-> ?counter &*& data->source |-> _ &*& malloc_block_count_pulses_data(data) &*&
+    data->counter |-> ?counter &*& data->source |-> ?source &*& malloc_block_count_pulses_data(data) &*&
     [1/2]counter->mutex |-> ?mutex &*& [1/3]mutex(mutex, counter(counter));
 
 @*/

--- a/tutorial_solutions/precise.c
+++ b/tutorial_solutions/precise.c
@@ -32,7 +32,7 @@ predicate tree(struct tree *t; int depth) =
     t == 0 ?
         depth == 0
     :
-        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> _ &*& malloc_block_tree(t) &*&
+        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> ?value &*& malloc_block_tree(t) &*&
         tree(left, ?childDepth) &*& tree(right, childDepth) &*& depth == childDepth + 1;
 @*/
 
@@ -94,9 +94,9 @@ struct fold_data {
 /*@
 
 predicate_family_instance thread_run_pre(folder)(struct fold_data *data, any info) =
-    [1/2]data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> _;
+    [1/2]data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> ?acc;
 predicate_family_instance thread_run_post(folder)(struct fold_data *data, any info) =
-    [1/2]data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> _;
+    [1/2]data->tree |-> ?tree &*& [1/2]tree(tree, _) &*& data->f |-> ?f &*& is_fold_function(f) == true &*& data->acc |-> ?acc;
 
 @*/
 

--- a/tutorial_solutions/push_all.c
+++ b/tutorial_solutions/push_all.c
@@ -38,7 +38,7 @@ predicate lseg(struct node *first, struct node *last, int count) =
         count == 0
     :
         0 < count &*& first != 0 &*&
-        first->value |-> _ &*& first->next |-> ?next &*& malloc_block_node(first) &*&
+        first->value |-> ?value &*& first->next |-> ?next &*& malloc_block_node(first) &*&
         lseg(next, last, count - 1);
 
 lemma void nodes_to_lseg_lemma(struct node *first)
@@ -64,7 +64,7 @@ lemma void lseg_to_nodes_lemma(struct node *first)
 }
 
 lemma void lseg_add_lemma(struct node *first)
-    requires lseg(first, ?last, ?count) &*& last != 0 &*& last->value |-> _ &*& last->next |-> ?next &*& malloc_block_node(last) &*& lseg(next, 0, ?count0);
+    requires lseg(first, ?last, ?count) &*& last != 0 &*& last->value |-> ?lastValue &*& last->next |-> ?next &*& malloc_block_node(last) &*& lseg(next, 0, ?count0);
     ensures lseg(first, next, count + 1) &*& lseg(next, 0, count0);
 {
     open lseg(first, last, count);
@@ -139,7 +139,7 @@ void stack_push_all(struct stack *stack, struct stack *other)
             /*@
             invariant
                 lseg(head0, n, ?count1) &*&
-                n != 0 &*& n->value |-> _ &*& n->next |-> ?next &*& malloc_block_node(n) &*& lseg(next, 0, count0 - count1 - 1);
+                n != 0 &*& n->value |-> ?nValue &*& n->next |-> ?next &*& malloc_block_node(n) &*& lseg(next, 0, count0 - count1 - 1);
             @*/
         {
             n = n->next;

--- a/tutorial_solutions/threads.c
+++ b/tutorial_solutions/threads.c
@@ -32,7 +32,7 @@ predicate tree(struct tree *t, int depth) =
     t == 0 ?
         depth == 0
     :
-        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> _ &*& malloc_block_tree(t) &*&
+        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> ?value &*& malloc_block_tree(t) &*&
         tree(left, depth - 1) &*& tree(right, depth - 1);
 @*/
 
@@ -82,9 +82,9 @@ struct sum_data {
 /*@
 
 predicate_family_instance thread_run_pre(summator)(struct sum_data *data, any info) =
-    data->tree |-> ?tree &*& tree(tree, _) &*& data->sum |-> _;
+    data->tree |-> ?tree &*& tree(tree, _) &*& data->sum |-> ?sum;
 predicate_family_instance thread_run_post(summator)(struct sum_data *data, any info) =
-    data->tree |-> ?tree &*& tree(tree, _) &*& data->sum |-> _;
+    data->tree |-> ?tree &*& tree(tree, _) &*& data->sum |-> ?sum;
 
 @*/
 
@@ -106,6 +106,7 @@ struct sum_data *start_sum_thread(struct tree *tree)
     struct thread *t = 0;
     if (data == 0) abort();
     //@ leak malloc_block_sum_data(data);
+    data->sum = 0;
     data->tree = tree;
     //@ close thread_run_pre(summator)(data, unit);
     t = thread_start_joinable(summator, data);

--- a/tutorial_solutions/threads0.c
+++ b/tutorial_solutions/threads0.c
@@ -31,7 +31,7 @@ predicate tree(struct tree *t, int depth) =
     t == 0 ?
         depth == 0
     :
-        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> _ &*& malloc_block_tree(t) &*&
+        t->left |-> ?left &*& t->right |-> ?right &*& t->value |-> ?value &*& malloc_block_tree(t) &*&
         tree(left, depth - 1) &*& tree(right, depth - 1);
 @*/
 


### PR DESCRIPTION
This breaking change (probably the biggest breaking change in the history of VeriFast) is necessary to make VeriFast sound with respect to the fact that C compilers perform optimizations that assume that the program does not read uninitialized memory. (See e.g. <https://www.ralfj.de/blog/2019/07/14/uninit.html> and <https://godbolt.org/z/Y4x6cn6fq>.)

For each field f of type T of a struct S, VeriFast introduces a predicate S_f(struct S *s, T v) that represents an initialized instance of the field. This commit causes VeriFast to also introduce the corresponding "underscore predicate" S_f_(struct S *s, option<T> v) that represents a possibly-uninitialized instance of the field.

Writing consumes an underscore chunk and produces an initialized chunk; reading requires an initialized chunk. Allocation produces an underscore chunk and deallocation consumes an underscore chunk.

The syntax s->f |-> _ is now interpreted as denoting an underscore chunk. The syntax s->f |-> ?_ can be used to denote an initialized chunk.

See the discussion at #315.

TODO:
- Update the VeriFast Tutorial
- Make VeriFast sound with respect to pointer provenance and effective types
- Improve soundness regarding struct padding