### PR TITLE
Track pointer provenance

### DIFF
--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -14,6 +14,7 @@
 .provides ./string.h#strcmp
 .provides ./string.h#strlen
 .provides ./string.h#strdup
+.provides ./prelude.h#field_ptr_provenance_injective
 .provides ./prelude.h#integer__distinct
 .provides ./prelude.h#integer__unique
 .provides ./prelude.h#integer__limits
@@ -121,6 +122,7 @@
 .provides ./prelude.h#uchars_to_chars
 .provides ./prelude.h#chars_to_ints
 .provides ./prelude.h#ints_to_chars
+.provides ./prelude.h#ints__to_chars_
 .provides ./prelude.h#chars_to_uints
 .provides ./prelude.h#uints_to_chars
 .provides ./prelude.h#chars_to_bools
@@ -249,6 +251,7 @@
 .provides ./target.gh#int_size_int_max
 .provides ./target.gh#long_size_long_max
 .provides ./target.gh#ptr_size_ptr_max
+.provides ./target.gh#uintptr_size_uintptr_max
 .provides ./target.gh#target_sizes
 .predicate @./stdarg.h#va_list
 .provides ./stdarg.h#__va_start

--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -29,6 +29,33 @@ lemma void div_rem_nonneg(int D, int d);
     requires 0 <= D &*& 0 < d;
     ensures D == D / d * d + D % d &*& 0 <= D / d &*& D / d <= D &*& 0 <= D % d &*& D % d < d;
 
+abstract_type pointer_provenance;
+inductive pointer = pointer_ctor(pointer_provenance provenance, uintptr_t address);
+
+fixpoint pointer ptr_add(pointer p, int offset) {
+    return pointer_ctor(p.provenance, p.address + offset);
+}
+
+fixpoint pointer_provenance field_ptr_provenance(pointer p, int fieldOffset);
+fixpoint pointer field_ptr_provenance_parent(pointer_provenance pr, int fieldOffset);
+
+lemma_auto(field_ptr_provenance(p, fieldOffset)) void field_ptr_provenance_injective(pointer p, int fieldOffset);
+    requires true;
+    ensures field_ptr_provenance_parent(field_ptr_provenance(p, fieldOffset), fieldOffset) == p;
+
+fixpoint pointer field_ptr(pointer p, int fieldOffset) {
+    return pointer_ctor(field_ptr_provenance(p, fieldOffset), p.address + fieldOffset);
+}
+fixpoint pointer_provenance union_variant_ptr_provenance(pointer p, int variantId) {
+    return p.provenance; // TODO: enforce strict aliasing (a.k.a. "effective types")
+}
+fixpoint pointer union_variant_ptr(pointer p, int variantId) {
+    return pointer_ctor(union_variant_ptr_provenance(p, variantId), p.address);
+}
+
+fixpoint pointer_provenance null_pointer_provenance();
+fixpoint pointer null_pointer() { return pointer_ctor(null_pointer_provenance, 0); }
+
 predicate generic_points_to<t>(t *p; t v);
 
 predicate integer__(void *p, int size, bool signed_; option<int> v);
@@ -606,6 +633,10 @@ lemma_auto void chars_to_ints(void *p, int n);
 lemma_auto void ints_to_chars(void *p);
     requires [?f]ints(p, ?n, _);
     ensures [f]chars(p, n * sizeof(int), _);
+
+lemma_auto void ints__to_chars_(void *p);
+    requires [?f]ints_(p, ?n, _);
+    ensures [f]chars_(p, n * sizeof(int), _);
 
 lemma_auto void chars_to_uints(void *p, int n);
     requires [?f]chars(p, n * sizeof(unsigned int), _);

--- a/bin/stdio.h
+++ b/bin/stdio.h
@@ -47,11 +47,11 @@ FILE* fopen(char* filename, char* mode); // todo: check that mode is a valid mod
     @*/
     //@ ensures [f]string(filename, fcs) &*& [g]string(mode, mcs) &*& result == 0 ? true : file(result);
 
-int fread(void* buffer, int size, int n, FILE* fp);
+int fread(void* buffer, size_t size, size_t n, FILE* fp);
     //@ requires chars_(buffer, ?m, ?cs) &*& 0<=size &*& 0<=n &*& size * n <= m &*& [?f]file(fp);
     //@ ensures chars(buffer, size * result, ?cs2) &*& chars_(buffer + size * result, m - size * result, _) &*& [f]file(fp) &*& 0 <= result &*& result <= n;
   
-int fwrite(void* buffer, int size, int n, FILE* fp);
+int fwrite(void* buffer, size_t size, size_t n, FILE* fp);
     //@ requires [?fb]chars(buffer, ?m, ?cs) &*& 0<=size &*& 0<=n &*& size * n <= m &*& [?ff]file(fp);
     //@ ensures [fb]chars(buffer, m, cs) &*& [ff]file(fp) &*& 0 <= result &*& result <= n;
   

--- a/bin/target.gh
+++ b/bin/target.gh
@@ -13,6 +13,10 @@ lemma_auto void ptr_size_ptr_max();
     requires true;
     ensures __maxvalue(intptr_t) == (1 << (8 * sizeof(intptr_t) - 1)) - 1;
 
+lemma_auto void uintptr_size_uintptr_max();
+    requires true;
+    ensures __maxvalue(uintptr_t) == (1 << (8 * sizeof(uintptr_t))) - 1;
+
 inductive target = IP16 | I16 | ILP32 | LLP64 | LP64;
 
 fixpoint target __target();

--- a/examples/MockKernel/MockKernel.mysh
+++ b/examples/MockKernel/MockKernel.mysh
@@ -3,7 +3,7 @@ verifast
 verifast -prover redux
 in
 dlsymtool MockKernelModule.dlsymspec
-verifast_both -c -emit_vfmanifest MockKernel.c
+verifast_both -c -emit_vfmanifest -assume_no_subobject_provenance MockKernel.c
 verifast_both -emit_dll_vfmanifest MockKernelModule_proxy.o threading.o contrib.o ghost_sets.o libraries.o lists.o sockets.o MockKernel.o
 dlsymtool MockKernelModule.dlsymspec AdderModule
 verifast_both -shared MockKernel.dll.vfmanifest AdderModule.c -export MockKernelModule_AdderModule.vfmanifest

--- a/examples/chat.mysh
+++ b/examples/chat.mysh
@@ -1,7 +1,7 @@
-verifast CRT/threading.o stringBuffers.c sockets.o lists.c ghostlist.o chat.c
+verifast CRT/threading.o stringBuffers.c sockets.o lists.c ghostlist.o -assume_no_subobject_provenance chat.c
 verifast -c -emit_vfmanifest stringBuffers.c
 verifast -c -emit_vfmanifest lists.c
-verifast -c -emit_vfmanifest chat.c
+verifast -c -emit_vfmanifest -assume_no_subobject_provenance chat.c
 verifast CRT/threading.o stringBuffers.o sockets.o lists.o ghostlist.o chat.o
 del stringBuffers.vfmanifest
 del chat.vfmanifest

--- a/examples/cp.c
+++ b/examples/cp.c
@@ -21,7 +21,7 @@ int main(int argc, char** argv) //@ : main
   while(0 < nb_read)
     //@ invariant file(from) &*& file(to) &*& buffer[..nb_read] |-> ?_ &*& nb_read <= 100 &*& buffer[nb_read..100] |-> _;
   {
-    int nb_written = fwrite(buffer, 1, nb_read, to);
+    int nb_written = fwrite(buffer, 1, (uintptr_t)nb_read, to);
     //@ chars_chars__join(buffer);
     nb_read = fread(buffer, 1, 100, from);
   }

--- a/examples/crypto_ccs/annotated_api/aes.h
+++ b/examples/crypto_ccs/annotated_api/aes.h
@@ -16,7 +16,7 @@ typedef struct aes_context aes_context;
 /*@
 
 predicate aes_context(aes_context *context) =
-  chars_((void*) context, AES_CONTEXT_SIZE, _) &*&
+  chars_(context->content, AES_CONTEXT_SIZE, _) &*&
   struct_aes_context_padding(context)
 ;
 

--- a/examples/crypto_ccs/annotated_api/gcm.h
+++ b/examples/crypto_ccs/annotated_api/gcm.h
@@ -16,7 +16,7 @@ typedef struct gcm_context gcm_context;
 /*@
 
 predicate gcm_context(gcm_context *context) =
-  chars_((void*) context, GCM_CONTEXT_SIZE, _) &*&
+  chars_(context->content, GCM_CONTEXT_SIZE, _) &*&
   struct_gcm_context_padding(context)
 ;
 predicate gcm_context_initialized(gcm_context *context,

--- a/examples/crypto_ccs/annotated_api/havege.h
+++ b/examples/crypto_ccs/annotated_api/havege.h
@@ -14,7 +14,7 @@ typedef struct havege_state havege_state;
 /*@
 
 predicate havege_state(havege_state *state) =
-  chars_((void*) state, HAVEGE_STATE_SIZE, _) &*&
+  chars_(state->content, HAVEGE_STATE_SIZE, _) &*&
   struct_havege_state_padding(state)
 ;
 

--- a/examples/custom_bindir/bin/stdlib/crt.dll.vfmanifest
+++ b/examples/custom_bindir/bin/stdlib/crt.dll.vfmanifest
@@ -1,3 +1,4 @@
+.provides ./prelude.h#field_ptr_provenance_injective
 .predicate @./prelude.h#cutom_chars
 .provides ./prelude.h#custom_chars_inv
 .predicate @./prelude.h#malloc_block

--- a/examples/custom_bindir/bin/stdlib/prelude.h
+++ b/examples/custom_bindir/bin/stdlib/prelude.h
@@ -12,6 +12,33 @@ fixpoint int length<t>(list<t> xs) {
     }
 }
 
+abstract_type pointer_provenance;
+inductive pointer = pointer_ctor(pointer_provenance provenance, uintptr_t address);
+
+fixpoint pointer ptr_add(pointer p, int offset) {
+    return pointer_ctor(p.provenance, p.address + offset);
+}
+
+fixpoint pointer_provenance field_ptr_provenance(pointer p, int fieldOffset);
+fixpoint pointer field_ptr_provenance_parent(pointer_provenance pr, int fieldOffset);
+
+lemma_auto(field_ptr_provenance(p, fieldOffset)) void field_ptr_provenance_injective(pointer p, int fieldOffset);
+    requires true;
+    ensures field_ptr_provenance_parent(field_ptr_provenance(p, fieldOffset), fieldOffset) == p;
+
+fixpoint pointer field_ptr(pointer p, int fieldOffset) {
+    return pointer_ctor(field_ptr_provenance(p, fieldOffset), p.address + fieldOffset);
+}
+fixpoint pointer_provenance union_variant_ptr_provenance(pointer p, int variantId) {
+    return p.provenance; // TODO: enforce strict aliasing (a.k.a. "effective types")
+}
+fixpoint pointer union_variant_ptr(pointer p, int variantId) {
+    return pointer_ctor(union_variant_ptr_provenance(p, variantId), p.address);
+}
+
+fixpoint pointer_provenance null_pointer_provenance();
+fixpoint pointer null_pointer() { return pointer_ctor(null_pointer_provenance, 0); }
+
 predicate custom_chars(char *array, int size, list<char> cs);
 
 lemma_auto void custom_chars_inv();

--- a/examples/mcas/bitops_ex.c
+++ b/examples/mcas/bitops_ex.c
@@ -1,5 +1,6 @@
 //@ #include <bitops.gh>
 //@ #include "bitops_ex.gh"
+//@ #include "target.gh"
 
 /*@
 
@@ -37,7 +38,7 @@ lemma Z Z_of_int(int x)
 
 lemma void Z_and_Z_or_lemma(Z x, Z y)
     requires int_of_Z(Z_and(x, y)) == 0;
-    ensures int_of_Z(y) == int_of_Z(Z_and(Z_or(x, y), y)) &*& int_of_Z(x) == int_of_Z(Z_and(Z_or(x, y), Z_not(y)));
+    ensures int_of_Z(y) == int_of_Z(Z_and(Z_or(x, y), y)) &*& int_of_Z(x) == int_of_Z(Z_and(Z_or(x, y), Z_not(y))) &*& int_of_Z(Z_or(x, y)) == int_of_Z(x) + int_of_Z(y);
 {
     switch (x) {
     case Zsign(xs):
@@ -56,8 +57,8 @@ lemma void Z_and_Z_or_lemma(Z x, Z y)
 }
 
 lemma void bitand_bitor_lemma(uintptr_t x, uintptr_t y)
-    requires true == ((x & y) == 0);
-    ensures y == ((x | y) & y) &*& x == ((x | y) & ~y);
+    requires true == ((x & y) == 0) &*& 0 <= x &*& x <= UINTPTR_MAX &*& 0 <= y &*& y <= UINTPTR_MAX;
+    ensures y == ((x | y) & y) &*& x == ((x | y) & ~y) &*& (x | y) == x + y &*& x + y <= UINTPTR_MAX;
 {
     Z zx = Z_of_int(x);
     Z zy = Z_of_int(y);
@@ -67,12 +68,46 @@ lemma void bitand_bitor_lemma(uintptr_t x, uintptr_t y)
     bitand_def(x | y, Z_or(zx, zy), y, zy);
     bitnot_def(y, zy);
     bitand_def(x | y, Z_or(zx, zy), ~y, Z_not(zy));
+    assert UINTPTR_MAX == (1 << (8 * sizeof(uintptr_t))) - 1;
+    shiftleft_def(1, nat_of_int(8 * sizeof(uintptr_t)));
+    bitor_limits(x, y, nat_of_int(8 * sizeof(uintptr_t)));
+}
+
+lemma void bitand_minus_lemma(uintptr_t x)
+    requires (x & 1) != 0 &*& 0 <= x;
+    ensures 0 <= x - 1;
+{
+    Z zx = Z_of_int(x);
+    switch (zx) {
+    case Zsign(zxs):
+    case Zdigit(zx1, zd0):
+        switch (zx1) {
+        case Zsign(zxs):
+        case Zdigit(zx2, zd1):
+        }
+    }
+    Z z1 = Zdigit(Zsign(false), true);
+    bitand_def(x, zx, 1, z1);
+}
+
+lemma void bitand_minus2_lemma(uintptr_t x)
+    requires (x & 2) != 0 &*& 0 <= x;
+    ensures 0 <= x - 2;
+{
+    Z zx = Z_of_int(x);
+    Z z2 = Zdigit(Zdigit(Zsign(false), true), false);
+    bitand_def(x, zx, 2, z2);
+    assert zx == Zdigit(Zdigit(?zx2, ?zd1), ?zd0);
+    switch (zx2) { case Zsign(zs): case Zdigit(zs, zd2): }
+    if (zd0) {} else {}
+    if (zd1) {} else {}
 }
 
 lemma void bitand_bitor_1_2_lemma(void *x)
-    requires true == (((uintptr_t)x & 1) == 0);
-    ensures  true == ((((uintptr_t)x | 2) & 1) == 0);
+    requires true == (((uintptr_t)x & 1) == 0) &*& ((uintptr_t)x & 2) == 0 &*& 0 <= (uintptr_t)x &*& (uintptr_t)x <= UINTPTR_MAX;
+    ensures  true == ((((uintptr_t)x | 2) & 1) == 0) &*& true == ((((uintptr_t)x + 2) & 1) == 0) &*& (uintptr_t)x + 2 <= UINTPTR_MAX;
 {
+    bitand_bitor_lemma((uintptr_t)x, 2);
     uintptr_t ux = (uintptr_t)x;
     Z zx = Z_of_int(ux);
     switch (zx) {

--- a/examples/mcas/bitops_ex.gh
+++ b/examples/mcas/bitops_ex.gh
@@ -4,12 +4,20 @@
 #include <bitops.gh>
 
 lemma void bitand_bitor_lemma(uintptr_t x, uintptr_t y);
-    requires true == ((x & y) == 0);
-    ensures y == ((x | y) & y) &*& x == ((x | y) & ~y);
+    requires true == ((x & y) == 0) &*& 0 <= x &*& x <= UINTPTR_MAX &*& 0 <= y &*& y <= UINTPTR_MAX;
+    ensures y == ((x | y) & y) &*& x == ((x | y) & ~y) &*& y == ((x + y) & y) &*& x + y <= UINTPTR_MAX;
+
+lemma void bitand_minus_lemma(uintptr_t x);
+    requires (x & 1) != 0 &*& 0 <= x;
+    ensures 0 <= x - 1;
+
+lemma void bitand_minus2_lemma(uintptr_t x);
+    requires (x & 2) != 0 &*& 0 <= x;
+    ensures 0 <= x - 2;
 
 lemma void bitand_bitor_1_2_lemma(void *x);
-    requires true == (((uintptr_t)x & 1) == 0);
-    ensures  true == ((((uintptr_t)x | 2) & 1) == 0);
+    requires true == (((uintptr_t)x & 1) == 0) &*& ((uintptr_t)x & 2) == 0 &*& 0 <= (uintptr_t)x &*& (uintptr_t)x <= UINTPTR_MAX;
+    ensures  true == ((((uintptr_t)x | 2) & 1) == 0) &*& true == ((((uintptr_t)x + 2) & 1) == 0) &*& (uintptr_t)x + 2 <= UINTPTR_MAX;
 
 lemma void bitand_plus_4(void *x);
     requires true == (((uintptr_t)x & 1) == 0) &*& true == (((uintptr_t)x & 2) == 0);

--- a/examples/mcas/bitops_ex.vfmanifest
+++ b/examples/mcas/bitops_ex.vfmanifest
@@ -2,6 +2,7 @@
 .requires CRT/bitops.gh#bitand_uintN_def
 .requires CRT/bitops.gh#bitnot_def
 .requires CRT/bitops.gh#bitor_def
+.requires CRT/bitops.gh#bitor_limits
 .requires CRT/bitops.gh#bitor_uintN_def
 .requires CRT/bitops.gh#bitxor_uintN_def
 .requires CRT/bitops.gh#shiftleft_def
@@ -72,6 +73,7 @@
 .requires CRT/prelude.h#chars_unseparate_string
 .requires CRT/prelude.h#div_rem
 .requires CRT/prelude.h#divrem_elim
+.requires CRT/prelude.h#field_ptr_provenance_injective
 .requires CRT/prelude.h#int__to_chars_
 .requires CRT/prelude.h#int_of_chars_of_int
 .requires CRT/prelude.h#int_of_chars_size
@@ -84,6 +86,7 @@
 .requires CRT/prelude.h#ints__inv
 .requires CRT/prelude.h#ints__join
 .requires CRT/prelude.h#ints__split
+.requires CRT/prelude.h#ints__to_chars_
 .requires CRT/prelude.h#ints__to_ints
 .requires CRT/prelude.h#ints_inv
 .requires CRT/prelude.h#ints_to_chars
@@ -129,7 +132,14 @@
 .requires CRT/prelude.h#ullongs_inv
 .requires CRT/prelude.h#ushorts_inv
 .requires CRT/prelude_core.gh#default_value_eq_zero
+.requires CRT/target.gh#int_size_int_max
+.requires CRT/target.gh#long_size_long_max
+.requires CRT/target.gh#ptr_size_ptr_max
+.requires CRT/target.gh#target_sizes
+.requires CRT/target.gh#uintptr_size_uintptr_max
 .provides ./bitops_ex.gh#bitand_bitor_1_2_lemma
 .provides ./bitops_ex.gh#bitand_bitor_lemma
+.provides ./bitops_ex.gh#bitand_minus2_lemma
+.provides ./bitops_ex.gh#bitand_minus_lemma
 .provides ./bitops_ex.gh#bitand_plus_4
 .produces module bitops_ex

--- a/examples/mcas/popl20_prophecies.h
+++ b/examples/mcas/popl20_prophecies.h
@@ -25,7 +25,7 @@ typedef long long popl20_prophecy_id;
 
 /*@
 
-predicate popl20_prophecy(popl20_prophecy_id pid, list<pair<int, list<vararg> > > vs);
+predicate popl20_prophecy(popl20_prophecy_id pid, list<pair<vararg, list<vararg> > > vs);
 
 lemma void popl20_prophecy_inv(popl20_prophecy_id pid);
     requires popl20_prophecy(pid, ?vs);
@@ -88,7 +88,7 @@ void resolve_list_push(resolve_list_id rlid, popl20_prophecy_id pid, ...);
 
 /*@
 
-predicate prophecies(list<resolve_cmd> resolveCmds, list<list<pair<int, list<vararg> > > > vss) =
+predicate prophecies(list<resolve_cmd> resolveCmds, list<list<pair<vararg, list<vararg> > > > vss) =
     switch (resolveCmds) {
     case nil: return vss == nil;
     case cons(resolveCmd, resolveCmds0): return
@@ -98,7 +98,7 @@ predicate prophecies(list<resolve_cmd> resolveCmds, list<list<pair<int, list<var
         prophecies(resolveCmds0, vss0);
     };
 
-predicate prophecies_resolved(list<resolve_cmd> resolveCmds, list<list<pair<int, list<vararg> > > > vss, int result) =
+predicate prophecies_resolved(list<resolve_cmd> resolveCmds, list<list<pair<vararg, list<vararg> > > > vss, vararg result) =
     switch (resolveCmds) {
     case nil: return vss == nil;
     case cons(resolveCmd, resolveCmds0): return
@@ -115,7 +115,7 @@ predicate prophecies_resolved(list<resolve_cmd> resolveCmds, list<list<pair<int,
 
 typedef lemma void popl20_atomic_load_pointer_ghop(void **pp, list<resolve_cmd> resolveCmds, predicate() P, predicate(void *) Q)();
     requires [?f]*pp |-> ?p &*& prophecies(resolveCmds, ?vss) &*& P();
-    ensures [f]*pp |-> p &*& prophecies_resolved(resolveCmds, vss, (uintptr_t)p) &*& Q(p);
+    ensures [f]*pp |-> p &*& prophecies_resolved(resolveCmds, vss, vararg_pointer(p)) &*& Q(p);
 
 typedef lemma void popl20_atomic_load_pointer_ctxt(void **pp, list<resolve_cmd> resolveCmds, predicate() pre, predicate(void *) post)();
     requires popl20_atomic_spaces(nil) &*& pre() &*& is_popl20_atomic_load_pointer_ghop(?ghop, pp, resolveCmds, ?P, ?Q) &*& P();
@@ -145,8 +145,8 @@ fixpoint bool fst_head_eq<a, b>(a x, list<pair<a, b> > xys) {
 }
 
 typedef lemma void popl20_atomic_compare_and_swap_pointer_ghop(void **pp, void *old, void *new, list<resolve_cmd> resolveCmds, predicate() P, predicate(void *) Q)();
-    requires [?f]*pp |-> ?p &*& prophecies(resolveCmds, ?vss) &*& P() &*& p != old || !forall(vss, (fst_head_eq)((uintptr_t)p)) || f == 1;
-    ensures [f]*pp |-> (p == old ? new : p) &*& prophecies_resolved(resolveCmds, vss, (uintptr_t)p) &*& Q(p);
+    requires [?f]*pp |-> ?p &*& prophecies(resolveCmds, ?vss) &*& P() &*& p != old || !forall(vss, (fst_head_eq)(vararg_pointer(p))) || f == 1;
+    ensures [f]*pp |-> (p == old ? new : p) &*& prophecies_resolved(resolveCmds, vss, vararg_pointer(p)) &*& Q(p);
 
 typedef lemma void popl20_atomic_compare_and_swap_pointer_ctxt(void **pp, void *old, void *new, list<resolve_cmd> resolveCmds, predicate() pre, predicate(void *) post)();
     requires popl20_atomic_spaces(nil) &*& is_popl20_atomic_compare_and_swap_pointer_ghop(?ghop, pp, old, new, resolveCmds, ?P, ?Q) &*& P() &*& pre();

--- a/examples/stringBuffers.c
+++ b/examples/stringBuffers.c
@@ -209,7 +209,7 @@ int chars_index_of_string(char *chars, int length, char *string)
     //@ chars_limits(chars);
     end = chars + length;
     while (true)
-        //@ invariant [f1]chars(chars, length, charsChars) &*& [f2]string(string, stringChars) &*& chars <= p &*& p <= end;
+        //@ invariant [f1]chars(chars, length, charsChars) &*& [f2]string(string, stringChars) &*& 0 <= p - chars &*& p - chars <= length &*& p == chars + (p - chars);
     {
         if ((size_t)(end - p) < n) return -1;
         //@ chars_split(chars, p - chars);

--- a/examples/termination/termination.mysh
+++ b/examples/termination/termination.mysh
@@ -10,5 +10,5 @@ verifast_both -shared -link_should_fail inter_module_loop1.c inter_module_loop2.
 verifast_both -allow_assume simple_recursion.c
 
 verifast_both -disable_overflow_check -c ackermann.c
-verifast_both -disable_overflow_check -c funcptr.c
-verifast_both call_perms.o termination.c cons.c
+verifast_both -disable_overflow_check -c -assume_no_subobject_provenance funcptr.c
+verifast_both call_perms.o termination.c -assume_no_subobject_provenance cons.c

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2740,7 +2740,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         match penv, dialect, in_pure_context with
         | ("this", this_term) :: _, Some Cxx, false ->
           let ("this", PtrType (StructType sn)) :: _ = ps in
-          assume_neq this_term real_zero @@ fun () ->
+          assume_neq this_term (null_pointer_term ()) @@ fun () ->
           cont (Some (sn, this_term))
         | _ -> 
           cont None
@@ -2896,7 +2896,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       check_should_fail () @@ fun () ->
       execute_branch @@ fun () ->
       with_context (Executing ([], env, loc, sprintf "Verifying constructor '%s'" struct_name)) @@ fun () ->
-      assume_neq this_term int_zero_term @@ fun () ->
+      assume_neq this_term (null_pointer_term ()) @@ fun () ->
       produce_asn [] [] ghostenv env pre real_unit None None @@ fun h ghostenv env ->
       init_constructs this_term init_list leminfo sizemap h env ghostenv @@ fun delegated h init_list ->
       if List.exists (function ("this", _) -> true | _ -> false) init_list then assert_false h env loc "Invalid order of initialization: the base or delegating constructor should already have been handled." None;
@@ -2950,7 +2950,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | (base_name, (base_spec_loc, is_virtual, base_offset)) :: bases_rest ->
           iter bases_rest @@ fun h env tenv ->
           with_context (Executing (h, [], base_spec_loc, "Executing base destructor")) @@ fun () ->
-          let this_addr = ctxt#mk_add this_addr base_offset in
+          let this_addr = mk_field_ptr this_addr base_offset in
           let verify_dtor_call = verify_dtor_call (pn, ilist) leminfo funcmap predinstmap sizemap tenv ghostenv h env this_addr None in
           consume_cxx_object base_spec_loc real_unit_pat this_addr (StructType base_name) verify_dtor_call false h env @@ fun h env ->
           cont h env tenv
@@ -2969,7 +2969,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       check_should_fail () @@ fun () ->
       execute_branch @@ fun () ->
       with_context (Executing ([], env, loc, sprintf "Verifying destructor '%s'" @@ cxx_dtor_name struct_name)) @@ fun () ->
-      assume_neq this_term int_zero_term @@ fun () ->
+      assume_neq this_term (null_pointer_term ()) @@ fun () ->
       produce_asn [] [] ghostenv env pre real_unit None None @@ fun h ghostenv env ->
       begin fun cont ->
         match try_assoc struct_name bases_constructed_map with

--- a/src/verifast0.ml
+++ b/src/verifast0.ml
@@ -145,6 +145,7 @@ let bases_constructed_pred_name sn = sn ^ "_bases_constructed"
 type options = {
   option_verbose: int;
   option_disable_overflow_check: bool;
+  option_assume_no_subobject_provenance: bool;
   option_allow_should_fail: bool;
   option_emit_manifest: bool;
   option_check_manifest: bool;

--- a/src/vfconsole.ml
+++ b/src/vfconsole.ml
@@ -335,6 +335,7 @@ let _ =
   let json = ref false in
   let verbose = ref 0 in
   let disable_overflow_check = ref false in
+  let assume_no_subobject_provenance = ref false in
   let prover: string ref = ref default_prover in
   let compileOnly = ref false in
   let isLibrary = ref false in
@@ -388,6 +389,7 @@ let _ =
             ; "-json", Set json, "Report result as JSON"
             ; "-verbose", Set_int verbose, "-1 = file processing; 1 = statement executions; 2 = produce/consume steps; 4 = prover queries."
             ; "-disable_overflow_check", Set disable_overflow_check, " "
+            ; "-assume_no_subobject_provenance", Set assume_no_subobject_provenance, "Assume the compiler's alias analysis ignores subobject provenance. CompCert ignores subobject provenance, and so, it seems, do GCC and Clang (last time I checked)"
             ; "-prover", String (fun str -> prover := str), "Set SMT prover (" ^ list_provers() ^ ")."
             ; "-c", Set compileOnly, "Compile only, do not perform link checking."
             ; "-shared", Set isLibrary, "The file is a library (i.e. no main function required)."
@@ -437,6 +439,7 @@ let _ =
         let options = {
           option_verbose = !verbose;
           option_disable_overflow_check = !disable_overflow_check;
+          option_assume_no_subobject_provenance = !assume_no_subobject_provenance;
           option_allow_should_fail = !allowShouldFail;
           option_emit_manifest = !emitManifest;
           option_check_manifest = !checkManifest;

--- a/tests/provenance.c
+++ b/tests/provenance.c
@@ -1,0 +1,46 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+bool do_alias(int *x, int *y)
+//@ requires true;
+//@ ensures result == (x == y);
+{
+    if ((uintptr_t)x <= (uintptr_t)y)
+        return (uintptr_t)y - (uintptr_t)x == 0;
+    else
+        return (uintptr_t)x - (uintptr_t)y == 0;
+}
+
+int main()
+//@ requires true;
+//@ ensures !result;
+{
+    int y[2];
+    int x[2];
+    //@ ints__to_chars_(&x[0]);
+    if (fread(x, sizeof(int), 2, stdin) != 2) abort();
+    //@ ints__to_chars_(&y[0]);
+    if (fread(y, sizeof(int), 2, stdin) != 2) abort();
+    bool b1 = do_alias(&x[2], &y[0]);
+    bool b2 = &x[2] != &y[0];
+    printf("%p %p %d %d\n", &x[2], &y[0], b1 ? 1 : 0, b2 ? 1 : 0);
+    fwrite(x, sizeof(int), 2, stdout);
+    fwrite(y, sizeof(int), 2, stdout);
+    return b1 && b2 ? 1 : 0;
+    //@ chars_to_ints(&x[0], 2);
+    //@ chars_to_ints(&y[0], 2);
+}
+
+/*
+
+# gcc --version
+gcc (GCC) 12.2.0
+# gcc -o provenance -O0 provenance.c
+# echo 0123456789abcdef | ./provenance
+0x7ffdc2207f44 0x7ffdc2207f44 1 1
+# echo $?
+1
+
+*/

--- a/tests/provenance0.c
+++ b/tests/provenance0.c
@@ -1,0 +1,14 @@
+void provenance()
+//@ requires true;
+//@ ensures true;
+{
+  int x[2];
+  int y[2];
+  // Uncomment the lines below to get VeriFast to accept this program.
+  // //@ assume(&x[2] == (int *)(uintptr_t)&x[2]);
+  // //@ assume(&y[0] == (int *)(uintptr_t)&y[0]);
+  if ((uintptr_t)&x[2] == (uintptr_t)&y[0]) {
+    x[2] = 42; //~should_fail
+    assert(y[0] == 42); //~allow_dead_code
+  }
+}

--- a/tests/subobject_provenance.c
+++ b/tests/subobject_provenance.c
@@ -1,0 +1,45 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+bool do_alias(int *x, int *y)
+//@ requires true;
+//@ ensures result == (x == y);
+{
+    if ((uintptr_t)x <= (uintptr_t)y)
+        return (uintptr_t)y - (uintptr_t)x == 0;
+    else
+        return (uintptr_t)x - (uintptr_t)y == 0;
+}
+
+struct foo {
+  int x[2];
+  int y[2];
+};
+
+int main()
+//@ requires true;
+//@ ensures !result;
+{
+    struct foo f;
+    //@ ints__to_chars_(&f.x[0]);
+    if (fread(f.x, sizeof(int), 2, stdin) != 2) abort();
+    //@ ints__to_chars_(&f.y[0]);
+    if (fread(f.y, sizeof(int), 2, stdin) != 2) abort();
+    bool b1 = do_alias(&f.x[2], &f.y[0]);
+    bool b2 = &f.x[2] != &f.y[0];
+    printf("%p %p %d %d\n", &f.x[2], &f.y[0], b1 ? 1 : 0, b2 ? 1 : 0);
+    fwrite(f.x, sizeof(int), 2, stdout);
+    fwrite(f.y, sizeof(int), 2, stdout);
+    return b1 && b2 ? 1 : 0;
+    //@ chars_to_ints(&f.x[0], 2);
+    //@ chars_to_ints(&f.y[0], 2);
+}
+
+/*
+
+This returns 0 on all platforms I tried. Current compilers
+do not appear to exploit subobject provenance.
+
+*/

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -110,7 +110,7 @@ cd examples
     cd ..
   cd ..
   cd tso
-    verifast_both -c cvm0.c
+    verifast_both -c -assume_no_subobject_provenance cvm0.c
     verifast_both -c lock.c
     verifast_both -c -disable_overflow_check prodcons.c
   cd ..
@@ -143,13 +143,13 @@ cd examples
   verifast_both -allow_assume -disable_overflow_check dyncode.c
   verifast_both enums.c
   verifast_both -c equalsmap.c
-  verifast_both -disable_overflow_check expr.c
+  verifast_both -disable_overflow_check -assume_no_subobject_provenance expr.c
   cd fm2012
     mysh < fm2012.mysh
   cd ..
   verifast_both -disable_overflow_check -c fractions-counting.c
-  verifast_both -disable_overflow_check -c gcl0.c
-  verifast_both -disable_overflow_check -c gcl.c
+  verifast_both -disable_overflow_check -c -assume_no_subobject_provenance gcl0.c
+  verifast_both -disable_overflow_check -c -assume_no_subobject_provenance gcl.c
   verifast_both ghost_field.c
   verifast_both -disable_overflow_check globals.c
   verifast_both -disable_overflow_check global_points_to_syntax.c
@@ -220,7 +220,7 @@ cd examples
   verifast_both -target 32bit -c -disable_overflow_check quicksort.c
   verifast_both -c tokenizer_test.c
   verifast_both -c truncating.c
-  verifast_both -disable_overflow_check stringBuffers.c tokenizer.c ghostlist.o rcl.c
+  verifast_both -disable_overflow_check stringBuffers.c tokenizer.c ghostlist.o -assume_no_subobject_provenance rcl.c
   verifast_both reallittest.c
   verifast_both -disable_overflow_check ref_points_to_syntax.c
   cd reduced_annotations
@@ -398,7 +398,7 @@ cd examples
   verifast_both -c void_ignore.c
   cd sizeof
     verifast_both -c -allow_should_fail struct.c
-    verifast_both -c packed.c
+    verifast_both -c -assume_no_subobject_provenance packed.c
   cd ..
 cd ..
 cd tutorial_solutions
@@ -444,6 +444,7 @@ cd tutorial_solutions
   verifast_both -target 32bit students.c
 cd ..
 cd tests
+  verifast -c -allow_should_fail provenance0.c
   verifast -c -allow_should_fail uninit.c
   verifast -c lit_ctor_pat.c
   verifast -c issue311.c


### PR DESCRIPTION
This breaking change is the first of a series of commits with the goal of making VeriFast sound with respect to the fact that C compilers perform optimisations that assume that pointers derived from different allocations do not alias.

From now on, a pointer is a pair consisting of a provenance (a value of an abstract type `provenance`) and an address (a uintptr_t). Pointer arithmetic does not affect the provenance. Selecting a struct field affects the provenance, except if the -assume_no_subobject_provenance flag is specified. Selecting a union member currently does not affect the provenance. Casting a pointer to uintptr_t simply returns its address; casting a uintptr_t to a pointer yields a pointer with the same provenance as the null pointer, which cannot be used to access any memory (but you can work around this (unsoundly) by assuming that the provenance of the allocation you are trying to access is also the null pointer provenance). (If you have a pointer to some allocation and you are casting a uintptr_t to a pointer to access the same allocation, you can instead compute the difference between the uintptr_t values and perform pointer arithmetic. You can also use pointer arithmetic for pointer tagging as well; see examples/mcas.)

See the discussion at #315.

TODO:
- Check pointer comparisons; these are only allowed if either they have the same provenance, or they point to the inside (not one-past) of live objects.
- If necessary, update the way object representation bytes are treated. (In CompCert and CH2O, object representation bytes are either poison, or plain integers, or pointer fragments.)
- (Eventually) support uintptr_t-to-pointer casts to construct pointers with non-null provenance.