### PR TITLE
[C++] Refactor frontend

### DIFF
--- a/src/cxx_frontend/ast_exporter/Annotation.h
+++ b/src/cxx_frontend/ast_exporter/Annotation.h
@@ -10,41 +10,41 @@ namespace vf {
  * Represents a VeriFast annotation in the source code.
  */
 class Annotation {
-  clang::SourceRange _range;
-  std::string _text;
-  bool _isContractClauseLike;
-  bool _isNewSeq;
-  bool _isTruncating;
+  clang::SourceRange m_range;
+  std::string m_text;
+  bool m_isContractClauseLike;
+  bool m_isNewSeq;
+  bool m_isTruncating;
 
 public:
   Annotation(clang::SourceRange &range, llvm::StringRef text,
              bool isContractClause, bool isTruncating, bool isNewSeq)
-      : _range(range), _text(text), _isContractClauseLike(isContractClause),
-        _isTruncating(isTruncating), _isNewSeq(isNewSeq) {}
+      : m_range(range), m_text(text), m_isContractClauseLike(isContractClause),
+        m_isTruncating(isTruncating), m_isNewSeq(isNewSeq) {}
 
 public:
-  clang::SourceRange getRange() const { return _range; }
+  clang::SourceRange getRange() const { return m_range; }
 
-  llvm::StringRef getText() const { return _text; }
+  llvm::StringRef getText() const { return m_text; }
 
   /**
    * @return whether or not this annotation can appear in a contract. I.e., the
    annotation starts with 'requires, 'ensures', 'terminates', ':', or
    'non_ghost_callers_only'. White space characters are not taken into account.
    */
-  bool isContractClauseLike() const { return _isContractClauseLike; }
+  bool isContractClauseLike() const { return m_isContractClauseLike; }
 
   /**
    * @return wether or not this annotation starts a new sequence of annotations.
    * I.e., the lines between this annotation and the previous one do not only
    * contain comments and/or white space.
    */
-  bool isNewSeq() const { return _isNewSeq; }
+  bool isNewSeq() const { return m_isNewSeq; }
 
   /**
    * @return wether or not this annotation is a truncating expression.
    */
-  bool isTruncating() const { return _isTruncating; }
+  bool isTruncating() const { return m_isTruncating; }
 };
 
 /**

--- a/src/cxx_frontend/ast_exporter/AnnotationStore.h
+++ b/src/cxx_frontend/ast_exporter/AnnotationStore.h
@@ -23,16 +23,16 @@ class AnnotationStore {
    * Holds a sequence of VeriFast annotations.
    */
   struct AnnCont {
-    unsigned int _pos;
-    ann_v _anns;
+    unsigned int m_pos;
+    ann_v m_anns;
 
-    explicit AnnCont() : _pos(0) {}
+    explicit AnnCont() : m_pos(0) {}
 
     /**
      * Moves the given annotation in this store.
      * @param ann the annotation that will be moved.
      */
-    void add(Annotation &&ann) { _anns.emplace_back(std::move(ann)); }
+    void add(Annotation &&ann) { m_anns.emplace_back(std::move(ann)); }
 
     /**
      * Retrieve every annotation from this container while the given predicate
@@ -47,11 +47,11 @@ class AnnotationStore {
      * the annotation container should be retrieved.
      */
     template <class Pred, class Cont> void getWhile(Cont &con, Pred pred) {
-      while (_pos < _anns.size()) {
-        auto ann = _anns.at(_pos);
+      while (m_pos < m_anns.size()) {
+        auto ann = m_anns.at(m_pos);
         if (pred(ann)) {
           con.push_back(ann);
-          ++_pos;
+          ++m_pos;
           continue;
         }
         return;
@@ -66,8 +66,8 @@ class AnnotationStore {
      * are added to.
      */
     template <class Cont> void getAll(Cont &con) {
-      while (_pos < _anns.size()) {
-        con.push_back(_anns.at(_pos));
+      while (m_pos < m_anns.size()) {
+        con.push_back(m_anns.at(m_pos));
       }
     }
   };
@@ -77,7 +77,7 @@ class AnnotationStore {
   /**
    * Retrieves the annotation container that corresponds with the given
    * location. The unique identifier of the file entry that contains the given
-   * location is used retrieve the correct annotation store.
+   * location is used to retrieve the correct annotation store.
    * @param loc source location that is used to get the correct annotation
    * container.
    * @param SM source manager.
@@ -179,7 +179,8 @@ public:
   queryTruncatingAnnotation(const clang::SourceLocation currentLoc,
                             const clang::SourceManager &SM) {
     auto pred = [&currentLoc](const Annotation &ann) {
-      // compare to 'begin' of range in case the end overlaps with the given currentLoc
+      // compare to 'begin' of range in case the end overlaps with the given
+      // currentLoc
       return ann.getRange().getBegin() < currentLoc && ann.isTruncating();
     };
     llvm::SmallVector<Annotation, 1> query;

--- a/src/cxx_frontend/ast_exporter/CommentProcessor.cpp
+++ b/src/cxx_frontend/ast_exporter/CommentProcessor.cpp
@@ -13,26 +13,26 @@ bool CommentProcessor::HandleComment(clang::Preprocessor &PP,
 
   // We have entered a different file
   // Set offset to start of file
-  if (fileID != prevFile) {
-    prevFile = fileID;
-    prevBufferOffset = 0;
+  if (fileID != m_prevFile) {
+    m_prevFile = fileID;
+    m_prevBufferOffset = 0;
   }
 
   unsigned currentOffset = locInfo.second;
-  auto fileBuffer = SM.getBufferData(prevFile);
-  onlyWhitespace = checkWhiteSpace(fileBuffer.data() + prevBufferOffset,
-                                   fileBuffer.data() + currentOffset);
+  auto fileBuffer = SM.getBufferData(m_prevFile);
+  m_onlyWhitespace = checkWhiteSpace(fileBuffer.data() + m_prevBufferOffset,
+                                     fileBuffer.data() + currentOffset);
 
-  auto annOpt =
-      annotationOf(comment, llvm::StringRef(begin, end - begin),
-                   /* annotation at the start of the file */ prevBufferOffset ==
-                           currentOffset ||
-                       !onlyWhitespace);
+  auto annOpt = annotationOf(
+      comment, llvm::StringRef(begin, end - begin),
+      /* annotation at the start of the file */ m_prevBufferOffset ==
+              currentOffset ||
+          !m_onlyWhitespace);
   if (annOpt) {
-    _store.add(std::move(*annOpt), SM);
+    m_store.add(std::move(*annOpt), SM);
   }
 
-  prevBufferOffset = currentOffset + end - begin;
+  m_prevBufferOffset = currentOffset + end - begin;
 
   return false;
 }

--- a/src/cxx_frontend/ast_exporter/CommentProcessor.h
+++ b/src/cxx_frontend/ast_exporter/CommentProcessor.h
@@ -10,15 +10,15 @@ namespace vf {
  * be added to the annotation store.
  */
 class CommentProcessor : public clang::CommentHandler {
-  clang::FileID prevFile;
-  unsigned prevBufferOffset;
-  bool onlyWhitespace = true;
+  clang::FileID m_prevFile;
+  unsigned m_prevBufferOffset;
+  bool m_onlyWhitespace = true;
 
-  AnnotationStore &_store;
+  AnnotationStore &m_store;
 
   /**
-   * @return whether or not all characters from 'start' up until 'end' only represent
-   * white space.
+   * @return whether or not all characters from 'start' up until 'end' only
+   * represent white space.
    */
   static bool checkWhiteSpace(const char *start, const char *end) {
     for (; start < end; ++start) {
@@ -37,7 +37,7 @@ public:
    */
   bool HandleComment(clang::Preprocessor &PP, clang::SourceRange comment);
 
-  explicit CommentProcessor(AnnotationStore &store) : _store(store) {}
+  explicit CommentProcessor(AnnotationStore &store) : m_store(store) {}
   CommentProcessor(AnnotationStore &&store) = delete;
 };
 } // namespace vf

--- a/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.h
+++ b/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.h
@@ -9,18 +9,18 @@ namespace vf {
 class ContextFreePPCallbacks : public clang::PPCallbacks {
 
   class PPDiags {
-    clang::Preprocessor &_PP;
+    clang::Preprocessor &m_PP;
 
     template <unsigned N>
     clang::DiagnosticBuilder createDiag(clang::SourceLocation loc,
                                         clang::DiagnosticsEngine::Level level,
                                         const char (&msg)[N]) const {
-      auto id = _PP.getDiagnostics().getCustomDiagID(level, msg);
-      return _PP.getDiagnostics().Report(loc, id);
+      auto id = m_PP.getDiagnostics().getCustomDiagID(level, msg);
+      return m_PP.getDiagnostics().Report(loc, id);
     }
 
   public:
-    explicit PPDiags(clang::Preprocessor &PP) : _PP(PP) {}
+    explicit PPDiags(clang::Preprocessor &PP) : m_PP(PP) {}
 
     void reportMacroDivergence(const clang::Token &macroNameTok,
                                const std::string &macroName,
@@ -36,12 +36,12 @@ class ContextFreePPCallbacks : public clang::PPCallbacks {
                                   const clang::MacroDefinition &MD);
   };
 
-  InclusionContext &_context;
-  clang::Preprocessor &_PP;
+  InclusionContext &m_context;
+  clang::Preprocessor &m_PP;
   const std::unordered_set<std::string> _whiteList;
   PPDiags _diags;
 
-  const clang::SourceManager &SM() const { return _PP.getSourceManager(); }
+  const clang::SourceManager &SM() const { return m_PP.getSourceManager(); }
 
   void checkDivergence(const clang::Token &macroNameToken,
                        const clang::MacroDefinition &MD);
@@ -54,10 +54,10 @@ public:
   explicit ContextFreePPCallbacks(InclusionContext &context,
                                   clang::Preprocessor &PP,
                                   const std::vector<std::string> &whiteList)
-      : _context(context), _PP(PP),
+      : m_context(context), m_PP(PP),
         _whiteList(whiteList.begin(), whiteList.end()), _diags(PP) {
     auto mainEntry = SM().getFileEntryForID(SM().getMainFileID());
-    _context.startInclusion(*mainEntry);
+    m_context.startInclusion(*mainEntry);
   }
 
   KJ_DISALLOW_COPY(ContextFreePPCallbacks);

--- a/src/cxx_frontend/ast_exporter/FixedWidthInt.h
+++ b/src/cxx_frontend/ast_exporter/FixedWidthInt.h
@@ -14,7 +14,8 @@ struct FixedWidthInt {
   FixedWidthInt() = delete;
 };
 
-inline llvm::Optional<FixedWidthInt> getFixedWidthFromString(llvm::StringRef name) {
+inline llvm::Optional<FixedWidthInt>
+getFixedWidthFromString(llvm::StringRef name) {
   if (name.equals("int8_t"))
     return llvm::Optional<FixedWidthInt>(std::move<FixedWidthInt>({8, false}));
   if (name.equals("int16_t"))

--- a/src/cxx_frontend/ast_exporter/FunctionMangler.h
+++ b/src/cxx_frontend/ast_exporter/FunctionMangler.h
@@ -6,32 +6,33 @@
 
 namespace vf {
 class FunctionMangler {
-  std::unique_ptr<clang::MangleContext> _mangler;
+  std::unique_ptr<clang::MangleContext> m_mangler;
 
-  std::unordered_map<int64_t, std::string> _mangledNames;
+  std::unordered_map<int64_t, std::string> m_mangledNames;
 
-  llvm::StringRef getMangledName(const clang::NamedDecl *nd, const clang::GlobalDecl &gd) {
+  llvm::StringRef getMangledName(const clang::NamedDecl *nd,
+                                 const clang::GlobalDecl &gd) {
     auto id = nd->getMostRecentDecl()->getID();
-    auto search = _mangledNames.find(id);
-    if (search != _mangledNames.end()) {
+    auto search = m_mangledNames.find(id);
+    if (search != m_mangledNames.end()) {
       return search->second;
     }
-    if (_mangler->shouldMangleDeclName(nd)) {
+    if (m_mangler->shouldMangleDeclName(nd)) {
       std::string name;
       {
         llvm::raw_string_ostream os(name);
-        _mangler->mangleName(gd, os);
+        m_mangler->mangleName(gd, os);
       }
-      _mangledNames.emplace(id, std::move(name));
+      m_mangledNames.emplace(id, std::move(name));
     } else {
-      _mangledNames.emplace(id, nd->getNameAsString());
+      m_mangledNames.emplace(id, nd->getNameAsString());
     }
-    return _mangledNames[id];
+    return m_mangledNames[id];
   }
 
 public:
   explicit FunctionMangler(clang::ASTContext &context)
-      : _mangler(clang::ItaniumMangleContext::create(
+      : m_mangler(clang::ItaniumMangleContext::create(
             context, context.getDiagnostics())){};
 
   llvm::StringRef mangleFunc(const clang::FunctionDecl *decl) {

--- a/src/cxx_frontend/ast_exporter/Inclusion.h
+++ b/src/cxx_frontend/ast_exporter/Inclusion.h
@@ -8,28 +8,29 @@ namespace vf {
 
 struct InclDirective {
   // #include "file" -> source range of "file"
-  clang::SourceRange _range;
+  clang::SourceRange m_range;
   // file name as written in the source code
-  clang::StringRef _fileName;
+  clang::StringRef m_fileName;
   // actual file the include directive refers to
-  unsigned _fileUID;
+  unsigned m_fileUID;
   // angled or quoted
-  bool _isAngled;
+  bool m_isAngled;
 
   explicit InclDirective(clang::SourceRange range, clang::StringRef fileName,
-                unsigned fileUID, bool isAngled)
-      : _range(range), _fileName(fileName), _fileUID(fileUID), _isAngled(isAngled) {}
+                         unsigned fileUID, bool isAngled)
+      : m_range(range), m_fileName(fileName), m_fileUID(fileUID),
+        m_isAngled(isAngled) {}
 };
 
 class Inclusion {
-  llvm::SmallVector<Inclusion *, 4> _inclusions;
-  llvm::SmallVector<InclDirective, 4> _inclDirectives;
+  llvm::SmallVector<Inclusion *, 4> m_inclusions;
+  llvm::SmallVector<InclDirective, 4> m_inclDirectives;
 
   bool containsInclusionFile(const clang::FileEntry &fileEntry) const {
     if (fileUID == fileEntry.getUID()) {
       return true;
     }
-    for (auto incl : _inclusions) {
+    for (auto incl : m_inclusions) {
       if (incl->containsInclusionFile(fileEntry)) {
         return true;
       }
@@ -44,7 +45,7 @@ public:
       : fileUID(fileEntry.getUID()), fileName(fileEntry.getName()){};
 
   const llvm::ArrayRef<InclDirective> getInclDirectives() const {
-    return _inclDirectives;
+    return m_inclDirectives;
   }
 
   bool ownsMacroDef(const clang::MacroDefinition &macroDef,
@@ -63,12 +64,12 @@ public:
   void addInclusion(Inclusion *inclusion) {
     // No cycles
     assert(this != inclusion);
-    _inclusions.emplace_back(inclusion);
+    m_inclusions.emplace_back(inclusion);
   }
 
   void addInclDirective(clang::SourceRange range, clang::StringRef fileName,
                         unsigned fileUID, bool isAngled) {
-    _inclDirectives.emplace_back(range, fileName, fileUID, isAngled);
+    m_inclDirectives.emplace_back(range, fileName, fileUID, isAngled);
   }
 };
 } // namespace vf

--- a/src/cxx_frontend/ast_exporter/InclusionContext.cpp
+++ b/src/cxx_frontend/ast_exporter/InclusionContext.cpp
@@ -10,26 +10,26 @@ void InclusionContext::serializeInclDirectivesCore(
     auto &lastInclDir = inclDirectives.back();
     auto firstDeclLocOpt = getFirstDeclLocOpt(fd);
     if (firstDeclLocOpt &&
-        lastInclDir._range.getEnd() > firstDeclLocOpt.getValue()) {
+        lastInclDir.m_range.getEnd() > firstDeclLocOpt.getValue()) {
       auto diagID = SM.getDiagnostics().getCustomDiagID(
           clang::DiagnosticsEngine::Level::Error,
           "An include directive can only appear at the start of a file.");
-      SM.getDiagnostics().Report(lastInclDir._range.getBegin(), diagID);
+      SM.getDiagnostics().Report(lastInclDir.m_range.getBegin(), diagID);
     }
   }
 
   for (size_t i(0); i < inclDirectives.size(); ++i) {
     auto inclDirBuilder = builder[i];
     auto inclDirective = inclDirectives[i];
-    auto currentFd = inclDirective._fileUID;
+    auto currentFd = inclDirective.m_fileUID;
 
     inclDirBuilder.setFd(currentFd);
-    inclDirBuilder.setFileName(inclDirective._fileName.str());
-    inclDirBuilder.setIsAngled(inclDirective._isAngled);
+    inclDirBuilder.setFileName(inclDirective.m_fileName.str());
+    inclDirBuilder.setIsAngled(inclDirective.m_isAngled);
     auto locBuilder = inclDirBuilder.initLoc();
-    serializeSrcRange(locBuilder, inclDirective._range, SM);
+    serializeSrcRange(locBuilder, inclDirective.m_range, SM);
 
-    auto &nestedInclDirectives = _includesMap.at(currentFd).getInclDirectives();
+    auto &nestedInclDirectives = m_includesMap.at(currentFd).getInclDirectives();
     auto nestedInclDirectivesBuilder =
         inclDirBuilder.initIncludes(nestedInclDirectives.size());
     serializeInclDirectivesCore(nestedInclDirectivesBuilder, SM,
@@ -42,7 +42,7 @@ void InclusionContext::serializeTUInclDirectives(
     stubs::TU::Builder &builder, const clang::SourceManager &SM,
     get_first_decl_loc_fn &getFirstDeclLocOpt) const {
   auto mainUID = SM.getFileEntryForID(SM.getMainFileID())->getUID();
-  auto &inclDirectives = _includesMap.at(mainUID).getInclDirectives();
+  auto &inclDirectives = m_includesMap.at(mainUID).getInclDirectives();
   auto inclDirectivesBuilder = builder.initIncludes(inclDirectives.size());
   serializeInclDirectivesCore(inclDirectivesBuilder, SM, inclDirectives,
                               getFirstDeclLocOpt, mainUID);

--- a/src/cxx_frontend/ast_exporter/StmtSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/StmtSerializer.cpp
@@ -5,28 +5,23 @@ namespace vf {
 
 using StmtNodeOrphan = NodeOrphan<stubs::Stmt>;
 bool StmtSerializer::VisitCompoundStmt(const clang::CompoundStmt *stmt) {
-  auto orphanage = capnp::Orphanage::getForMessageContaining(_builder);
-
+  auto orphanage = capnp::Orphanage::getForMessageContaining(m_builder);
   llvm::SmallVector<StmtNodeOrphan, 32> stmtNodeOrphans;
-
-  auto &store = _serializer.getAnnStore();
-
+  auto &store = m_serializer.getAnnStore();
   auto &SM = getSourceManager();
+  std::list<Annotation> anns;
 
-  clang::SourceLocation currentLoc;
   for (auto s : stmt->body()) {
-    std::list<Annotation> anns;
     store.getUntilLoc(anns, s->getBeginLoc(), SM);
-    _serializer.serializeAnnsToOrphans(anns, orphanage, stmtNodeOrphans);
-    _serializer.serializeToOrphan(s, orphanage, stmtNodeOrphans);
-    currentLoc = s->getEndLoc();
+    m_serializer.serializeAnnsToOrphans(anns, orphanage, stmtNodeOrphans);
+    m_serializer.serializeToOrphan(s, orphanage, stmtNodeOrphans);
+    anns.clear();
   }
 
-  std::list<Annotation> anns;
   store.getUntilLoc(anns, stmt->getRBracLoc(), SM);
-  _serializer.serializeAnnsToOrphans(anns, orphanage, stmtNodeOrphans);
+  m_serializer.serializeAnnsToOrphans(anns, orphanage, stmtNodeOrphans);
 
-  auto comp = _builder.initCompound();
+  auto comp = m_builder.initCompound();
   auto children = comp.initStmts(stmtNodeOrphans.size());
   AstSerializer::adoptOrphansToListBuilder(stmtNodeOrphans, children);
 
@@ -38,53 +33,53 @@ bool StmtSerializer::VisitCompoundStmt(const clang::CompoundStmt *stmt) {
 }
 
 bool StmtSerializer::VisitReturnStmt(const clang::ReturnStmt *stmt) {
-  auto ret = _builder.initReturn();
+  auto ret = m_builder.initReturn();
   auto retVal = stmt->getRetValue();
 
   if (retVal) {
     auto retExpr = ret.initExpr();
-    _serializer.serializeExpr(retExpr, retVal);
+    m_serializer.serializeExpr(retExpr, retVal);
   }
   return true;
 }
 
 bool StmtSerializer::VisitDeclStmt(const clang::DeclStmt *stmt) {
   auto nbChildren = std::distance(stmt->decl_begin(), stmt->decl_end());
-  auto children = _builder.initDecl(nbChildren);
+  auto children = m_builder.initDecl(nbChildren);
 
   size_t i(0);
   for (auto it = stmt->decl_begin(); it != stmt->decl_end(); ++it, ++i) {
     auto child = children[i];
-    _serializer.serializeDecl(child, *it);
+    m_serializer.serializeDecl(child, *it);
   }
   return true;
 }
 
 bool StmtSerializer::VisitExpr(const clang::Expr *stmt) {
-  auto expr = _builder.initExpr();
+  auto expr = m_builder.initExpr();
 
-  _serializer.serializeExpr(expr, stmt);
+  m_serializer.serializeExpr(expr, stmt);
   return true;
 }
 
 bool StmtSerializer::VisitIfStmt(const clang::IfStmt *stmt) {
-  auto ifStmt = _builder.initIf();
+  auto ifStmt = m_builder.initIf();
 
   auto cond = ifStmt.initCond();
-  _serializer.serializeExpr(cond, stmt->getCond());
+  m_serializer.serializeExpr(cond, stmt->getCond());
 
   auto then = ifStmt.initThen();
-  _serializer.serializeStmt(then, stmt->getThen());
+  m_serializer.serializeStmt(then, stmt->getThen());
 
   if (stmt->hasElseStorage()) {
     auto el = ifStmt.initElse();
-    _serializer.serializeStmt(el, stmt->getElse());
+    m_serializer.serializeStmt(el, stmt->getElse());
   }
   return true;
 }
 
 bool StmtSerializer::VisitNullStmt(const clang::NullStmt *stmt) {
-  _builder.setNull();
+  m_builder.setNull();
   return true;
 }
 
@@ -93,16 +88,16 @@ bool StmtSerializer::visitWhi(stubs::Stmt::While::Builder &builder,
                               const While *stmt) {
 
   auto cond = builder.initCond();
-  _serializer.serializeExpr(cond, stmt->getCond());
+  m_serializer.serializeExpr(cond, stmt->getCond());
 
   std::list<Annotation> anns;
-  _serializer.getAnnStore().getUntilLoc(anns, stmt->getBody()->getBeginLoc(),
-                                    getSourceManager());
+  m_serializer.getAnnStore().getUntilLoc(anns, stmt->getBody()->getBeginLoc(),
+                                         getSourceManager());
   auto specBuilder = builder.initSpec(anns.size());
   size_t i(0);
   for (auto &ann : anns) {
     auto annBuilder = specBuilder[i++];
-    _serializer.serializeAnnotationClause(annBuilder, ann);
+    m_serializer.serializeAnnotationClause(annBuilder, ann);
   }
 
   auto whileLoc = builder.initWhileLoc();
@@ -110,35 +105,35 @@ bool StmtSerializer::visitWhi(stubs::Stmt::While::Builder &builder,
   serializeSrcRange(whileLoc, {whileBegin, whileBegin}, getSourceManager());
 
   auto body = builder.initBody();
-  _serializer.serializeStmt(body, stmt->getBody());
+  m_serializer.serializeStmt(body, stmt->getBody());
   return true;
 }
 
 bool StmtSerializer::VisitWhileStmt(const clang::WhileStmt *stmt) {
-  auto whi = _builder.initWhile();
+  auto whi = m_builder.initWhile();
   return visitWhi(whi, stmt);
 }
 
 bool StmtSerializer::VisitDoStmt(const clang::DoStmt *stmt) {
-  auto doWhi = _builder.initDoWhile();
+  auto doWhi = m_builder.initDoWhile();
   return visitWhi(doWhi, stmt);
 }
 
 bool StmtSerializer::VisitBreakStmt(const clang::BreakStmt *stmt) {
-  _builder.setBreak();
+  m_builder.setBreak();
   return true;
 }
 
 bool StmtSerializer::VisitContinueStmt(const clang::ContinueStmt *stmt) {
-  _builder.setContinue();
+  m_builder.setContinue();
   return true;
 }
 
 bool StmtSerializer::VisitSwitchStmt(const clang::SwitchStmt *stmt) {
-  auto sw = _builder.initSwitch();
+  auto sw = m_builder.initSwitch();
 
   auto cond = sw.initCond();
-  _serializer.serializeExpr(cond, stmt->getCond());
+  m_serializer.serializeExpr(cond, stmt->getCond());
 
   llvm::SmallVector<const clang::Stmt *, 4> casesPtrs;
   for (auto swCase = stmt->getSwitchCaseList(); swCase;
@@ -151,16 +146,16 @@ bool StmtSerializer::VisitSwitchStmt(const clang::SwitchStmt *stmt) {
   // clang traverses them in reverse order, so we reverse it again
   for (auto swCase : casesPtrs) {
     auto cas = cases[--i];
-    _serializer.serializeStmt(cas, swCase);
+    m_serializer.serializeStmt(cas, swCase);
   }
   return true;
 }
 
 bool StmtSerializer::VisitCaseStmt(const clang::CaseStmt *stmt) {
-  auto swCase = _builder.initCase();
+  auto swCase = m_builder.initCase();
 
   auto lhs = swCase.initLhs();
-  _serializer.serializeExpr(lhs, stmt->getLHS());
+  m_serializer.serializeExpr(lhs, stmt->getLHS());
 
   auto rhs = stmt->getRHS();
   // check if it has a rhs. Otherwise 'getSubsStmt' would point to the next case
@@ -168,17 +163,17 @@ bool StmtSerializer::VisitCaseStmt(const clang::CaseStmt *stmt) {
   // in the current case statement.
   if (rhs) {
     auto subStmt = swCase.initStmt();
-    _serializer.serializeStmt(subStmt, stmt->getSubStmt());
+    m_serializer.serializeStmt(subStmt, stmt->getSubStmt());
   }
   return true;
 }
 
 bool StmtSerializer::VisitDefaultStmt(const clang::DefaultStmt *stmt) {
-  auto defStmt = _builder.initDefCase();
+  auto defStmt = m_builder.initDefCase();
   auto subStmt = stmt->getSubStmt();
   if (subStmt) {
     auto sub = defStmt.initStmt();
-    _serializer.serializeStmt(sub, subStmt);
+    m_serializer.serializeStmt(sub, subStmt);
   }
   return true;
 }

--- a/src/cxx_frontend/ast_exporter/TypeSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/TypeSerializer.cpp
@@ -9,12 +9,12 @@ namespace vf {
 bool TypeSerializer::VisitBuiltinType(const clang::BuiltinType *type) {
 #define CASE_TYPE(CLANG_TYPE, STUBS_TYPE)                                      \
   case clang::BuiltinType::Kind::CLANG_TYPE:                                   \
-    _builder.setBuiltin(stubs::Type::BuiltinKind::STUBS_TYPE);                 \
+    m_builder.setBuiltin(stubs::Type::BuiltinKind::STUBS_TYPE);                \
     return true;
 
 #define CASE_TYPE_FW(CLANG_TYPE, STUBS_TYPE, BITS)                             \
   case clang::BuiltinType::Kind::CLANG_TYPE: {                                 \
-    auto fw = _builder.initFixedWidth();                                        \
+    auto fw = m_builder.initFixedWidth();                                      \
     fw.setKind(stubs::Type::FixedWidth::FixedWidthKind::STUBS_TYPE);           \
     fw.setBits(BITS);                                                          \
     return true;                                                               \
@@ -45,13 +45,13 @@ bool TypeSerializer::VisitBuiltinType(const clang::BuiltinType *type) {
 }
 
 bool TypeSerializer::VisitPointerType(const clang::PointerType *type) {
-  auto pointer = _builder.initPointer().initDesc();
-  _serializer.serializeQualType(pointer, type->getPointeeType());
+  auto pointer = m_builder.initPointer().initDesc();
+  m_serializer.serializeQualType(pointer, type->getPointeeType());
   return true;
 }
 
 bool TypeSerializer::VisitRecordType(const clang::RecordType *type) {
-  auto rec = _builder.initRecord();
+  auto rec = m_builder.initRecord();
   rec.setName(type->getDecl()->getQualifiedNameAsString());
   if (type->isClassType()) {
     rec.setKind(stubs::RecordKind::CLASS);
@@ -66,60 +66,60 @@ bool TypeSerializer::VisitRecordType(const clang::RecordType *type) {
 }
 
 bool TypeSerializer::VisitEnumType(const clang::EnumType *type) {
-  _builder.setEnumType(type->getDecl()->getQualifiedNameAsString());
+  m_builder.setEnumType(type->getDecl()->getQualifiedNameAsString());
   return true;
 }
 
-bool TypeSerializer::VisitElaboratedType(
-    const clang::ElaboratedType *type) {
-  auto elaborated = _builder.initElaborated().initDesc();
-  _serializer.serializeQualType(elaborated, type->getNamedType());
+bool TypeSerializer::VisitElaboratedType(const clang::ElaboratedType *type) {
+  auto elaborated = m_builder.initElaborated().initDesc();
+  m_serializer.serializeQualType(elaborated, type->getNamedType());
   return true;
 }
 
 bool TypeSerializer::VisitTypedefType(const clang::TypedefType *type) {
-  _builder.setTypedef(type->getDecl()->getQualifiedNameAsString());
+  m_builder.setTypedef(type->getDecl()->getQualifiedNameAsString());
   return true;
 }
 
 bool TypeSerializer::VisitLValueReferenceType(
     const clang::LValueReferenceType *type) {
-  auto ref = _builder.initLValueRef().initDesc();
-  _serializer.serializeQualType(ref, type->getPointeeType());
+  auto ref = m_builder.initLValueRef().initDesc();
+  m_serializer.serializeQualType(ref, type->getPointeeType());
   return true;
 }
 
 bool TypeSerializer::VisitRValueReferenceType(
     const clang::RValueReferenceType *type) {
-  auto ref = _builder.initRValueRef().initDesc();
-  _serializer.serializeQualType(ref, type->getPointeeType());
+  auto ref = m_builder.initRValueRef().initDesc();
+  m_serializer.serializeQualType(ref, type->getPointeeType());
   return true;
 }
 
-bool TypeLocSerializer::VisitPointerTypeLoc(const clang::PointerTypeLoc typeLoc) {
-  auto pointer = _builder.initPointer();
-  _serializer.serializeTypeLoc(pointer, typeLoc.getPointeeLoc());
+bool TypeLocSerializer::VisitPointerTypeLoc(
+    const clang::PointerTypeLoc typeLoc) {
+  auto pointer = m_builder.initPointer();
+  m_serializer.serializeTypeLoc(pointer, typeLoc.getPointeeLoc());
   return true;
 }
 
 bool TypeLocSerializer::VisitElaboratedTypeLoc(
     const clang::ElaboratedTypeLoc typeLoc) {
-  auto elaborated = _builder.initElaborated();
-  _serializer.serializeTypeLoc(elaborated, typeLoc.getNamedTypeLoc());
+  auto elaborated = m_builder.initElaborated();
+  m_serializer.serializeTypeLoc(elaborated, typeLoc.getNamedTypeLoc());
   return true;
 }
 
 bool TypeLocSerializer::VisitLValueReferenceTypeLoc(
     const clang::LValueReferenceTypeLoc typeLoc) {
-  auto ref = _builder.initLValueRef();
-  _serializer.serializeTypeLoc(ref, typeLoc.getPointeeLoc());
+  auto ref = m_builder.initLValueRef();
+  m_serializer.serializeTypeLoc(ref, typeLoc.getPointeeLoc());
   return true;
 }
 
 bool TypeLocSerializer::VisitRValueReferenceTypeLoc(
     const clang::RValueReferenceTypeLoc typeLoc) {
-  auto ref = _builder.initRValueRef();
-  _serializer.serializeTypeLoc(ref, typeLoc.getPointeeLoc());
+  auto ref = m_builder.initRValueRef();
+  m_serializer.serializeTypeLoc(ref, typeLoc.getPointeeLoc());
   return true;
 }
 

--- a/src/cxx_frontend/ast_exporter/VerifastASTExporter.cpp
+++ b/src/cxx_frontend/ast_exporter/VerifastASTExporter.cpp
@@ -19,9 +19,15 @@ static llvm::cl::OptionCategory category("Verifast AST exporter options");
 
 static llvm::cl::list<std::string> allowExpansions(
     "allow_macro_expansion",
-    llvm::cl::desc("is a list of macros that are always allowed to expand."),
+    llvm::cl::desc(
+        "Allow a set of macros to expand regardless of its context."),
     llvm::cl::value_desc("macros"), llvm::cl::ZeroOrMore,
     llvm::cl::CommaSeparated, llvm::cl::cat(category));
+
+static llvm::cl::opt<bool> exportImplicitDecls(
+    "export_implicit_decls",
+    llvm::cl::desc("Enable exporting implicit declarations."),
+    llvm::cl::cat(category));
 
 static llvm::cl::extrahelp
     commonHelp(clang::tooling::CommonOptionsParser::HelpMessage);
@@ -31,27 +37,27 @@ namespace vf {
 using Builder = stubs::TU::Builder;
 
 class VerifastASTConsumer : public clang::ASTConsumer {
-  Builder &_builder;
-  AnnotationStore &_store;
-  const InclusionContext &_context;
+  Builder &m_builder;
+  AnnotationStore &m_store;
+  const InclusionContext &m_context;
 
 public:
   void HandleTranslationUnit(clang::ASTContext &context) override {
-    AstSerializer serializer(context, _store, _context);
-    serializer.serializeTU(_builder, context.getTranslationUnitDecl());
+    AstSerializer serializer(context, m_store, m_context, exportImplicitDecls);
+    serializer.serializeTU(m_builder, context.getTranslationUnitDecl());
   }
 
   explicit VerifastASTConsumer(Builder &builder, AnnotationStore &store,
                                const InclusionContext &context)
-      : _builder(builder), _store(store), _context(context) {}
+      : m_builder(builder), m_store(store), m_context(context) {}
   VerifastASTConsumer(Builder &&builder, AnnotationStore &&store) = delete;
 };
 
 class VerifastFrontendAction : public clang::ASTFrontendAction {
-  Builder _builder;
-  AnnotationStore _store;
-  CommentProcessor _commentProcessor;
-  InclusionContext _context;
+  Builder m_builder;
+  AnnotationStore m_store;
+  CommentProcessor m_commentProcessor;
+  InclusionContext m_context;
 
 public:
   std::unique_ptr<clang::ASTConsumer>
@@ -59,29 +65,29 @@ public:
                     llvm::StringRef inFile) override {
     auto &PP = compiler.getPreprocessor();
     PP.addPPCallbacks(std::make_unique<ContextFreePPCallbacks>(
-        _context, PP, allowExpansions));
-    PP.addCommentHandler(&_commentProcessor);
-    return std::make_unique<VerifastASTConsumer>(_builder, _store, _context);
+        m_context, PP, allowExpansions));
+    PP.addCommentHandler(&m_commentProcessor);
+    return std::make_unique<VerifastASTConsumer>(m_builder, m_store, m_context);
   }
 
   explicit VerifastFrontendAction(Builder &&builder)
-      : _builder(builder), _commentProcessor(_store) {}
+      : m_builder(builder), m_commentProcessor(m_store) {}
 };
 
 using msg_builders = std::list<capnp::MallocMessageBuilder>;
 
 class VerifastActionFactory : public clang::tooling::FrontendActionFactory {
-  msg_builders &_builders;
+  msg_builders &m_builders;
 
 public:
   std::unique_ptr<clang::FrontendAction> create() override {
-    _builders.emplace_back();
+    m_builders.emplace_back();
     return std::make_unique<VerifastFrontendAction>(
-        _builders.back().initRoot<stubs::TU>());
+        m_builders.back().initRoot<stubs::TU>());
   }
 
   explicit VerifastActionFactory(msg_builders &builders)
-      : _builders(builders) {}
+      : m_builders(builders) {}
   VerifastActionFactory(Builder &&builder) = delete;
 };
 

--- a/src/cxx_frontend/cxx_fe_sig.ml
+++ b/src/cxx_frontend/cxx_fe_sig.ml
@@ -9,6 +9,11 @@ module type Cxx_Ast_Translator = sig
   *)
 end
 
+type struct_member_decl =
+  | CxxFieldMem of VF.field
+  | CxxInstPredMem of VF.instance_pred_decl
+  | CxxDeclMem of VF.decl
+
 module type CXX_TRANSLATOR_ARGS = sig
   val data_model_opt: VF.data_model option
   val enforce_annotations: bool

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -188,9 +188,8 @@ struct Decl {
       virtual @1 :Bool;
     }
     struct Body {
-      fields @0 :List(Node(Field));
-      decls @1 :List(DeclNode);
-      bases @2 :List(Node(BaseSpec));
+      decls @0 :List(DeclNode);
+      bases @1 :List(Node(BaseSpec));
     }
     name @0 :Text;
     kind @1 :RecordKind;


### PR DESCRIPTION
Some refactoring of the C++ frontend in preparation for instance predicates. The C++ code refactoring mainly changes member variables from `_member` to `m_member`.