### PR TITLE
Impose tight limits on pointer arithmetic

### DIFF
--- a/bin/arrays.c
+++ b/bin/arrays.c
@@ -3,8 +3,8 @@
 /*@
 
 lemma void ints_limits(int *pxs)
-    requires [?f]ints(pxs, ?N, ?xs) &*& pxs <= (int *)UINTPTR_MAX;
-    ensures [f]ints(pxs, N, xs) &*& pxs + N <= (int *)UINTPTR_MAX &*& forall(xs, int_within_limits) == true;
+    requires [?f]ints(pxs, ?N, ?xs) &*& (uintptr_t)pxs <= ptr_provenance_max_addr(((pointer)pxs).provenance);
+    ensures [f]ints(pxs, N, xs) &*& (uintptr_t)(pxs + N) <= ptr_provenance_max_addr(((pointer)pxs).provenance) &*& forall(xs, int_within_limits) == true;
 {
     open [f]ints(pxs, N, xs);
     if (N > 0) {

--- a/bin/arrays.gh
+++ b/bin/arrays.gh
@@ -6,8 +6,8 @@
 fixpoint bool int_within_limits(int x) { return INT_MIN <= x && x <= INT_MAX; }
 
 lemma void ints_limits(int *pxs);
-    requires [?f]ints(pxs, ?N, ?xs) &*& pxs <= (int *)UINTPTR_MAX;
-    ensures [f]ints(pxs, N, xs) &*& pxs + N <= (int *)UINTPTR_MAX &*& forall(xs, int_within_limits) == true;
+    requires [?f]ints(pxs, ?N, ?xs) &*& (uintptr_t)pxs <= ptr_provenance_max_addr(((pointer)pxs).provenance);
+    ensures [f]ints(pxs, N, xs) &*& (uintptr_t)(pxs + N) <= ptr_provenance_max_addr(((pointer)pxs).provenance) &*& forall(xs, int_within_limits) == true;
 
 lemma void ints_split(int *array, int offset);
     requires [?f]ints(array, ?N, ?as) &*& 0 <= offset &*& offset <= N;

--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -15,6 +15,13 @@
 .provides ./string.h#strlen
 .provides ./string.h#strdup
 .provides ./prelude.h#field_ptr_provenance_injective
+.provides ./prelude.h#ptr_provenance_min_addr_limits
+.provides ./prelude.h#ptr_provenance_max_addr_limits
+.provides ./prelude.h#null_pointer_provenance_min_addr
+.provides ./prelude.h#null_pointer_provenance_max_addr
+.provides ./prelude.h#field_ptr_provenance_min_addr
+.provides ./prelude.h#field_ptr_provenance_max_addr
+.provides ./prelude.h#ptr_provenance_min_addr_zero
 .provides ./prelude.h#integer__distinct
 .provides ./prelude.h#integer__unique
 .provides ./prelude.h#integer__limits

--- a/bin/malloc.h
+++ b/bin/malloc.h
@@ -12,7 +12,7 @@ lemma_auto void malloc_block_null();
 
 lemma void malloc_block_limits(void *array);
     requires [?f]malloc_block(array, ?size);
-    ensures [f]malloc_block(array, size) &*& (void *)0 <= array &*& 0 <= size &*& array + size <= (void *)UINTPTR_MAX;
+    ensures [f]malloc_block(array, size) &*& 0 <= size &*& pointer_within_limits(array) && pointer_within_limits(array + size);
 
 @*/
 
@@ -24,7 +24,7 @@ void *malloc(size_t size);
             emp
         :
             chars_(result, size, _) &*& malloc_block(result, size) &*&
-            (char *)0 < result && result + size <= (char *)UINTPTR_MAX; // one-past-end does not overflow
+            object_pointer_within_limits(result, size) == true; // one-past-end does not overflow
     @*/
     //@ terminates;
 

--- a/examples/crypto_ccs/crypto_ccs/crypto/crypto_chars.gh
+++ b/examples/crypto_ccs/crypto_ccs/crypto/crypto_chars.gh
@@ -48,9 +48,9 @@ lemma_auto void crypto_chars_inv();
 
 lemma_auto void crypto_chars_limits(char *array);
   requires [?f]crypto_chars(?kind, array, ?n, ?ccs) &*&
-           true == ((char *)0 <= array) &*& array <= (char *)UINTPTR_MAX;
+           pointer_within_limits(array) == true;
   ensures  [f]crypto_chars(kind, array, n, ccs) &*&
-           true == ((char *)0 <= array) &*& array + n <= (char *)UINTPTR_MAX;
+           pointer_within_limits(array + n) == true;
 
 lemma_auto void crypto_chars_distinct(char *array1, char *array2);
   requires crypto_chars(?kind1, array1, ?count1, ?ccs1) &*&

--- a/examples/crypto_ccs/crypto_ccs/crypto/cryptogram.c
+++ b/examples/crypto_ccs/crypto_ccs/crypto/cryptogram.c
@@ -21,9 +21,9 @@ lemma_auto void cryptogram_inv()
 
 lemma void cryptogram_limits(char *array)
   requires [?f]cryptogram(array, ?count, ?cs, ?cg) &*&
-           true == ((char *)0 <= array) &*& array <= (char *)UINTPTR_MAX;
+           pointer_within_limits(array) == true;
   ensures  [f]cryptogram(array, count, cs, cg) &*&
-           true == ((char *)0 <= array) &*& array + count <= (char *)UINTPTR_MAX;
+           pointer_within_limits(array + count) == true;
 {
   open [f]cryptogram(array, count, cs, cg);
   crypto_chars_limits(array);

--- a/examples/crypto_ccs/crypto_ccs/crypto/cryptogram.gh
+++ b/examples/crypto_ccs/crypto_ccs/crypto/cryptogram.gh
@@ -101,8 +101,8 @@ lemma_auto void cryptogram_inv();
 
 lemma void cryptogram_limits(char *array);
   requires [?f]cryptogram(array, ?count, ?cs, ?cg) &*&
-           true == ((char *)0 <= array) &*& array <= (char *)UINTPTR_MAX;
+           pointer_within_limits(array) == true;
   ensures  [f]cryptogram(array, count, cs, cg) &*&
-           true == ((char *)0 <= array) &*& array + count <= (char *)UINTPTR_MAX;
+           pointer_within_limits(array + count) == true;
 
 #endif

--- a/examples/crypto_ccs/symbolic_model/src/general.c
+++ b/examples/crypto_ccs/symbolic_model/src/general.c
@@ -19,8 +19,7 @@ void *malloc_wrapper(int size)
   //@ requires 0 <= size;
   /*@ ensures  result != 0 &*&
                malloc_block(result, size) &*& chars_(result, size, ?cs) &*&
-               true == ((char *)0 < result &&
-               result + size <= (char *)UINTPTR_MAX);
+               object_pointer_within_limits(result, size) == true;
   @*/
 {
   if (size > MAX_PACKAGE_SIZE)
@@ -38,7 +37,7 @@ void write_buffer(char **target, const char *source, int length)
                [?f]crypto_chars(?kind, source, length, ?ccs0) &*&
                length > 0 &*& kind == normal ||
                  (kind == secret && length >= MINIMAL_STRING_SIZE)
-               &*& length <= INT_MAX &*& t + length <= (void*) UINTPTR_MAX; @*/
+               &*& length <= INT_MAX &*& pointer_within_limits(t + length) == true; @*/
   /*@ ensures  pointer(target, t + length) &*&
                crypto_chars(kind, t, length, ccs0) &*&
                [f]crypto_chars(kind, source, length, ccs0); @*/

--- a/examples/crypto_ccs/symbolic_model/src/general.h
+++ b/examples/crypto_ccs/symbolic_model/src/general.h
@@ -44,15 +44,14 @@ void *malloc_wrapper(int size);
   //@ requires 0 <= size;
   /*@ ensures  result != 0 &*&
                malloc_block(result, size) &*& chars_(result, size, ?cs) &*&
-               true == ((char *)0 < result &&
-               result + size <= (char *)UINTPTR_MAX); @*/
+               object_pointer_within_limits(result, size) == true; @*/
 
 void write_buffer(char **target, const char *source, int length);
   /*@ requires pointer(target, ?t) &*& chars_(t, length, ?cs) &*&
                [?f]crypto_chars(?kind, source, length, ?ccs0) &*&
                length > 0 &*& kind == normal ||
                  (kind == secret && length >= MINIMAL_STRING_SIZE)
-               &*& length <= INT_MAX &*& t + length <= (void*) UINTPTR_MAX; @*/
+               &*& length <= INT_MAX &*& pointer_within_limits(t + length) == true; @*/
   /*@ ensures  pointer(target, t + length) &*&
                crypto_chars(kind, t, length, ccs0) &*&
                [f]crypto_chars(kind, source, length, ccs0); @*/

--- a/examples/crypto_ccs/symbolic_model/src/item.h
+++ b/examples/crypto_ccs/symbolic_model/src/item.h
@@ -19,7 +19,7 @@ predicate item(struct item *item, item i, predicate(item) pub) =
     size > MINIMAL_STRING_SIZE &*& size <= INT_MAX &*&
   item->content |-> ?content &*&
     crypto_chars(secret, content, size, ?ccs) &*&
-    content >= (char *)0 &*& content + size <= (char *)UINTPTR_MAX &*&
+    pointer_within_limits(content) && pointer_within_limits(content + size) &*&
     size == length(ccs) &*& malloc_block_chars(content, size) &*&
   malloc_block_item(item) &*&
 

--- a/examples/crypto_ccs/symbolic_model/src/item_tags.c
+++ b/examples/crypto_ccs/symbolic_model/src/item_tags.c
@@ -45,7 +45,7 @@ void write_tag(char* buffer, char tag)
   while (offset < TAG_LENGTH)
     /*@ requires offset <= TAG_LENGTH &*&
                  true == ((char *)0 <= buffer + offset) &*&
-                 buffer + offset <= (char *)UINTPTR_MAX &*&
+                 pointer_within_limits(buffer + offset) == true &*&
                  chars_(buffer + offset, TAG_LENGTH - offset, ?cs0) &*&
                  offset != TAG_LENGTH || cs0 == nil; @*/
     /*@ ensures  chars(buffer + old_offset, TAG_LENGTH - old_offset, ?cs1) &*&
@@ -72,7 +72,7 @@ void check_tag(char* buffer, char tag)
   while (offset < TAG_LENGTH)
     /*@ requires offset <= TAG_LENGTH &*&
                  true == ((char *)0 <= buffer + offset) &*&
-                 buffer + offset <= (char *)UINTPTR_MAX &*&
+                 pointer_within_limits(buffer + offset) == true &*&
                  [f]chars(buffer + offset, TAG_LENGTH - offset, ?cs0) &*&
                  offset >= 0 &*& offset <= TAG_LENGTH &*&
                  offset != TAG_LENGTH || cs0 == nil; @*/

--- a/examples/custom_bindir/bin/stdlib/prelude.h
+++ b/examples/custom_bindir/bin/stdlib/prelude.h
@@ -39,6 +39,21 @@ fixpoint pointer union_variant_ptr(pointer p, int variantId) {
 fixpoint pointer_provenance null_pointer_provenance();
 fixpoint pointer null_pointer() { return pointer_ctor(null_pointer_provenance, 0); }
 
+fixpoint uintptr_t ptr_provenance_min_addr(pointer_provenance pr);
+fixpoint uintptr_t ptr_provenance_max_addr(pointer_provenance pr);
+
+fixpoint bool ptr_within_limits(pointer p) {
+    return ptr_provenance_min_addr(p.provenance) <= p.address && p.address <= ptr_provenance_max_addr(p.provenance);
+}
+
+fixpoint bool pointer_within_limits(void *p) {
+    return ptr_within_limits((pointer)p);
+}
+
+fixpoint bool object_pointer_within_limits(void *p, int size) {
+    return pointer_within_limits(p) && pointer_within_limits(p + size) && 0 < (uintptr_t)p;
+}
+
 predicate custom_chars(char *array, int size, list<char> cs);
 
 lemma_auto void custom_chars_inv();

--- a/examples/mcas/bitops_ex.vfmanifest
+++ b/examples/mcas/bitops_ex.vfmanifest
@@ -74,6 +74,8 @@
 .requires CRT/prelude.h#div_rem
 .requires CRT/prelude.h#divrem_elim
 .requires CRT/prelude.h#field_ptr_provenance_injective
+.requires CRT/prelude.h#field_ptr_provenance_max_addr
+.requires CRT/prelude.h#field_ptr_provenance_min_addr
 .requires CRT/prelude.h#int__to_chars_
 .requires CRT/prelude.h#int_of_chars_of_int
 .requires CRT/prelude.h#int_of_chars_size
@@ -95,6 +97,8 @@
 .requires CRT/prelude.h#llongs_inv
 .requires CRT/prelude.h#map_char_of_uchar_uchar_of_char
 .requires CRT/prelude.h#map_uchar_of_char_char_of_uchar
+.requires CRT/prelude.h#null_pointer_provenance_max_addr
+.requires CRT/prelude.h#null_pointer_provenance_min_addr
 .requires CRT/prelude.h#pointer_nonzero
 .requires CRT/prelude.h#pointer_of_chars_of_pointer
 .requires CRT/prelude.h#pointer_to_chars
@@ -108,6 +112,8 @@
 .requires CRT/prelude.h#pointers_split
 .requires CRT/prelude.h#pointers_to_chars
 .requires CRT/prelude.h#pointers_to_pointers_
+.requires CRT/prelude.h#ptr_provenance_max_addr_limits
+.requires CRT/prelude.h#ptr_provenance_min_addr_limits
 .requires CRT/prelude.h#short_integer_to_chars
 .requires CRT/prelude.h#shorts_inv
 .requires CRT/prelude.h#string_to_body_chars

--- a/examples/mcas/mcas_client.c
+++ b/examples/mcas/mcas_client.c
@@ -26,6 +26,8 @@ predicate_family_instance mcas_unsep(interval_unsep)(interval_info info, int id,
     interval_values(?a, ?b) &*& a == b &*&
     true == (((uintptr_t)a & 2) == 0) &*&
     true == (((uintptr_t)a & 1) == 0) &*&
+    a == (void *)(uintptr_t)a &*&
+    b == (void *)(uintptr_t)b &*&
     switch (info) {
         case interval_info(interval): return
             &interval->a != &interval->b &*&
@@ -60,6 +62,8 @@ predicate interval_values(void *a, void *b) = true;
 
 predicate_ctor interval_ctor(int id, struct interval *interval)() =
     interval_values(?a, ?b) &*& a == b &*&
+    a == (void *)(uintptr_t)a &*&
+    b == (void *)(uintptr_t)b &*&
     &interval->a != &interval->b &*&
     true == (((uintptr_t)a & 2) == 0) &*&
     true == (((uintptr_t)a & 1) == 0) &*&
@@ -98,6 +102,7 @@ void shift_interval(struct interval *interval) //@ : thread_run
             predicate_family_instance mcas_read_pre(rop)(mcas_unsep *unsep, any mcasInfo, void *a) =
                 unsep == interval_unsep &*& mcasInfo == interval_info(interval) &*& a == &interval->a;
             predicate_family_instance mcas_read_post(rop)(void *result) =
+                result == (void *)(uintptr_t)result &*&
                 true == (((uintptr_t)result & 1) == 0) &*&
                 true == (((uintptr_t)result & 2) == 0);
             lemma void rop() : mcas_read_op
@@ -129,6 +134,7 @@ void shift_interval(struct interval *interval) //@ : thread_run
         /*@
         invariant
             [_]atomic_space(interval_ctor(id, interval)) &*&
+            a0 == (void *)(uintptr_t)a0 &*&
             true == (((uintptr_t)a0 & 1) == 0) &*&
             true == (((uintptr_t)a0 & 2) == 0);
         @*/
@@ -148,6 +154,7 @@ void shift_interval(struct interval *interval) //@ : thread_run
             predicate_family_instance mcas_read_pre(rop)(mcas_unsep *unsep, any mcasInfo, void *a) =
                 unsep == interval_unsep &*& mcasInfo == interval_info(interval) &*& a == &interval->b;
             predicate_family_instance mcas_read_post(rop)(void *result) =
+                result == (void *)(uintptr_t)result &*&
                 true == (((uintptr_t)result & 1) == 0) &*&
                 true == (((uintptr_t)result & 2) == 0);
             lemma void rop() : mcas_read_op

--- a/examples/tso/cvm0.c
+++ b/examples/tso/cvm0.c
@@ -230,7 +230,7 @@ struct class interval_class = {print_interval};
 char heap_[HEAP_SIZE];
 char *heap_free_space;
 
-//@ predicate free_space(;) = pointer(&heap_free_space, ?fs) &*& fs >= (char *)heap_ &*& chars(fs, (char *)heap_ + HEAP_SIZE - (char *)fs, _);
+//@ predicate free_space(;) = pointer(&heap_free_space, ?fs) &*& fs >= (char *)heap_ &*& fs == heap_ + ((char *)fs - heap_) &*& chars(fs, (char *)heap_ + HEAP_SIZE - (char *)fs, _);
 
 void *heap_alloc(size_t size)
     //@ requires free_space() &*& 0 <= size;

--- a/examples/vstte2012/problem3/problem3.c
+++ b/examples/vstte2012/problem3/problem3.c
@@ -49,7 +49,7 @@ predicate ring_buffer(struct ring_buffer *buffer; int size, list<int> items) =
 	&*& malloc_block_ints(fields, size)
 	&*& malloc_block_ring_buffer(buffer)
 
-	&*& fields + size <= (void*)UINTPTR_MAX
+	&*& pointer_within_limits(fields + size) == true
 	
 	&*& is_split_up_fp(size, first, len) ?
 	

--- a/examples/vstte2012/problem3/problem3_alt.c
+++ b/examples/vstte2012/problem3/problem3_alt.c
@@ -22,7 +22,7 @@ predicate ring_buffer(struct ring_buffer *buffer; int size, list<int> items) =
 	&*& first >= 0 && first < size
 	&*& length(items) == len
 	&*& len <= size  
-	&*& fields + size <= (void*)UINTPTR_MAX
+	&*& pointer_within_limits(fields + size) == true
 	
 	&*& malloc_block_ints(fields, size)
 	&*& malloc_block_ring_buffer(buffer)


### PR DESCRIPTION
So far, the only check VeriFast did on pointer arithmetic is that the address did not exceed the limits of uintptr_t.  With this breaking change, VeriFast checks that the result of pointer arithmetic is within the limits associated with the pointer's provenance. The limits of the null pointer provenance coincide with those of uintptr_t; the limits of other provenances are unspecified except that the minimum address is greater than zero, the maximum address is at most UINTPTR_MAX, and if an object is allocated at a given provenance, the addresses of that object's representation bytes, as well as the one-past address, are within the provenance's limits.

A very useful consequence is that the only pointer whose address is zero is the null pointer.

To port your code, it should suffice to replace the incantation 0 <= p <= UINTPTR_MAX by pointer_within_limits(p) == true.