### PR TITLE
Check pointer limits when taking a field's address

### DIFF
--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -22,6 +22,9 @@
 .provides ./prelude.h#field_ptr_provenance_min_addr
 .provides ./prelude.h#field_ptr_provenance_max_addr
 .provides ./prelude.h#ptr_provenance_min_addr_zero
+.provides ./prelude.h#field_pointer_within_limits_def
+.provides ./prelude.h#ptr_within_limits_field_ptr_0
+.provides ./prelude.h#first_field_pointer_within_limits_elim
 .provides ./prelude.h#integer__distinct
 .provides ./prelude.h#integer__unique
 .provides ./prelude.h#integer__limits

--- a/examples/MockKernel/MockKernel.c
+++ b/examples/MockKernel/MockKernel.c
@@ -523,6 +523,7 @@ void handle_connection(struct socket *socket) //@ : thread_run
                             open lseg(m, 0, _, _);
                         }
                         @*/
+                        //@ produce_limits(m);
                         pm = &m->next;
                     }
                 }

--- a/examples/crypto_ccs/symbolic_model/src/network.c
+++ b/examples/crypto_ccs/symbolic_model/src/network.c
@@ -16,15 +16,15 @@ predicate network_status_core(struct network_status *stat, bool initialized) =
   network_status_initialized(stat, ?i) &*&
     (i == 0 || i == 1) &*& 
     initialized == (i == 1) &*&
-  network_status_listen_socket(stat, ?l_socket) &*&
+  stat->listen_socket |-> ?l_socket &*&
     (l_socket == -1 ? true : initialized == true &*&
         net_status(l_socket, nil, ?l_port, bound_to_port)
     ) &*&
-  network_status_client_socket(stat, ?c_socket) &*&
+  stat->client_socket |-> ?c_socket &*&
     (c_socket == -1 ? true : initialized == true &*&
        net_status(c_socket, ?c_ip, ?c_port, connected)
     ) &*&
-  network_status_server_socket(stat, ?s_socket) &*&
+  stat->server_socket |-> ?s_socket &*&
     (s_socket == -1 ? true : initialized == true &*&
        net_status(s_socket, ?s_ip, ?s_port, connected)
     )

--- a/examples/jayanti/jayanti.c
+++ b/examples/jayanti/jayanti.c
@@ -163,6 +163,11 @@ predicate_ctor atomic_space_inv(struct array *array)() =
     );
 
 predicate array_scanner(array_t array; predicate(int, int) inv) =
+    pointer_within_limits(&array->fx) == true &*&
+    pointer_within_limits(&array->fy) == true &*&
+    pointer_within_limits(&array->x) == true &*&
+    pointer_within_limits(&array->y) == true &*&
+    pointer_within_limits(&array->S) == true &*&
     [_]popl20_atomic_space(create_array, atomic_space_inv(array)) &*&
     [_]array->Sid |-> ?Sid &*& [_]is_tracked_int(Sid) &*&
     [_]array->xid |-> ?xid &*& [_]is_tracked_int(xid) &*&
@@ -183,6 +188,8 @@ predicate array_scanner(array_t array; predicate(int, int) inv) =
     [_]array->inv |-> inv;
 
 predicate array_x_writer(array_t array; predicate(int, int) inv) =
+    pointer_within_limits(&array->x) == true &*&
+    pointer_within_limits(&array->fx) == true &*&
     [_]popl20_atomic_space(create_array, atomic_space_inv(array)) &*&
     [_]array->Sid |-> ?Sid &*& [_]is_tracked_int(Sid) &*&
     [_]array->xid |-> ?xid &*& [_]is_tracked_int(xid) &*&
@@ -201,6 +208,8 @@ predicate array_x_writer(array_t array; predicate(int, int) inv) =
     [_]array->inv |-> inv;
 
 predicate array_y_writer(array_t array; predicate(int, int) inv) =
+    pointer_within_limits(&array->y) == true &*&
+    pointer_within_limits(&array->fy) == true &*&
     [_]popl20_atomic_space(create_array, atomic_space_inv(array)) &*&
     [_]array->Sid |-> ?Sid &*& [_]is_tracked_int(Sid) &*&
     [_]array->xid |-> ?xid &*& [_]is_tracked_int(xid) &*&

--- a/examples/mcas/bitops_ex.vfmanifest
+++ b/examples/mcas/bitops_ex.vfmanifest
@@ -73,9 +73,11 @@
 .requires CRT/prelude.h#chars_unseparate_string
 .requires CRT/prelude.h#div_rem
 .requires CRT/prelude.h#divrem_elim
+.requires CRT/prelude.h#field_pointer_within_limits_def
 .requires CRT/prelude.h#field_ptr_provenance_injective
 .requires CRT/prelude.h#field_ptr_provenance_max_addr
 .requires CRT/prelude.h#field_ptr_provenance_min_addr
+.requires CRT/prelude.h#first_field_pointer_within_limits_elim
 .requires CRT/prelude.h#int__to_chars_
 .requires CRT/prelude.h#int_of_chars_of_int
 .requires CRT/prelude.h#int_of_chars_size
@@ -114,6 +116,7 @@
 .requires CRT/prelude.h#pointers_to_pointers_
 .requires CRT/prelude.h#ptr_provenance_max_addr_limits
 .requires CRT/prelude.h#ptr_provenance_min_addr_limits
+.requires CRT/prelude.h#ptr_within_limits_field_ptr_0
 .requires CRT/prelude.h#short_integer_to_chars
 .requires CRT/prelude.h#shorts_inv
 .requires CRT/prelude.h#string_to_body_chars

--- a/examples/mcas/mcas_client.c
+++ b/examples/mcas/mcas_client.c
@@ -31,6 +31,7 @@ predicate_family_instance mcas_unsep(interval_unsep)(interval_info info, int id,
     switch (info) {
         case interval_info(interval): return
             &interval->a != &interval->b &*&
+            pointer_within_limits(&interval->b) == true &*&
             cs == cons(pair(&interval->a, a), cons(pair(&interval->b, b), nil)) &*&
             inv == interval_ctor(id, interval);
     } &*&
@@ -65,12 +66,13 @@ predicate_ctor interval_ctor(int id, struct interval *interval)() =
     a == (void *)(uintptr_t)a &*&
     b == (void *)(uintptr_t)b &*&
     &interval->a != &interval->b &*&
+    pointer_within_limits(&interval->b) == true &*&
     true == (((uintptr_t)a & 2) == 0) &*&
     true == (((uintptr_t)a & 1) == 0) &*&
     mcas(id, interval_sep, interval_unsep, interval_info(interval), cons(pair(&interval->a, a), cons(pair(&interval->b, b), nil)));
 
 predicate_family_instance thread_run_data(shift_interval)(struct interval *interval) =
-    [_]interval->id |-> ?id &*& [_]atomic_space(interval_ctor(id, interval)) &*& &interval->a != &interval->b;
+    [_]interval->id |-> ?id &*& [_]atomic_space(interval_ctor(id, interval)) &*& &interval->a != &interval->b &*& pointer_within_limits(&interval->b) == true;
 
 @*/
 

--- a/examples/queue/queue.c
+++ b/examples/queue/queue.c
@@ -49,7 +49,10 @@ lemma void lseg2_distinct(struct node *first, struct node *middle, struct node *
     close lseg2(first, middle, value0, values);
 }
 
+predicate queue(struct queue *queue;) = pointer_within_limits(&queue->last) == true;
+
 predicate queue_consumer(struct queue *queue) =
+    pointer_within_limits(&queue->last) == true &*&
     queue->first |-> ?first &*& queue->middle |-> ?middle &*& [1/2]queue->ghost_middle |-> middle &*& malloc_block_queue(queue)
     &*& lseg2(first, middle, _, ?frontValues) &*& [1/2]queue->front_values |-> frontValues;
 
@@ -61,7 +64,7 @@ predicate queue_state(struct queue *queue, list<void *> values) =
 
 struct queue *create_queue()
     //@ requires emp;
-    //@ ensures queue_consumer(result) &*& queue_state(result, nil);
+    //@ ensures queue_consumer(result) &*& queue_state(result, nil) &*& [_]queue(result);
 {
     struct node *middle = malloc(sizeof(struct node));
     if (middle == 0) { abort(); }
@@ -88,6 +91,7 @@ struct queue *create_queue()
 void queue_enqueue(struct queue *queue, void *value)
     /*@
     requires
+        [_]queue(queue) &*&
         [?f]atomic_space(?inv) &*&
         is_queue_enqueue_context(?ctxt, inv, queue, value, ?pre, ?post) &*& pre();
     @*/
@@ -97,6 +101,7 @@ void queue_enqueue(struct queue *queue, void *value)
         is_queue_enqueue_context(ctxt, inv, queue, value, pre, post) &*& post();
     @*/
 {
+    //@ open queue(queue);
     struct node *n = malloc(sizeof(struct node));
     if (n == 0) { abort(); }
     n->value = value;

--- a/examples/queue/queue.h
+++ b/examples/queue/queue.h
@@ -8,13 +8,14 @@ struct queue;
 /*@
 
 predicate queue_state(struct queue *queue, list<void *> values);
+predicate queue(struct queue *queue;);
 predicate queue_consumer(struct queue *queue);
 
 @*/
 
 struct queue *create_queue();
     //@ requires emp;
-    //@ ensures queue_consumer(result) &*& queue_state(result, nil);
+    //@ ensures queue_consumer(result) &*& queue_state(result, nil) &*& [_]queue(result);
 
 /*@
 
@@ -32,6 +33,7 @@ typedef lemma void queue_enqueue_context(predicate() inv, struct queue *queue, v
 void queue_enqueue(struct queue *queue, void *value);
     /*@
     requires
+        [_]queue(queue) &*&
         [?f]atomic_space(?inv) &*&
         is_queue_enqueue_context(?ctxt, inv, queue, value, ?pre, ?post) &*& pre();
     @*/

--- a/examples/queue/queue_client.c
+++ b/examples/queue/queue_client.c
@@ -154,7 +154,7 @@ int main() //@ : main
     //@ leak thread(_, _, _, _);
     int id = 0;
     while (true)
-        //@ invariant [1/2]atomic_space(message_queue(queue, minIdCell, maxIdCell)) &*& [1/2]ghost_cell<int>(maxIdCell, id - 1);
+        //@ invariant [1/2]atomic_space(message_queue(queue, minIdCell, maxIdCell)) &*& [1/2]ghost_cell<int>(maxIdCell, id - 1) &*& [_]queue(queue);
     {
         struct message *message = create_message(id);
         {

--- a/examples/shared_boxes/atomic_integer.h
+++ b/examples/shared_boxes/atomic_integer.h
@@ -4,6 +4,12 @@
 //@ predicate atomic_integer(int* i, real level, predicate(int) I);
 
 /*@
+lemma_auto void atomic_integer_inv();
+    requires [?f]atomic_integer(?i, ?level, ?I);
+    ensures [f]atomic_integer(i, level, I) &*& pointer_within_limits(i) == true;
+@*/
+
+/*@
 lemma void create_atomic_integer(int* i, real upper_bound, predicate(int) I);
   requires integer(i, ?value) &*& I(value);
   ensures atomic_integer(i, ?new_level, I) &*& new_level < upper_bound;

--- a/examples/shared_boxes/cell_refcounted.c
+++ b/examples/shared_boxes/cell_refcounted.c
@@ -9,9 +9,9 @@ and its Use in Observational Disjointness".
 //@ #include "listex.gh"
 
 struct cell {
+  int lock;
   int value;
   int refcount;
-  int lock;
 };
 
 struct cell_client {

--- a/examples/shared_boxes/concurrentqueue.c
+++ b/examples/shared_boxes/concurrentqueue.c
@@ -7,8 +7,8 @@ Michael-Scott queue (without memory reclamation)
 #include "concurrentqueue.h"
 
 struct node {
-  int value;
   struct node* next;
+  int value;
 };
 
 struct queue {

--- a/examples/shared_boxes/cowl.c
+++ b/examples/shared_boxes/cowl.c
@@ -5,9 +5,9 @@
 #include "cowl.h"
 
 struct node {
+  int lock;
   int value;
   int refcount;
-  int lock;
   struct node* next;
   //@ list<int> values;
 };

--- a/examples/shared_boxes/lcl_set.c
+++ b/examples/shared_boxes/lcl_set.c
@@ -7,9 +7,9 @@
 struct lock;
 
 struct node {
+  int lock;
   int value;
   struct node* next;
-  int lock;
 };
 
 struct set {

--- a/examples/splitcounter/splitcounter.c
+++ b/examples/splitcounter/splitcounter.c
@@ -33,6 +33,7 @@ predicate_ctor counter_inv(struct counter *counter, predicate(int) inv)() =
     foreach(readers, reader(inv, left, right));
 
 predicate counter(struct counter *counter, predicate(int) inv) =
+    pointer_within_limits(&counter->right) == true &*&
     atomic_space(counter_inv(counter, inv)) &*&
     [1/2]counter->ghostListId |-> _ &*&
     malloc_block_counter(counter);

--- a/examples/usbkbd/src/linux/input.h
+++ b/examples/usbkbd/src/linux/input.h
@@ -134,7 +134,7 @@ struct input_dev {
 		&*& input_dev->event |-> event_cb
 		&*& input_dev->name |-> name
 		&*& input_dev->phys |-> phys
-		&*& input_id_bustype(&input_dev->id, _)
+		&*& input_dev->id.bustype |-> _
 		&*& input_id_vendor(&input_dev->id, _)
 		&*& input_id_product(&input_dev->id, _)
 		&*& input_id_version(&input_dev->id, _)

--- a/examples/usbkbd/src/linux/spinlock.h
+++ b/examples/usbkbd/src/linux/spinlock.h
@@ -19,6 +19,10 @@
 /*@
 predicate spinlock(spinlock_t *spinlock, predicate() p ;);
 // XXX mutex uses p as output-argument. Why didn't I do that?
+
+lemma_auto void spinlock_inv();
+    requires [?f]spinlock(?spinlock, ?p);
+    ensures [f]spinlock(spinlock, p) &*& object_pointer_within_limits(spinlock, sizeof(spinlock_t)) == true;
 @*/
 
 /*#

--- a/examples/usbkbd/src/linux/usb/ch9.h
+++ b/examples/usbkbd/src/linux/usb/ch9.h
@@ -108,6 +108,10 @@ struct usb_endpoint_descriptor {
 
 /*@ 
   predicate usb_endpoint_descriptor(struct usb_endpoint_descriptor *epd; int direction, int xfer_type, int pipe);
+
+lemma_auto void usb_endpoint_descriptor_inv();
+    requires [?f]usb_endpoint_descriptor(?epd, ?dir, ?xfer_type, ?pipe);
+    ensures [f]usb_endpoint_descriptor(epd, dir, xfer_type, pipe) &*& object_pointer_within_limits(epd, sizeof(struct usb_endpoint_descriptor)) == true;
 @*/
 
 static inline int usb_endpoint_is_int_in(const struct usb_endpoint_descriptor *epd);

--- a/examples/usbkbd/src/usbkbd_verified.c
+++ b/examples/usbkbd/src/usbkbd_verified.c
@@ -1455,6 +1455,9 @@ static int usb_kbd_probe(struct usb_interface *iface,
 		return -ENODEV;
 	}
 	
+	//@ assert [_]interface->endpoint |-> ?host_endpoint;
+	//@ open usb_host_endpoint(host_endpoint);
+
 	/* The control endpoint 0 always exists: "All USB devices are required to
 	 * implement a default control method that uses both the input and output
 	 * endpoints with endpoint number zero" -- USB 2.0 specs page 34.
@@ -1466,9 +1469,6 @@ static int usb_kbd_probe(struct usb_interface *iface,
 	ep = interface->endpoint;
 	endpoint = &ep->desc;
 	//original: endpoint = &interface->endpoint[0].desc;
-	
-	//@ assert [_]interface->endpoint |-> ?host_endpoint;
-	//@ open usb_host_endpoint(host_endpoint);
 	
 	if (!usb_endpoint_is_int_in(endpoint))
 	{ // extra "{"

--- a/examples/usbkbd/src/usbmouse.c
+++ b/examples/usbkbd/src/usbmouse.c
@@ -341,9 +341,9 @@ static int usb_mouse_probe(struct usb_interface *intf, const struct usb_device_i
 		return -ENODEV;
 	}
 	
+	//@ open usb_host_endpoint(interface->endpoint);
 	ep = interface->endpoint;
 	endpoint = &(ep->desc);
-	//@ open usb_host_endpoint(interface->endpoint);
 	
 	//int usb_endpoint_is_int_in_res = ;
 	if (! usb_endpoint_is_int_in(endpoint)) {

--- a/soundness.md
+++ b/soundness.md
@@ -17,35 +17,6 @@ Known VeriFast unsoundnesses:
   However, this unsoundness does not apply to `gcc -O2 -fno-strict-aliasing`.
 - The C standard says that reading an uninitialized variable or using the value so obtained can cause a trap. VeriFast does not check that the program does not read or use uninitialized variables.
 - I am not 100% sure that a statement of the form `x = foo();` where x is a global and foo modifies x is allowed by the C standard. VeriFast allows this statement.
-- The pointer arithmetic implied by field or array dereference should be checked for arithmetic overflow. For example, the following program verifies, even though
-  the `assert(false);` is reachable:
-
-    ```c
-    struct bar { int x; int y; };
-
-    void foo()
-      //@ requires true;
-      //@ ensures true;
-    {
-      void *p0 = 0;
-      void *q0 = &((struct bar *)p0)->y;
-      //@ produce_limits(q0);
-      //@ assert p0 <= q0;
-      //@ assert q0 - p0 >= 0;
-      void *p = (void *)UINTPTR_MAX;
-      void *q = &((struct bar *)p)->y;
-      //@ produce_limits(q);
-      //@ assert q <= p;
-      //@ assert q - p <= 0;
-      //@ assert q - p == 0;
-      struct bar b;
-      //@ open bar_x(&b, _);
-      //@ open bar_y(&b, _);
-      //@ integer_distinct(&b.x, &b.x);
-      assert(false);
-    }
-    ```
-
 - Per the C standard, the following program has undefined behavior. (Compilers exploit this to infer that the assignment to `xs[4]` does not modify `ys[0]`.) However, VeriFast allows it to be verified.
 
     ```c

--- a/tests/pointer_limits.c
+++ b/tests/pointer_limits.c
@@ -1,0 +1,32 @@
+void test_pointer_arithmetic()
+//@ requires true;
+//@ ensures true;
+{
+  char foo[2];
+  char *pfoo = foo;
+  char *bad_null = pfoo - (uintptr_t)pfoo; //~should_fail
+}
+
+void test_address_of_subscript()
+//@ requires true;
+//@ ensures true;
+{
+  char foo[2];
+  //@ char__limits(foo);
+  char *pfoo = foo;
+  char *bad_ptr = &pfoo[UINTPTR_MAX]; //~should_fail
+  //@ produce_limits(bad_ptr); //~allow_dead_code
+  //@ assert false; //~allow_dead_code
+}
+
+struct foo { int x; int y; } __attribute__((packed));
+
+void test_address_of_field()
+//@ requires true;
+//@ ensures true;
+{
+  struct foo *p = (struct foo *)UINTPTR_MAX;
+  int *q = &p->y; //~should_fail
+  //@ produce_limits(q); //~allow_dead_code
+  //@ assert false; //~allow_dead_code
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -444,6 +444,7 @@ cd tutorial_solutions
   verifast_both -target 32bit students.c
 cd ..
 cd tests
+  verifast -c -allow_should_fail pointer_limits.c
   verifast -c -allow_should_fail provenance0.c
   verifast -c -allow_should_fail uninit.c
   verifast -c lit_ctor_pat.c


### PR DESCRIPTION
Also checks them when taking the address of an array element. This breaking change fixes a long-standing unsoundness.

This change should only cause proof breakage in cases where you are taking the address of a field for which the thread does not currently own a field chunk, *and* where the field is not the first field of the struct.