### PR TITLE
Pointer equality tests possibly ignore provenance

### DIFF
--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -25,6 +25,8 @@
 .provides ./prelude.h#field_pointer_within_limits_def
 .provides ./prelude.h#ptr_within_limits_field_ptr_0
 .provides ./prelude.h#first_field_pointer_within_limits_elim
+.provides ./prelude.h#pointer_fractions_same_address
+.provides ./prelude.h#pointer__fractions_same_address
 .provides ./prelude.h#integer__distinct
 .provides ./prelude.h#integer__unique
 .provides ./prelude.h#integer__limits

--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -97,7 +97,7 @@ fixpoint bool pointer_within_limits(void *p) {
 }
 
 fixpoint bool object_pointer_within_limits(void *p, int size) {
-    return pointer_within_limits(p) && pointer_within_limits(p + size) && p != 0;
+    return pointer_within_limits(p) && pointer_within_limits(p + size) && (uintptr_t)p != 0;
 }
 
 // When producing a field chunk, VeriFast produces a field_pointer_within_limits fact
@@ -169,7 +169,7 @@ predicate long_double(long double *p; long double v) = long_double_(p, some(v));
 
 lemma void integer__distinct(void *i, void *j);
     requires integer_(i, ?size1, ?signed1, ?v1) &*& integer_(j, ?size2, ?signed2, ?v2);
-    ensures integer_(i, size1, signed1, v1) &*& integer_(j, size2, signed2, v2) &*& i != j;
+    ensures integer_(i, size1, signed1, v1) &*& integer_(j, size2, signed2, v2) &*& (uintptr_t)i != (uintptr_t)j;
 
 lemma void integer___unique(void *p);
     requires [?f]integer__(p, ?size, ?signed_, ?v);
@@ -201,7 +201,7 @@ lemma void u_character_limits(unsigned char *pc);
 
 lemma void integer_distinct(int* i, int* j);
     requires integer(i, ?v1) &*& integer(j, ?v2);
-    ensures integer(i, v1) &*& integer(j, v2) &*& i != j;
+    ensures integer(i, v1) &*& integer(j, v2) &*& (uintptr_t)i != (uintptr_t)j;
 
 lemma void integer_unique(int *p);
     requires [?f]integer(p, ?v);
@@ -225,7 +225,15 @@ lemma void u_short_integer_limits(unsigned short *p);
 
 lemma void pointer_distinct(void *pp1, void *pp2);
     requires pointer(pp1, ?p1) &*& pointer(pp2, ?p2);
-    ensures pointer(pp1, p1) &*& pointer(pp2, p2) &*& pp1 != pp2;
+    ensures pointer(pp1, p1) &*& pointer(pp2, p2) &*& (uintptr_t)pp1 != (uintptr_t)pp2;
+
+lemma void pointer_fractions_same_address(void *pp1, void *pp2);
+    requires [?f1]pointer(pp1, ?p1) &*& [?f2]pointer(pp2, ?p2) &*& (uintptr_t)pp1 == (uintptr_t)pp2;
+    ensures [f1]pointer(pp1, p1) &*& [f2]pointer(pp2, p2) &*& pp1 == pp2 &*& p2 == p1;
+
+lemma void pointer__fractions_same_address(void *pp1, void *pp2);
+    requires [?f1]pointer_(pp1, ?p1) &*& [?f2]pointer_(pp2, ?p2) &*& (uintptr_t)pp1 == (uintptr_t)pp2;
+    ensures [f1]pointer_(pp1, p1) &*& [f2]pointer_(pp2, p2) &*& pp1 == pp2 &*& p2 == p1;
 
 lemma void pointer_unique(void *pp);
     requires [?f]pointer(pp, ?p);
@@ -233,7 +241,7 @@ lemma void pointer_unique(void *pp);
 
 lemma_auto void pointer_nonzero();
     requires pointer(?pp, ?p);
-    ensures pointer(pp, p) &*& pp != 0;
+    ensures pointer(pp, p) &*& (uintptr_t)pp != 0;
 
 lemma void pointer_limits(void *pp);
     requires [?f]pointer(pp, ?p);
@@ -241,7 +249,7 @@ lemma void pointer_limits(void *pp);
 
 lemma void boolean_distinct(bool* i, bool* j);
     requires boolean(i, ?v1) &*& boolean(j, ?v2);
-    ensures boolean(i, v1) &*& boolean(j, v2) &*& i != j;
+    ensures boolean(i, v1) &*& boolean(j, v2) &*& (uintptr_t)i != (uintptr_t)j;
 
 lemma void boolean_unique(bool *p);
     requires [?f]boolean(p, ?v);

--- a/examples/abstract_io/chat_server/queues.c
+++ b/examples/abstract_io/chat_server/queues.c
@@ -79,6 +79,7 @@ bool queue_is_empty/*@ <t> @*/(queue queue)
 {
     //@ open queue(queue, pred, elems);
     //@ open nodes(?first, ?last, _, _);
+    //@ if ((uintptr_t)queue->first == (uintptr_t)queue->last && queue->first != queue->last) pointer__fractions_same_address(&queue->first->next, &queue->last->next);
     //@ close [f]nodes(first, last, pred, elems);
     return queue->first == queue->last;
     //@ close [f]queue(queue, pred, elems);

--- a/examples/arraylist.c
+++ b/examples/arraylist.c
@@ -117,7 +117,7 @@ int main()
   list_add(a, (void *)20);
   
   tmp = list_get(a, 1);
-  assert tmp == (void*) 20;
+  assert(tmp == (void*) 20);
   list_dispose(a);
 
   return 0;

--- a/examples/composite4.c
+++ b/examples/composite4.c
@@ -131,8 +131,8 @@ int subtree_get_count(struct node *node)
 }
 
 void fixup_ancestors(struct node * n, struct node * p, int count)
-  //@ requires context(n, p, _, ?c) &*& 0 <= count;
-  //@ ensures context(n, p, count, c);
+  //@ requires context(n, p, _, ?c) &*& 0 <= count &*& n->left |-> ?nLeft;
+  //@ ensures context(n, p, count, c) &*& n->left |-> nLeft;
 {
   //@ open context(n, p, _, c);
   if (p == 0) {
@@ -143,6 +143,7 @@ void fixup_ancestors(struct node * n, struct node * p, int count)
     int leftCount = 0;
     int rightCount = 0;
     if (n == left) {
+      //@ if (n != left) { open subtree(left, _, _); pointer_fractions_same_address(&n->left, &left->left); }
       leftCount = count;
       rightCount = subtree_get_count(right);
     } else {
@@ -188,7 +189,9 @@ struct node *tree_add_left(struct node *node)
       node->left = n;
       /*@ close context(n, node, 0,
                   left_context(c, node, r)); @*/
+      //@ open subtree(n, node, tree(n, empty, empty));
       fixup_ancestors(n, node, 1);
+      //@ close subtree(n, node, tree(n, empty, empty));
   }
   /*@ close tree(n, left_context(c, node, r),
               tree(n, empty, empty)); @*/
@@ -221,7 +224,9 @@ struct node *tree_add_right(struct node *node)
         //@ open subtree(nodeRight, node, empty);
         node->right = n;
         //@ close context(n, node, 0, right_context(contextNodes, node, leftNodes));
+        //@ open subtree(n, node, tree(n, empty, empty));
         fixup_ancestors(n, node, 1);
+        //@ close subtree(n, node, tree(n, empty, empty));
     }
     //@ close tree(n, right_context(contextNodes, node, leftNodes), tree(n, empty, empty));
     return n;

--- a/examples/contains.c
+++ b/examples/contains.c
@@ -93,7 +93,7 @@ predicate_family_instance equals_post(my_equals)(void* v1, void* v2, fixpoint(un
 
 fixpoint bool my_eq_func(unit un, void* v1, void* v2) {
   switch(un) {
-    case unit: return v1 == v2;
+    case unit: return (uintptr_t)v1 == (uintptr_t)v2;
   }
 }
 @*/
@@ -103,7 +103,7 @@ bool my_equals(void* v1, void* v2) //@: equals
   //@ ensures equals_post(my_equals)(v1, v2, eq_func) &*& result == eq_func(unit, v1, v2);
 {
   //@ open equals_pre(my_equals)(v1, v2, eq_func);
-  if(v1 == v2) {
+  if((uintptr_t)v1 == (uintptr_t)v2) {
     return true;
     //@ close equals_post(my_equals)(v1, v2, eq_func);
   } else {

--- a/examples/crypto_ccs/symbolic_model/src/nonce_item.c
+++ b/examples/crypto_ccs/symbolic_model/src/nonce_item.c
@@ -11,6 +11,8 @@ struct havege_state random_state;
 predicate nonces_initialized() =
   havege_state_initialized(&random_state)
 ;
+
+predicate nonces_state(void *state) = state == &random_state;
 @*/
 
 void nonces_init()
@@ -25,20 +27,19 @@ void nonces_init()
 
 void *nonces_expose_state()
   //@ requires [?f]nonces_initialized();
-  //@ ensures  [f]havege_state_initialized(result);
+  //@ ensures  [f]havege_state_initialized(result) &*& [_]nonces_state(result);
 {
   //@ open [f]nonces_initialized();
   return &random_state;
+  //@ close nonces_state(&random_state);
+  //@ leak nonces_state(_);
 }
 
 void nonces_hide_state(void* state)
-  //@ requires [?f]havege_state_initialized(state);
+  //@ requires [?f]havege_state_initialized(state) &*& [_]nonces_state(state);
   //@ ensures  [f]nonces_initialized();
 {
-  void *temp = &random_state;
-  if (state != temp)
-    abort_crypto_lib("Illegal state for nonces");
-
+  //@ open nonces_state(state);
   //@ close [f]nonces_initialized();
 }
 

--- a/examples/crypto_ccs/symbolic_model/src/nonce_item.h
+++ b/examples/crypto_ccs/symbolic_model/src/nonce_item.h
@@ -6,6 +6,7 @@
 //@ require_module nonce_item;
 
 //@ predicate nonces_initialized();
+//@ predicate nonces_state(void *state);
 
 void nonces_init();
   //@ requires module(nonce_item, true);
@@ -13,10 +14,10 @@ void nonces_init();
 
 void *nonces_expose_state();
   //@ requires [?f]nonces_initialized();
-  //@ ensures  [f]havege_state_initialized(result);
+  //@ ensures  [f]havege_state_initialized(result) &*& [_]nonces_state(result);
 
 void nonces_hide_state(void* state);
-  //@ requires [?f]havege_state_initialized(state);
+  //@ requires [?f]havege_state_initialized(state) &*& [_]nonces_state(state);
   //@ ensures  [f]nonces_initialized();
 
 void nonces_exit();

--- a/examples/gcl.c
+++ b/examples/gcl.c
@@ -989,6 +989,8 @@ void destruct_cons(struct object *object, struct object **head, struct object **
     else {
         struct cons *cons = (void *)object;
         //@ open class_info();
+        //@ pointer_fractions_same_address(&object->class->dispose, &cons_class.dispose);
+        //@ merge_fractions cons_class.inv |-> _;
         //@ open cons_inv(cons, ?cs);
         *head = cons->head;
         *tail = cons->tail;
@@ -1124,6 +1126,8 @@ struct object *parse(struct tokenizer *tokenizer)
                     //@ open object(objects2)(parent);
                     if (parent->class != &cons_class) abort();
                     //@ open class_info();
+                    //@ pointer_fractions_same_address(&parent->class->dispose, &cons_class.dispose);
+                    //@ merge_fractions cons_class.inv |-> _;
                     //@ open cons_inv(parentCons, _);
                     if (parentCons->head == &nil_value) {
                         parentCons->head = expr;
@@ -1194,6 +1198,8 @@ struct object *pop()
         error("pop: stack underflow");
     else {
         //@ open class_info();
+        //@ pointer_fractions_same_address(&old_operand_stack->class->dispose, &cons_class.dispose);
+        //@ merge_fractions cons_class.inv |-> _;
         struct cons *cons = (void *)operand_stack;
         //@ open cons_inv(cons, ?cs);
         struct object *result = cons->head;
@@ -1240,6 +1246,8 @@ struct object *pop_cont()
         return 0;
     } else {
         //@ open class_info();
+        //@ pointer_fractions_same_address(&old_cont_stack->class->dispose, &cons_class.dispose);
+        //@ merge_fractions cons_class.inv |-> _;
         struct cons *cons = (void *)cont_stack;
         //@ open cons_inv(cons, ?cs);
         struct object *result = cons->head;
@@ -1366,6 +1374,8 @@ void apply(struct object *function)
         error("apply: not a function");
     {
         //@ open class_info();
+        //@ pointer_fractions_same_address(&function->class->dispose, &function_class.dispose);
+        //@ merge_fractions function_class.inv |-> _;
         struct function *f = (void *)function;
         //@ open function_inv(_, ?cs);
         apply_func *applyFunc = f->apply;
@@ -1408,6 +1418,9 @@ bool atom_equals(struct object *object1, struct object *object2)
         //@ open class(_, _, _);
         //@ open class(_, _, _);
         //@ open class_info();
+        //@ pointer_fractions_same_address(&object1->class->dispose, &atom_class.dispose);
+        //@ pointer_fractions_same_address(&object2->class->dispose, &atom_class.dispose);
+        //@ merge_fractions atom_class.inv |-> _;
         //@ open atom_inv(a1, _);
         //@ open atom_inv(a2, _);
         return string_buffer_equals(a1->chars, a2->chars);
@@ -1577,6 +1590,8 @@ void print_atom(struct object *data) //@ : apply_func
     //@ open object(objects)(arg);
     if (arg->class != &atom_class) error("print_atom: argument is not an atom");
     //@ open class_info();
+    //@ pointer_fractions_same_address(&arg->class->dispose, &atom_class.dispose);
+    //@ merge_fractions atom_class.inv |-> _;
     //@ open atom_inv((void *)arg, _);
     print_string_buffer(((struct atom *)(void *)arg)->chars);
     //@ close atom_inv((void *)arg, nil);

--- a/examples/gcl0.c
+++ b/examples/gcl0.c
@@ -744,6 +744,8 @@ void destruct_cons(struct object *object, struct object **head, struct object **
     else {
         struct cons *cons = (void *)object;
         //@ open class_info();
+        //@ pointer_fractions_same_address(&object->class->dispose, &cons_class.dispose);
+        //@ merge_fractions cons_class.inv |-> _;
         //@ open cons_inv(cons, ?cs);
         *head = cons->head;
         *tail = cons->tail;
@@ -856,6 +858,8 @@ struct object *parse(struct tokenizer *tokenizer)
                     //@ open object(objects2)(parent);
                     if (parent->class != &cons_class) abort();
                     //@ open class_info();
+                    //@ pointer_fractions_same_address(&parent->class->dispose, &cons_class.dispose);
+                    //@ merge_fractions cons_class.inv |-> _;
                     //@ open cons_inv(parentCons, _);
                     if (parentCons->head == &nil_value) {
                         parentCons->head = expr;
@@ -926,6 +930,8 @@ struct object *pop()
         error("pop: stack underflow");
     else {
         //@ open class_info();
+        //@ pointer_fractions_same_address(&old_operand_stack->class->dispose, &cons_class.dispose);
+        //@ merge_fractions cons_class.inv |-> _;
         struct cons *cons = (void *)operand_stack;
         //@ open cons_inv(cons, ?cs);
         struct object *result = cons->head;
@@ -972,6 +978,8 @@ struct object *pop_cont()
         return 0;
     } else {
         //@ open class_info();
+        //@ pointer_fractions_same_address(&old_cont_stack->class->dispose, &cons_class.dispose);
+        //@ merge_fractions cons_class.inv |-> _;
         struct cons *cons = (void *)cont_stack;
         //@ open cons_inv(cons, ?cs);
         struct object *result = cons->head;
@@ -1060,6 +1068,8 @@ void apply(struct object *function)
         error("apply: not a function");
     {
         //@ open class_info();
+        //@ pointer_fractions_same_address(&function->class->dispose, &function_class.dispose);
+        //@ merge_fractions function_class.inv |-> _;
         struct function *f = (void *)function;
         //@ open function_inv(_, ?cs);
         apply_func *applyFunc = f->apply;
@@ -1100,6 +1110,9 @@ bool atom_equals(struct object *object1, struct object *object2)
         struct atom *a1 = (void *)object1;
         struct atom *a2 = (void *)object2;
         //@ open class_info();
+        //@ pointer_fractions_same_address(&object1->class->dispose, &atom_class.dispose);
+        //@ pointer_fractions_same_address(&object2->class->dispose, &atom_class.dispose);
+        //@ merge_fractions atom_class.inv |-> _;
         //@ open atom_inv(a1, _);
         //@ open class_info();
         //@ open atom_inv(a2, _);
@@ -1270,6 +1283,8 @@ void print_atom(struct object *data) //@ : apply_func
     //@ open object(objects)(arg);
     if (arg->class != &atom_class) error("print_atom: argument is not an atom");
     //@ open class_info();
+    //@ pointer_fractions_same_address(&arg->class->dispose, &atom_class.dispose);
+    //@ merge_fractions atom_class.inv |-> _;
     //@ open atom_inv((void *)arg, _);
     print_string_buffer(((struct atom *)(void *)arg)->chars);
     //@ close atom_inv((void *)arg, nil);

--- a/examples/iter.c
+++ b/examples/iter.c
@@ -107,6 +107,7 @@ void llist_append(struct llist *list1, struct llist *list2)
   struct node *l2 = list2->last;
   //@ open lseg(f2, l2, _v2);  // Causes case split.
   if (f2 == l2) {
+    //@ if (f2 != l2) pointer_fractions_same_address(&f2->next, &l2->next);
     free(l2);
     free(list2);
     //@ append_nil(_v1);
@@ -140,6 +141,7 @@ void llist_dispose(struct llist *list)
     free(n);
     n = next;
   }
+  //@ if (n != l) pointer_fractions_same_address(&n->next, &l->next);
   //@ open lseg(n, n, _);  // Clean up empty lseg.
   free(l);
   free(list);
@@ -214,6 +216,7 @@ int llist_length(struct llist *list)
     //@ assert [frac]lseg(next, l, ?ls3);
     //@ append_assoc(_ls1, cons(value, nil), ls3);
   }
+  //@ if (n != l) pointer_fractions_same_address(&n->next, &l->next);
   //@ open lseg(n, l, _ls2);
   //@ append_nil(_ls1);
   //@ lseg2_to_lseg(f);

--- a/examples/iter_with_auto.c
+++ b/examples/iter_with_auto.c
@@ -100,6 +100,7 @@ void llist_append(struct llist *list1, struct llist *list2)
   struct node *l2 = list2->last;
   //@ open lseg(f2, l2, _v2);  // Causes case split.
   if (f2 == l2) {
+    //@ if (f2 != l2) pointer_fractions_same_address(&f2->next, &l2->next);
     free(l2);
     free(list2);
   } else {
@@ -127,6 +128,7 @@ void llist_dispose(struct llist *list)
     free(n);
     n = next;
   }
+  //@ if (n != l) pointer_fractions_same_address(&n->next, &l->next);
   free(l);
   free(list);
 }
@@ -196,6 +198,7 @@ int llist_length(struct llist *list)
     //@ assert [frac]lseg(next, l, ?ls3);
     //@ append_assoc(_ls1, cons(value, nil), ls3);
   }
+  //@ if (n != l) pointer_fractions_same_address(&n->next, &l->next);
   //@ open lseg(n, l, _ls2);
   return c;
 }

--- a/examples/lists.c
+++ b/examples/lists.c
@@ -44,6 +44,30 @@ lemma void lseg_add(void *n1)
     append_assoc(xs0, cons(n2, nil), xs1);
 }
 
+lemma void lseg_distinct(void *element, void *n)
+    requires lseg(?first, ?last, ?xs, ?p) &*& mem(element, xs) == true &*& pointer(n, ?nNext);
+    ensures lseg(first, last, xs, p) &*& pointer(n, nNext) &*& (uintptr_t)element != (uintptr_t)n;
+{
+    open lseg(first, last, xs, p);
+    if (first != last) {
+        if (first != element)
+            lseg_distinct(element, n);
+        else
+            pointer_distinct(first, n);
+    }
+    close lseg(first, last, xs, p);
+}    
+
+lemma void lseg_same_address(void *element)
+    requires lseg(?first, ?last, ?xs, ?p) &*& mem(element, xs) == true &*& (uintptr_t)first == (uintptr_t)element;
+    ensures lseg(first, last, xs, p) &*& first == element;
+{
+    open lseg(first, last, xs, p);
+    if (first != element)
+        lseg_distinct(element, first);
+    close lseg(first, last, xs, p);
+}
+
 @*/
 
 void lseg_remove(void *phead, void *element)
@@ -86,6 +110,7 @@ void lseg_remove(void *phead, void *element)
         @*/
         pnext = next;
     }
+    //@ lseg_same_address(element);
     //@ void *next = *pnext;
     //@ open lseg(next, 0, _, p);
     {

--- a/examples/mcas/mcas.mysh
+++ b/examples/mcas/mcas.mysh
@@ -1,2 +1,2 @@
 ifz3v4.5 verifast -prover z3v4.5 -c -check_vfmanifest bitops_ex.c
-verifast threading.o bitops_ex.o popl20_prophecies.vfmanifest atomics.c ghost_cells_ex.c listex_ex.c assoc_list.c ghost_lists.c ghost_counters.c rdcss.c mcas.c mcas_client.c
+verifast -assume_no_provenance threading.o bitops_ex.o popl20_prophecies.vfmanifest atomics.c ghost_cells_ex.c listex_ex.c assoc_list.c ghost_lists.c ghost_counters.c rdcss.c mcas.c mcas_client.c

--- a/examples/set.c
+++ b/examples/set.c
@@ -52,20 +52,22 @@ void set_add(struct set* set, void* x)
 
 bool set_contains(struct set* set, void* x)
   //@ requires set(set, ?size, ?elems);
-  //@ ensures set(set, size, elems) &*& result == elems(x);
+  //@ ensures set(set, size, elems) &*& result ? exists<void *>(?elem) &*& elems(elem) == true &*& (uintptr_t)x == (uintptr_t)elem : !elems(x);
 {
   //@ open set(set, size, elems);
   struct node* curr = set->head;
   bool found = false;
   //@ open lseg(curr, 0, ?vss);
   //@ close lseg(curr, 0, vss);
+  //@ void *elem = 0;
   while(curr != 0 && ! found) 
     //@ requires lseg(curr, 0, ?vs) &*& curr == 0 ? vs == nil : true;
-    //@ ensures lseg(old_curr, 0, vs) &*& found == (old_found || (list_as_set(vs))(x) == true);
+    //@ ensures lseg(old_curr, 0, vs) &*& old_found ? found && elem == old_elem : found ? (uintptr_t)elem == (uintptr_t)x && (list_as_set(vs))(elem) : !(list_as_set(vs))(x);
   {
     //@ open lseg(curr, 0, vs);
     //@ assert lseg(_, 0, ?tail);
     if(curr->val == x) {
+      //@ elem = curr->val;
       found = true;
     }
     curr = curr->next;
@@ -75,6 +77,7 @@ bool set_contains(struct set* set, void* x)
     //@ close lseg(old_curr, 0, vs);
   }
   //@ close set(set, size, elems);
+  //@ if (found) close exists(elem);
   return found;
 }
 

--- a/examples/shared_boxes/concurrentstackclient.c
+++ b/examples/shared_boxes/concurrentstackclient.c
@@ -8,8 +8,10 @@ fixpoint bool sublist<t>(list<t> vs1, list<t> vs2) {
   }
 }
 
+fixpoint bool has_null_provenance(void *p) { return p == (void *)(uintptr_t)p; }
+
 box_class incr_box(list<void*> all, list<void*> vs) {
-  invariant distinct(all) && distinct(vs) && sublist(vs, all) == true;
+  invariant distinct(all) && distinct(vs) && sublist(vs, all) == true && forall(all, has_null_provenance) && forall(vs, has_null_provenance);
   
   action push(void* x);
     requires ! mem(x, all);
@@ -44,7 +46,7 @@ void consumer(struct stack* s, struct stack_client* client)
   {
   /*@
     predicate_family_instance stack_pop_pre(my_pop_lemma)() = true;
-    predicate_family_instance stack_pop_post(my_pop_lemma)(bool success, void* res) = not_contains(?ha, id, success, res);
+    predicate_family_instance stack_pop_post(my_pop_lemma)(bool success, void* res) = not_contains(?ha, id, success, res) &*& has_null_provenance(res) == true;
     lemma void my_pop_lemma()
       requires stack_pop_pre(my_pop_lemma)() &*& myi(id)(?vs);
       ensures stack_pop_post(my_pop_lemma)(vs != nil, ?out) &*& (vs == nil ? myi(id)(nil) : myi(id)(tail(vs)) &*& out == head(vs));
@@ -80,7 +82,7 @@ void consumer(struct stack* s, struct stack_client* client)
     {
     /*@
     predicate_family_instance stack_pop_pre(my_pop_lemma2)() = not_contains(?ha, id, true, y);
-    predicate_family_instance stack_pop_post(my_pop_lemma2)(bool success2, void* res) = ! success2 || res != y;
+    predicate_family_instance stack_pop_post(my_pop_lemma2)(bool success2, void* res) = ! success2 || res != y &*& has_null_provenance(res) == true;
     lemma void my_pop_lemma2()
       requires stack_pop_pre(my_pop_lemma2)() &*& myi(id)(?vs);
       ensures stack_pop_post(my_pop_lemma2)(vs != nil, ?out) &*& (vs == nil ? myi(id)(nil) : myi(id)(tail(vs)) &*& out == head(vs));

--- a/examples/vstte2012/problem5/lset.c
+++ b/examples/vstte2012/problem5/lset.c
@@ -197,6 +197,8 @@ lemma void lset_subset_add_l<t>(list<t> s1, t el, list<t> s2)
 {
 }
 
+*/
+
 lemma void lset_subset_add_r<t>(list<t> s1, list<t> s2, t el)
     requires lset_subset(s1, s2) == true;
     ensures lset_subset(s1, lset_add(s2, el)) == true;
@@ -207,6 +209,8 @@ lemma void lset_subset_add_r<t>(list<t> s1, list<t> s2, t el)
             lset_subset_add_r(t, s2, el);
     }
 }
+
+/*
 
 lemma void lset_subset_remove_l<t>(list<t> s1, t el, list<t> s2)
     requires lset_subset(s1, s2) == true;
@@ -231,6 +235,8 @@ lemma void lset_subset_remove_r<t>(list<t> s1, list<t> s2, t el)
     }    
 }
 
+*/
+
 lemma void lset_subset_union_l<t>(list<t> s1, list<t> s2)
     requires true;
     ensures lset_subset(s1, lset_union(s1, s2)) == true;
@@ -242,6 +248,8 @@ lemma void lset_subset_union_l<t>(list<t> s1, list<t> s2)
             lset_subset_add_r(t, lset_union(t, s2), h);
     }
 }
+
+/*
 
 lemma void lset_subset_union_r<t>(list<t> s1, list<t> s2)
     requires true;
@@ -291,6 +299,8 @@ lemma void lset_subset_refl<t>(list<t> s)
     }
 }
 
+*/
+
 lemma void lset_subset_trans<t>(list<t> s1, list<t> s2, list<t> s3)
     requires lset_subset(s1, s2) == true &*& lset_subset(s2, s3) == true;
     ensures lset_subset(s1, s3) == true;
@@ -304,6 +314,7 @@ lemma void lset_subset_trans<t>(list<t> s1, list<t> s2, list<t> s3)
 
 }
 
+/*
 //subset is structurally compatible
 
 lemma void lset_add_remains_subset<t>(list<t> s1, list<t> s2, t el)
@@ -742,6 +753,8 @@ lemma void lset_equals_add_r_remove_l<t>(list<t> s1, list<t> s2, t el)
 
 // more advanced
 
+*/
+
 lemma void lset_union_subset_l<t>(list<t> s1, list<t> s2, list<t> s3)
     requires true;
     ensures lset_subset(lset_union(s1, s2), s3) == (lset_subset(s1, s3) && lset_subset(s2, s3));
@@ -753,7 +766,7 @@ lemma void lset_union_subset_l<t>(list<t> s1, list<t> s2, list<t> s3)
     }
 }
 
-
+/*
 lemma void lset_inters_distr_union<t>(list<t> s1, list<t> s2, list<t> s3)
     requires true;
     ensures lset_equals(lset_inters(s1, lset_union(s2, s3)), lset_union(lset_inters(s1, s2), lset_inters(s1, s3))) == true; 

--- a/examples/vstte2012/problem5/lset.gh
+++ b/examples/vstte2012/problem5/lset.gh
@@ -88,8 +88,8 @@ lemma void lset_diff_contains<t>(list<t> s1, list<t> s2, t el);
     ensures lset_contains(lset_diff(s1, s2), el) == (lset_contains(s1, el) && !lset_contains(s2, el));
 
 lemma void lset_subset_contains<t>(list<t> s1, list<t> s2, t el);
-    requires lset_subset(s1, s2) == true;
-    ensures lset_contains(s1, el) ? lset_contains(s2, el)==true : true;
+    requires lset_subset(s1, s2) && lset_contains(s1, el);
+    ensures lset_contains(s2, el)==true;
 
 lemma void lset_equals_contains<t>(list<t> s1, list<t> s2, t el);
     requires lset_equals(s1, s2) == true;
@@ -156,9 +156,13 @@ lemma void lset_subset_remove_r<t>(list<t> s1, list<t> s2, t el);
     requires true;
     ensures lset_subset(s1, lset_remove(s2, el)) == (!lset_contains(s1, el) && lset_subset(s1, s2));
 
+*/
+
 lemma void lset_subset_union_l<t>(list<t> s1, list<t> s2);
     requires true;
     ensures lset_subset(s1, lset_union(s1, s2)) == true;
+
+/*
 
 lemma void lset_subset_union_r<t>(list<t> s1, list<t> s2);
     requires true;
@@ -178,9 +182,13 @@ lemma void lset_subset_refl<t>(list<t> s);
     requires true;
     ensures lset_subset(s, s) == true;
 
+*/
+
 lemma void lset_subset_trans<t>(list<t> s1, list<t> s2, list<t> s3);
     requires lset_subset(s1, s2) == true &*& lset_subset(s2, s3) == true;
     ensures lset_subset(s1, s3) == true;
+
+/*
 
 //subset is structurally compatible
 
@@ -376,9 +384,13 @@ lemma void lset_inters_subset<t>(list<t> s1, list<t> s2);
 
 // todo: place these in the right category 
 
+*/
+
 lemma void lset_union_subset_l<t>(list<t> s1, list<t> s2, list<t> s3);
     requires true;
     ensures lset_subset(lset_union(s1, s2), s3) == (lset_subset(s1, s3) && lset_subset(s2, s3));
+
+/*
 
 lemma void lset_inters_subset_r<t>(list<t> s1, list<t> s2, list<t> s3);
     requires true;

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -166,7 +166,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         cont (chunk::h0)
       | Chunk (g, targs', tcoef', [tp'; tv'], _) as chunk::h when is_related_pred_symb g ->
         if tcoef == real_unit || tcoef' == real_unit then
-          assume_neq tp tp' (fun _ -> iter h)
+          assume_neq (mk_ptr_address tp) (mk_ptr_address tp') (fun _ -> iter h)
         else if definitely_equal tp tp' then
         begin
           let cont coef = 

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -931,7 +931,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       end
     | Assert (l, p) when not pure ->
       let we = check_expr_t (pn,ilist) tparams tenv p boolt in
-      let t = eval env we in
+      eval_h h env we $. fun h env t ->
       assert_term t h env l "Assertion might not hold." None;
       cont h env
     | Assert (l, p) ->

--- a/src/verifast0.ml
+++ b/src/verifast0.ml
@@ -145,6 +145,7 @@ let bases_constructed_pred_name sn = sn ^ "_bases_constructed"
 type options = {
   option_verbose: int;
   option_disable_overflow_check: bool;
+  option_assume_no_provenance: bool;
   option_assume_no_subobject_provenance: bool;
   option_allow_should_fail: bool;
   option_emit_manifest: bool;

--- a/src/vfconsole.ml
+++ b/src/vfconsole.ml
@@ -335,6 +335,7 @@ let _ =
   let json = ref false in
   let verbose = ref 0 in
   let disable_overflow_check = ref false in
+  let assume_no_provenance = ref false in
   let assume_no_subobject_provenance = ref false in
   let prover: string ref = ref default_prover in
   let compileOnly = ref false in
@@ -389,6 +390,7 @@ let _ =
             ; "-json", Set json, "Report result as JSON"
             ; "-verbose", Set_int verbose, "-1 = file processing; 1 = statement executions; 2 = produce/consume steps; 4 = prover queries."
             ; "-disable_overflow_check", Set disable_overflow_check, " "
+            ; "-assume_no_provenance", Set assume_no_provenance, "Disregard pointer provenance. This is unsound, even when compiling with -O0!"
             ; "-assume_no_subobject_provenance", Set assume_no_subobject_provenance, "Assume the compiler's alias analysis ignores subobject provenance. CompCert ignores subobject provenance, and so, it seems, do GCC and Clang (last time I checked)"
             ; "-prover", String (fun str -> prover := str), "Set SMT prover (" ^ list_provers() ^ ")."
             ; "-c", Set compileOnly, "Compile only, do not perform link checking."
@@ -439,6 +441,7 @@ let _ =
         let options = {
           option_verbose = !verbose;
           option_disable_overflow_check = !disable_overflow_check;
+          option_assume_no_provenance = !assume_no_provenance;
           option_assume_no_subobject_provenance = !assume_no_subobject_provenance;
           option_allow_should_fail = !allowShouldFail;
           option_emit_manifest = !emitManifest;

--- a/src/vfide.ml
+++ b/src/vfide.ml
@@ -137,7 +137,7 @@ module TreeMetrics = struct
   let cw = dotWidth + 2 * padding
 end
 
-let show_ide initialPath prover codeFont traceFont runtime layout javaFrontend enforceAnnotations allowUndeclaredStructTypes dataModel overflowCheck assumeNoSubobjectProvenance verifyAndQuit =
+let show_ide initialPath prover codeFont traceFont runtime layout javaFrontend enforceAnnotations allowUndeclaredStructTypes dataModel overflowCheck assumeNoProvenance assumeNoSubobjectProvenance verifyAndQuit =
   let dataModel = ref dataModel in
   let leftBranchPixbuf = Branchleft_png.pixbuf () in
   let rightBranchPixbuf = Branchright_png.pixbuf () in
@@ -164,6 +164,7 @@ let show_ide initialPath prover codeFont traceFont runtime layout javaFrontend e
   let scaledTraceFont = ref !traceFont in
   let actionGroup = GAction.action_group ~name:"Actions" () in
   let disableOverflowCheck = ref (not overflowCheck) in
+  let assumeNoProvenance = ref assumeNoProvenance in
   let assumeNoSubobjectProvenance = ref assumeNoSubobjectProvenance in
   let useJavaFrontend = ref false in
   let toggle_java_frontend active =
@@ -269,6 +270,7 @@ let show_ide initialPath prover codeFont traceFont runtime layout javaFrontend e
       a "ShowExecutionTree" ~label:"Show _execution tree" ~accel:"<Ctrl>T";
       a "Verify" ~label:"_Verify";
       GAction.add_toggle_action "CheckOverflow" ~label:"Check arithmetic overflow" ~active:true ~callback:(fun toggleAction -> disableOverflowCheck := not toggleAction#get_active);
+      GAction.add_toggle_action "AssumeNoProvenance" ~label:"Assume no pointer provenance" ~active:false ~callback:(fun toggleAction -> assumeNoProvenance := toggleAction#get_active);
       GAction.add_toggle_action "AssumeNoSubobjectProvenance" ~label:"Assume no subobject provenance" ~active:false ~callback:(fun toggleAction -> assumeNoSubobjectProvenance := toggleAction#get_active);
       GAction.add_toggle_action "UseJavaFrontend" ~label:"Use the Java frontend" ~active:(toggle_java_frontend javaFrontend; javaFrontend) ~callback:(fun toggleAction -> toggle_java_frontend toggleAction#get_active);
       GAction.add_toggle_action "SimplifyTerms" ~label:"Simplify Terms" ~active:true ~callback:(fun toggleAction -> simplifyTerms := toggleAction#get_active);
@@ -330,6 +332,7 @@ let show_ide initialPath prover codeFont traceFont runtime layout javaFrontend e
           <menuitem action='RunShapeAnalysis' />
           <separator />
           <menuitem action='CheckOverflow' />
+          <menuitem action='AssumeNoProvenance' />
           <menuitem action='AssumeNoSubobjectProvenance' />
           <menuitem action='UseJavaFrontend' />
           <menuitem action='SimplifyTerms' />
@@ -1461,6 +1464,7 @@ let show_ide initialPath prover codeFont traceFont runtime layout javaFrontend e
               let options = {
                 option_verbose = 0;
                 option_disable_overflow_check = !disableOverflowCheck;
+                option_assume_no_provenance = !assumeNoProvenance;
                 option_assume_no_subobject_provenance = !assumeNoSubobjectProvenance;
                 option_use_java_frontend = !useJavaFrontend;
                 option_enforce_annotations = enforceAnnotations;
@@ -1887,6 +1891,7 @@ let () =
   let enforceAnnotations = ref false in
   let allowUndeclaredStructTypes = ref false in
   let overflow_check = ref true in
+  let assume_no_provenance = ref false in
   let assume_no_subobject_provenance = ref false in
   let data_model = ref None in
   let verify_and_quit = ref false in
@@ -1910,10 +1915,11 @@ let () =
     | "-allow_undeclared_struct_types"::args -> allowUndeclaredStructTypes := true; iter args
     | "-target"::target::args -> data_model := Some (data_model_of_string target); iter args
     | "-disable_overflow_check"::args -> overflow_check := false; iter args
+    | "-assume_no_provenance"::args -> assume_no_provenance := true; iter args
     | "-assume_no_subobject_provenance"::args -> assume_no_subobject_provenance := true; iter args
     | "-verify_and_quit"::args -> verify_and_quit := true; iter args
     | arg::args when not (startswith arg "-") -> path := Some arg; iter args
-    | [] -> show_ide !path !prover !codeFont !traceFont !runtime !layout !javaFrontend !enforceAnnotations !allowUndeclaredStructTypes !data_model !overflow_check !assume_no_subobject_provenance !verify_and_quit
+    | [] -> show_ide !path !prover !codeFont !traceFont !runtime !layout !javaFrontend !enforceAnnotations !allowUndeclaredStructTypes !data_model !overflow_check !assume_no_provenance !assume_no_subobject_provenance !verify_and_quit
     | _ ->
       let options = [
         "-prover prover    (" ^ list_provers () ^ ")";

--- a/tests/provenance.c
+++ b/tests/provenance.c
@@ -5,12 +5,12 @@
 
 bool do_alias(int *x, int *y)
 //@ requires true;
-//@ ensures result == (x == y);
+//@ ensures result == (x == y); //~should_fail
 {
     if ((uintptr_t)x <= (uintptr_t)y)
         return (uintptr_t)y - (uintptr_t)x == 0;
     else
-        return (uintptr_t)x - (uintptr_t)y == 0;
+        return (uintptr_t)x - (uintptr_t)y == 0; //~allow_dead_code
 }
 
 int main()

--- a/tests/subobject_provenance.c
+++ b/tests/subobject_provenance.c
@@ -5,12 +5,12 @@
 
 bool do_alias(int *x, int *y)
 //@ requires true;
-//@ ensures result == (x == y);
+//@ ensures result == (x == y); //~should_fail
 {
     if ((uintptr_t)x <= (uintptr_t)y)
         return (uintptr_t)y - (uintptr_t)x == 0;
     else
-        return (uintptr_t)x - (uintptr_t)y == 0;
+        return (uintptr_t)x - (uintptr_t)y == 0; //~allow_dead_code
 }
 
 struct foo {

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -90,7 +90,7 @@ cd examples
     verifast_both -c gotsmanlock.c
     verifast_both -c spinlock.c
     verifast -c -target 32bit concurrentqueue.c
-    verifast -c -prover z3v4.5 -target 32bit concurrentstack.c
+    verifast -c -prover z3v4.5 -target 32bit -assume_no_provenance concurrentstack.c
     verifast -c concurrentstackclient.c
     verifast -target 32bit -allow_assume threading.o atomics.o concurrentqueue.c concurrentqueue_client.c
     verifast_both -c atomic_integer.c
@@ -444,6 +444,8 @@ cd tutorial_solutions
   verifast_both -target 32bit students.c
 cd ..
 cd tests
+  verifast -c -allow_should_fail subobject_provenance.c
+  verifast -c -allow_should_fail provenance.c
   verifast -c -allow_should_fail pointer_limits.c
   verifast -c -allow_should_fail provenance0.c
   verifast -c -allow_should_fail uninit.c


### PR DESCRIPTION
A pointer equality test takes the pointers' provenances (i.e. the way the pointers were derived) into account if the test is evaluated by the compiler's alias analysis, and ignores them if it is evaluated at run time. So if a test succeeds, all we know is that the addresses are equal (not that the pointers are equal), and if it fails, all we know is that the pointers are different (not that the addresses are different).

This may cause non-trivial proof breakage, so an -assume_no_provenance flag is provided to allow this issue to be postponed.