### PR TITLE
[C++] Consume bases_constructed at end of destructor body

### DIFF
--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2976,15 +2976,15 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       with_context (Executing ([], env, loc, sprintf "Verifying destructor '%s'" @@ cxx_dtor_name struct_name)) @@ fun () ->
       assume_neq this_term (null_pointer_term ()) @@ fun () ->
       produce_asn [] [] ghostenv env pre real_unit None None @@ fun h ghostenv env ->
-      begin fun cont ->
-        match try_assoc struct_name bases_constructed_map with
-        | Some (_, (_, _, _, _, bases_constructed_symb, _, _)) ->
-          consume_chunk rules h [] env [] loc (bases_constructed_symb, true) [] real_unit real_unit_pat (Some 1) [TermPat this_term] @@ fun _ h _ _ _ _ _ _ ->
-          cont h
-        | None ->
-          cont h
-      end @@ fun h ->
       let return_cont h tenv2 env2 retval =
+        begin fun cont ->
+          match try_assoc struct_name bases_constructed_map with
+          | Some (_, (_, _, _, _, bases_constructed_symb, _, _)) ->
+            consume_chunk rules h [] env [] loc (bases_constructed_symb, true) [] real_unit real_unit_pat (Some 1) [TermPat this_term] @@ fun _ h _ _ _ _ _ _ ->
+            cont h
+          | None ->
+            cont h
+        end @@ fun h ->
         consume_fields this_term h env tenv ghostenv leminfo sizemap @@ fun h ->
         consume_bases bases h env tenv this_term ghostenv leminfo sizemap @@ fun h env tenv ->
         consume_asn rules [] h ghostenv env post true real_unit @@ fun _ h ghostenv env size_first ->

--- a/tests/cxx/inheritance/method_call_in_dtor.cpp
+++ b/tests/cxx/inheritance/method_call_in_dtor.cpp
@@ -1,0 +1,57 @@
+struct A
+{
+    A()
+    //@ requires true;
+    //@ ensures true;
+    {}
+
+    ~A()
+    //@ requires true;
+    //@ ensures true;
+    {}
+};
+
+class B : public A
+{
+    int *m_i;
+    
+    void cleanup()
+    /*@ requires 
+        [?f]B_bases_constructed(this) &*& 
+        this->m_i |-> ?i_addr &*&
+        integer(i_addr, _) &*&
+        new_block_ints(i_addr, 1);
+    @*/
+    /*@ ensures
+        [f]B_bases_constructed(this) &*&
+        this->m_i |-> i_addr;
+    @*/
+    {
+        delete m_i;
+    }
+public:
+    B()
+    //@ requires true;
+    /*@ ensures 
+        B_bases_constructed(this) &*& 
+        this->m_i |-> ?i_addr &*&
+        integer(i_addr, 0) &*&
+        new_block_ints(i_addr, 1);
+    @*/
+    {
+        m_i = new int(0);
+    }
+    
+    ~B()
+    /*@ requires
+        B_bases_constructed(this) &*&
+        this->m_i |-> ?i_addr &*&
+        integer(i_addr, _) &*&
+        new_block_ints(i_addr, 1);
+    @*/
+    //@ ensures true;
+    {
+        cleanup();
+    }
+    
+};

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -597,6 +597,7 @@ cd ..
         verifast -c -disable_overflow_check single_inheritance.cpp
         verifast -c -disable_overflow_check diamond.cpp
         verifast -c multiple_inheritance.cpp
+        verifast -c method_call_in_dtor.cpp
     cd ..
     verifast -c main_implicit_return.cpp
     verifast -c new_class.cpp


### PR DESCRIPTION
`X_bases_constructed` was consumed too early when verifying a destructor, which didn't allow to call methods during destruction.