### PR TITLE
Forbid negative-size objects

### DIFF
--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -96,7 +96,7 @@ fixpoint bool pointer_within_limits(void *p) {
 }
 
 fixpoint bool object_pointer_within_limits(void *p, int size) {
-    return pointer_within_limits(p) && pointer_within_limits(p + size) && (uintptr_t)p != 0 && size > 0;
+    return pointer_within_limits(p) && pointer_within_limits(p + size) && (uintptr_t)p != 0 && size >= 0;
 }
 
 // When producing a field chunk, VeriFast produces a field_pointer_within_limits fact
@@ -196,11 +196,11 @@ lemma void integer__unique(void *p);
 
 lemma void integer__limits(void *p);
     requires [?f]integer_(p, ?size, ?signed_, ?v);
-    ensures [f]integer_(p, size, signed_, v) &*& object_pointer_within_limits(p, size) == true &*& signed_ ? -(1<<(8*size-1)) <= v &*& v < (1<<(8*size-1)) : 0 <= v &*& v < (1<<(8*size));
+    ensures [f]integer_(p, size, signed_, v) &*& object_pointer_within_limits(p, size) == true &*& size > 0 &*& signed_ ? -(1<<(8*size-1)) <= v &*& v < (1<<(8*size-1)) : 0 <= v &*& v < (1<<(8*size));
 
 lemma void integer___limits(void *p);
     requires [?f]integer__(p, ?size, ?signed_, ?v);
-    ensures [f]integer__(p, size, signed_, v) &*& object_pointer_within_limits(p, size) == true;
+    ensures [f]integer__(p, size, signed_, v) &*& object_pointer_within_limits(p, size) == true &*& size > 0;
 
 lemma void char__limits(char *pc);
     requires [?f]char_(pc, ?c);

--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -96,7 +96,7 @@ fixpoint bool pointer_within_limits(void *p) {
 }
 
 fixpoint bool object_pointer_within_limits(void *p, int size) {
-    return pointer_within_limits(p) && pointer_within_limits(p + size) && (uintptr_t)p != 0;
+    return pointer_within_limits(p) && pointer_within_limits(p + size) && (uintptr_t)p != 0 && size > 0;
 }
 
 // When producing a field chunk, VeriFast produces a field_pointer_within_limits fact

--- a/tests/alloc_zero.c
+++ b/tests/alloc_zero.c
@@ -1,0 +1,13 @@
+#include <malloc.h>
+
+void test()
+//@ requires true;
+//@ ensures true;
+{
+    void* p = malloc(0);
+    if(p) {
+        //@ assert object_pointer_within_limits(p,0) == true;
+        //@ assert false; //~should_fail
+    }
+}
+

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -445,6 +445,7 @@ cd tutorial_solutions
   verifast_both -target 32bit students.c
 cd ..
 cd tests
+  verifast -c -allow_should_fail alloc_zero.c
   verifast -c malloc_integers_.c
   verifast -c void_cast.c
   verifast -c typedef_pointers.c


### PR DESCRIPTION
I couldn't figure out how to prove:

```
lemma void integers__limits(void *array);
    requires [?f]integers_(array, ?sz, ?sgn, ?n, ?cs) &*& n > 0;
    ensures [f]integers_(array, sz, sgn, n, cs) &*& (void *)0 <= array
        &*& array + n <= (void *)UINTPTR_MAX
        &*& array + n*sz <= (void *)UINTPTR_MAX;
```

because there didn't seem to be any axiom guaranteeing `sz >= 1`. This seems like a reasonable spot to add that axiom.