### PR TITLE
Use new vfdeps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,9 +259,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Add vcvarsall to PATH
-        run: echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
       - name: Build setup
         run: ./setup-windows.bat
 

--- a/.gitignore
+++ b/.gitignore
@@ -147,7 +147,6 @@ src/java_frontend/ast_server.jar
 examples/crypto/lib/polarssl
 
 # Cxx frontend
-src/cxx_frontend/ast_exporter/MSVC_CACHE
 src/cxx_frontend/ast_exporter/build/*
 !src/cxx_frontend/ast_exporter/build/.keep
 src/cxx_frontend/stubs/stubs_ast.capnp.c++

--- a/config.sh
+++ b/config.sh
@@ -1,2 +1,2 @@
-export VFDEPS_NAME=vfdeps-1c84e9a
-export VF_LLVM_CLANG_BUILD_VERSION=aafd059
+export VFDEPS_NAME=vfdeps-a4be456
+export VF_LLVM_CLANG_BUILD_VERSION=37740a3

--- a/setup-build.sh
+++ b/setup-build.sh
@@ -30,7 +30,7 @@ dl_and_unzip_vfdeps() {
 dl_and_unzip_llvm-clang() {
   platform="$1"
   hash="$2"
-  dl_and_unzip "https://github.com/NielsMommen/vf-llvm-clang-build/releases/download/v1.0.0/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION-$platform.tar.gz" $hash 256 z
+  dl_and_unzip "https://github.com/NielsMommen/vf-llvm-clang-build/releases/download/v2.0.3/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION-$platform.tar.gz" $hash 256 z
 }
 
 script_dir=$(pwd)
@@ -41,14 +41,14 @@ if [ $(uname -s) = "Linux" ]; then
        git wget ca-certificates m4 \
        patch unzip libgtk2.0-dev \
        valac libgtksourceview2.0-dev \
-       cmake build-essential
+       cmake build-essential ninja-build
   
   cd /tmp
-  dl_and_unzip_llvm-clang Linux ab42b50fd7fbd59254d3a8aef5473a5c6ceb9ca3508f31c76d95ee5d31268291
-  dl_and_unzip_vfdeps https://github.com/verifast/vfdeps/releases/download/21.11/$VFDEPS_NAME-linux.txz a4298c2ba2d969197db0c47379630223a2d282fe40394d22a708709a
+  dl_and_unzip_llvm-clang Linux f39cc6feb96ebbc5cf7cb39f304b3bf7484a32842da4859441da6f983c43f22a
+  dl_and_unzip_vfdeps https://github.com/verifast/vfdeps/releases/download/23.04/$VFDEPS_NAME-linux.txz 9d108282a8a94526f8d043c3e2e4c3cac513788a42fa8d6964ee4937
 
-  cd $script_dir/src/cxx_frontend/ast_exporter/build
-  cmake -DLLVM_INSTALL_DIR=/tmp/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/tmp/$VFDEPS_NAME -DCMAKE_BUILD_TYPE=Release ..
+  cd $script_dir/src/cxx_frontend/ast_exporter
+  cmake -S . -B build -G Ninja -DLLVM_INSTALL_DIR=/tmp/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/tmp/$VFDEPS_NAME -DCMAKE_BUILD_TYPE=Release
 
 
 elif [ $(uname -s) = "Darwin" ]; then
@@ -70,17 +70,18 @@ elif [ $(uname -s) = "Darwin" ]; then
   brewinstall gtksourceview
   brewinstall vala
   brewinstall cmake
+  brewinstall ninja
   export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig
   sudo mkdir /usr/local/$VFDEPS_NAME
   sudo mkdir /usr/local/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION
   sudo chown -R $(whoami):admin /usr/local/*
 
   cd /usr/local
-  dl_and_unzip_llvm-clang MacOS 365648cc3fea920b49dc262b13a19d64896d873c1ceaa40d3da37c71c8201168
-  dl_and_unzip_vfdeps https://github.com/verifast/vfdeps/releases/download/21.11/$VFDEPS_NAME-macos.txz f47a09659ab3a699ba63daaa666e0ee9fc4fe28a3b186c0badc8834a
+  dl_and_unzip_llvm-clang MacOS 77474d414aa7ddc4e68bc00525a8dccec284c9936c45f6241157070dc5dfdfd6
+  dl_and_unzip_vfdeps https://github.com/verifast/vfdeps/releases/download/23.04/$VFDEPS_NAME-macos.txz a43ad92202761103a03400d78679a94838eaad44567c69b94eedd10d
 
-  cd $script_dir/src/cxx_frontend/ast_exporter/build
-  cmake -DLLVM_INSTALL_DIR=/usr/local/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/usr/local/$VFDEPS_NAME -DCMAKE_BUILD_TYPE=Release ..
+  cd $script_dir/src/cxx_frontend/ast_exporter
+  cmake -S . -B build -G Ninja -DLLVM_INSTALL_DIR=/usr/local/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/usr/local/$VFDEPS_NAME -DCMAKE_BUILD_TYPE=Release
   
 else
   echo "Your OS is not supported by this script."

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -7,7 +7,7 @@
 c:\cygwin\bin\bash -lc "cygcheck -c -d" 
 
 bitsadmin.exe /transfer "cygwin" https://www.cygwin.com/setup-x86_64.exe %TEMP%\setup-cygwin.exe || exit /b
-%TEMP%\setup-cygwin.exe -B -qnNd -R c:/cygwin64 -l c:/cygwin64/var/cache/setup -s http://ftp.inf.tu-dresden.de/software/windows/cygwin32/ -P p7zip -P cygutils-extra -P make -P patch -P rlwrap -P libreadline6 -P diffutils -P wget -P cmake -P ninja || exit /b
+%TEMP%\setup-cygwin.exe -B -qnNd -R c:/cygwin64 -l c:/cygwin64/var/cache/setup -s http://ftp.inf.tu-dresden.de/software/windows/cygwin32/ -P p7zip -P cygutils-extra -P mingw64-x86_64-gcc-g++ -P make -P patch -P rlwrap -P libreadline6 -P diffutils -P wget -P cmake -P ninja || exit /b
 
 @rem Add ",noacl" to prevent cygwin from messing with Windows file permissions
 echo none /cygdrive cygdrive binary,posix=0,user,noacl 0 0 > c:\cygwin64\etc\fstab || exit /b

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -7,14 +7,11 @@
 c:\cygwin\bin\bash -lc "cygcheck -c -d" 
 
 bitsadmin.exe /transfer "cygwin" https://www.cygwin.com/setup-x86_64.exe %TEMP%\setup-cygwin.exe || exit /b
-%TEMP%\setup-cygwin.exe -B -qnNd -R c:/cygwin64 -l c:/cygwin64/var/cache/setup -s http://ftp.inf.tu-dresden.de/software/windows/cygwin32/ -P p7zip -P cygutils-extra -P make -P mingw64-i686-gcc-g++ -P mingw64-i686-gcc-core -P mingw64-i686-gcc -P patch -P rlwrap -P libreadline6 -P diffutils -P mingw64-i686-binutils -P wget || exit /b
+%TEMP%\setup-cygwin.exe -B -qnNd -R c:/cygwin64 -l c:/cygwin64/var/cache/setup -s http://ftp.inf.tu-dresden.de/software/windows/cygwin32/ -P p7zip -P cygutils-extra -P make -P patch -P rlwrap -P libreadline6 -P diffutils -P wget -P cmake -P ninja || exit /b
 
 @rem Add ",noacl" to prevent cygwin from messing with Windows file permissions
 echo none /cygdrive cygdrive binary,posix=0,user,noacl 0 0 > c:\cygwin64\etc\fstab || exit /b
 
 for /f "TOKENS=* USEBACKQ" %%f in (`cd`) do set VFWORKDIR=%%f
-
-@rem set MSVC environment variables
-call vcvarsall.bat x86
 
 c:\cygwin64\bin\bash -lc "cd ""$VFWORKDIR"" && bash setup-windows.sh" || exit /b

--- a/setup-windows.sh
+++ b/setup-windows.sh
@@ -19,18 +19,13 @@ dl_and_unzip() {
 }
 
 script_dir=$(pwd)
-MSVC_CACHE_FILEPATH=$script_dir/src/cxx_frontend/ast_exporter/MSVC_CACHE
 
 cd /cygdrive/c
-dl_and_unzip https://github.com/NielsMommen/vf-llvm-clang-build/releases/download/v1.0.0/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION-Windows.tar.gz B0D469554382EB68DB0E754DDED1AE49734FE837E6A768CAEA85184E5BEE0405 256 z
-dl_and_unzip https://github.com/verifast/vfdeps-win/releases/download/21.11/vfdeps-fdd90f3-win.txz 5e7adb1f3fabe8d5709d3e5ab7dbf2e3c276cbd28c2d8e1142aedb52 224 j
+dl_and_unzip https://github.com/NielsMommen/vf-llvm-clang-build/releases/download/v2.0.3/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION-Windows-MinGW-x86_64.tar.gz 0379947ECC2F475ECA7A876C858910DEAE507C2588BC8534935AE76C233AA49F 256 z
+dl_and_unzip https://github.com/verifast/vfdeps-win/releases/download/23.04/vfdeps-$VFDEPS_NAME-win.txz 63a593c235fbcb4d86c4cbe821aca1a943873daadfbbc1af37f0bb3f 224 j
 
-# $VCINSTALLDIR and $VCToolsRedistDir are set by invoking vcvarsall.bat in setup-windows.bat
-echo VCVARSALL_BAT_DIR="\"$VCINSTALLDIR\Auxiliary\Build\"" > $MSVC_CACHE_FILEPATH
-echo MSVC_REDIST_DIR="\"$VCToolsRedistDir\x86\Microsoft.VC142.CRT\"" >> $MSVC_CACHE_FILEPATH
-
-cd $script_dir/src/cxx_frontend/ast_exporter/build
-cmd /C "cmake -DLLVM_INSTALL_DIR=C:/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=C:/vfdeps -A Win32 -Thost=x64 .."
+cd $script_dir/src/cxx_frontend/ast_exporter
+cmake -S . -B build -G ninja -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_BUILD_TYPE=Release -DLLVM_INSTALL_DIR=/cygdrive/c/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/cygdrive/c/vfdeps
 
 echo 'export PATH="/cygdrive/c/vfdeps/bin:$PATH"' >> ~/.bash_profile
       export PATH="/cygdrive/c/vfdeps/bin:$PATH"

--- a/setup-windows.sh
+++ b/setup-windows.sh
@@ -22,7 +22,7 @@ script_dir=$(pwd)
 
 cd /cygdrive/c
 dl_and_unzip https://github.com/NielsMommen/vf-llvm-clang-build/releases/download/v2.0.3/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION-Windows-MinGW-x86_64.tar.gz 0379947ECC2F475ECA7A876C858910DEAE507C2588BC8534935AE76C233AA49F 256 z
-dl_and_unzip https://github.com/verifast/vfdeps-win/releases/download/23.04/$VFDEPS_NAME-win.txz 63a593c235fbcb4d86c4cbe821aca1a943873daadfbbc1af37f0bb3f 224 j
+dl_and_unzip https://github.com/verifast/vfdeps-win/releases/download/23.04/vfdeps-e62a07d-win.txz 63a593c235fbcb4d86c4cbe821aca1a943873daadfbbc1af37f0bb3f 224 j
 
 cd $script_dir/src/cxx_frontend/ast_exporter
 cmake -S . -B build -G ninja -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_BUILD_TYPE=Release -DLLVM_INSTALL_DIR=/cygdrive/c/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/cygdrive/c/vfdeps

--- a/setup-windows.sh
+++ b/setup-windows.sh
@@ -22,7 +22,7 @@ script_dir=$(pwd)
 
 cd /cygdrive/c
 dl_and_unzip https://github.com/NielsMommen/vf-llvm-clang-build/releases/download/v2.0.3/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION-Windows-MinGW-x86_64.tar.gz 0379947ECC2F475ECA7A876C858910DEAE507C2588BC8534935AE76C233AA49F 256 z
-dl_and_unzip https://github.com/verifast/vfdeps-win/releases/download/23.04/vfdeps-$VFDEPS_NAME-win.txz 63a593c235fbcb4d86c4cbe821aca1a943873daadfbbc1af37f0bb3f 224 j
+dl_and_unzip https://github.com/verifast/vfdeps-win/releases/download/23.04/$VFDEPS_NAME-win.txz 63a593c235fbcb4d86c4cbe821aca1a943873daadfbbc1af37f0bb3f 224 j
 
 cd $script_dir/src/cxx_frontend/ast_exporter
 cmake -S . -B build -G ninja -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_BUILD_TYPE=Release -DLLVM_INSTALL_DIR=/cygdrive/c/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/cygdrive/c/vfdeps

--- a/setup-windows.sh
+++ b/setup-windows.sh
@@ -25,7 +25,7 @@ dl_and_unzip https://github.com/NielsMommen/vf-llvm-clang-build/releases/downloa
 dl_and_unzip https://github.com/verifast/vfdeps-win/releases/download/23.04/vfdeps-e62a07d-win.txz 63a593c235fbcb4d86c4cbe821aca1a943873daadfbbc1af37f0bb3f 224 j
 
 cd $script_dir/src/cxx_frontend/ast_exporter
-cmake -S . -B build -G ninja -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_BUILD_TYPE=Release -DLLVM_INSTALL_DIR=/cygdrive/c/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/cygdrive/c/vfdeps
+cmake -S . -B build -G Ninja -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_BUILD_TYPE=Release -DLLVM_INSTALL_DIR=/cygdrive/c/vf-llvm-clang-build-$VF_LLVM_CLANG_BUILD_VERSION -DVFDEPS=/cygdrive/c/vfdeps
 
 echo 'export PATH="/cygdrive/c/vfdeps/bin:$PATH"' >> ~/.bash_profile
       export PATH="/cygdrive/c/vfdeps/bin:$PATH"

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -112,7 +112,7 @@ ifdef Z3V4DOT5
   Z3CCOPTS = -cclib "-L $(Z3_DLL_DIR)"
   Z3ARGS_EARLY = -I $(Z3_OCAML) z3ml.cmxa z3$(Z3VERSION)prover.cmx verifastPluginZ3$(Z3VERSION).ml verifastPluginReduxZ3$(Z3VERSION).ml  verifastPluginZ3$(Z3VERSION)Smtlib.ml $(Z3CCOPTS)
   ifeq ($(OS), Windows_NT)
-    Z3_DLL_DEPS_DIR:=/usr/i686-w64-mingw32/sys-root/mingw/bin
+    Z3_DLL_DEPS_DIR:=/usr/x86_64-w64-mingw32/sys-root/mingw/bin
     LDLPATH:=$(shell pwd)/../bin
     VERIFAST := $(LDLPATHVAR)=${LDLPATH}:$$$(LDLPATHVAR) ../bin/verifast
   else ifeq ($(OS), Darwin)
@@ -156,7 +156,7 @@ clean::
 	echo > ../lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 
 ../bin/libz3.dll:
-	cp $(Z3_DLL_DIR)/libz3.dll $(Z3_DLL_DEPS_DIR)/libwinpthread-1.dll $(Z3_DLL_DEPS_DIR)/libgomp-1.dll $(Z3_DLL_DEPS_DIR)/libgcc_s_sjlj-1.dll ../bin
+	cp $(Z3_DLL_DIR)/libz3.dll $(Z3_DLL_DEPS_DIR)/libwinpthread-1.dll $(Z3_DLL_DEPS_DIR)/libgomp-1.dll $(Z3_DLL_DEPS_DIR)/libgcc_s_seh-1.dll ../bin
 
 ../bin/libz3.so:
 	cp $(Z3_DLL_DIR)/libz3.so ../bin
@@ -183,11 +183,6 @@ OCAML        = ${OCAMLBIN}/ocaml
 OCAMLC       = $(firstword $(wildcard ${OCAMLBIN}/ocamlc.opt ${OCAMLBIN}/ocamlc))
 OCAMLOPT     = $(firstword $(wildcard ${OCAMLBIN}/ocamlopt.opt ${OCAMLBIN}/ocamlopt))
 OCAMLDEP     = $(firstword $(wildcard ${OCAMLBIN}/ocamldep.opt ${OCAMLBIN}/ocamldep))
-ifeq ($(OS), Windows_NT)
-  CAMLP4O    = camlp4o.opt
-else
-  CAMLP4O      = $(firstword $(wildcard ${OCAMLBIN}/camlp4o.opt ${OCAMLBIN}/camlp4o))
-endif
 
 # Do we build with "-I ./linux" or "-I ./win":
 ifeq ($(OS), Windows_NT)
@@ -280,8 +275,8 @@ clean::
 SET_LDD    = export CAML_LD_LIBRARY_PATH="$$CAML_LD_LIBRARY_PATH:$$GTKSOURCEVIEW_LIBS"
 SET_ENV    = export PATH="$(CWD)/../bin/:$(OCAMLBIN):$$PATH"; \
              export $(LDLPATHVAR)="$(LDLPATH):$$$(LDLPATHVAR)"
-COMPILE    = ocamlfind ocamlopt $(OCAMLCFLAGS)
-COMPILE_BC = ocamlfind ocamlc $(OCAMLCFLAGS)
+COMPILE    = ocamlfind ocamlopt $(OCAMLCFLAGS) -package ppx_parser,camlp-streams
+COMPILE_BC = ocamlfind ocamlc $(OCAMLCFLAGS) -package ppx_parser,camlp-streams
 
 STDLIB = ../bin/crt.dll.vfmanifest
 #sequence is important, it presents dependencies in command line of VeriFast
@@ -337,20 +332,20 @@ clean::
 
 %.cmi: %.mli
 	@echo "  OCAMLOPT " $@
-	$(COMPILE) $(INCLUDES) -c -package num $*.mli
+	$(COMPILE) $(INCLUDES) -c -package num,camlp-streams $*.mli
 clean::
 	rm -f *.cmi
 
 %.cmx: %.ml $(INCLUDE_OS_DIR)/Perf.cmxa
 	@echo "  OCAMLOPT " $@
-	$(COMPILE) -thread -c -w p -warn-error +F+S+U -c $(INCLUDES) -pp ${CAMLP4O} -package num $*.ml
+	$(COMPILE) -thread -c -w p -warn-error +F+S+U -c $(INCLUDES) -package num,camlp-streams $*.ml
 clean::
 	rm -f *.cmx
 	rm -f *.o
 
 %.cmo: %.ml
 	@echo "    OCAMLC " $@
-	$(COMPILE_BC) -thread $(INCLUDES) -I $(Z3_OCAML) -pp $(CAMLP4O) -o $@ -c $*.ml
+	$(COMPILE_BC) -thread $(INCLUDES) -I $(Z3_OCAML) -o $@ -c $*.ml
 clean::
 	rm -f *.cmo
 	cd java_frontend && rm -f *.cmo
@@ -436,11 +431,11 @@ ifndef WITHOUT_GTKSOURCEVIEW
 	make -C linemarks OCAMLOPT=${OCAMLOPT} OCAMLCFLAGS="${OCAMLCFLAGS}" LABLGTK_FLAGS="$(LABLGTK_FLAGS_)" linemarks.cmxa
 endif
 	$(SET_LDD); $(COMPILE) -thread -c -w p -warn-error +F+S+U -c $(INCLUDES) \
-	-pp ${CAMLP4O} -package num,threads $(LABLGTK_FLAGS) $(GTKSOURCEVIEW_LFLAGS) vfide.ml
+	-package num,threads $(LABLGTK_FLAGS) $(GTKSOURCEVIEW_LFLAGS) vfide.ml
 
 VERIFAST_PLUGINS=Redux Cvc4 ExternalZ3 ReduxSmtlib
 
-OCAMLOPT_LINKFLAGS = -package num,unix,str -linkpkg
+OCAMLOPT_LINKFLAGS = -package num,unix,str,camlp-streams -linkpkg
 ifeq ($(OS), Darwin)
   OCAMLOPT_LINKFLAGS += -cclib "-Xlinker -headerpad_max_install_names"
 else ifeq ($(OS), Linux)
@@ -452,7 +447,7 @@ endif
 ifndef WITHOUT_GTKSOURCEVIEW
 	cd linemarks; make linemarks.cmxa
 endif
-	$(SET_LDD); $(COMPILE) $(OCAMLOPT_LINKFLAGS) $(CAPNP_LINK_FLAGS) -warn-error F -pp ${CAMLP4O} -o ../bin/vfide$(DOTEXE)	\
+	$(SET_LDD); $(COMPILE) $(OCAMLOPT_LINKFLAGS) $(CAPNP_LINK_FLAGS) -warn-error F -o ../bin/vfide$(DOTEXE)	\
 	  $(LABLGTK_FLAGS) $(GTKSOURCEVIEW_LFLAGS) \
 	  $(INCLUDES) Perf.cmxa proverapi.cmx dynlink.cmxa \
 	  util.cmx ast.cmx stats.cmx lexer.cmx \
@@ -477,7 +472,7 @@ vfide: ../bin/vfide$(DOTEXE) $(STDLIB)
 
 ../bin/verifast$(DOTEXE): vfconsole.cmx $(VERIFAST_PLUGINS:%=verifastPlugin%.cmx) $(Z3DEPS)
 	@echo "  OCAMLOPT " $@
-	$(COMPILE) $(OCAMLOPT_LINKFLAGS) $(CAPNP_LINK_FLAGS) -warn-error F -pp ${CAMLP4O} -o ../bin/verifast$(DOTEXE) \
+	$(COMPILE) $(OCAMLOPT_LINKFLAGS) $(CAPNP_LINK_FLAGS) -warn-error F -o ../bin/verifast$(DOTEXE) \
 	$(INCLUDES) Perf.cmxa proverapi.cmx \
 	  util.cmx ast.cmx stats.cmx lexer.cmx parser.cmx \
 	  ${JAVA_FE_INCLS} $(CXX_FE_DEPS) verifast0.cmx verifast1.cmx assertions.cmx \
@@ -526,7 +521,7 @@ VERIFAST_BC_INCLUDES = -I $(INCLUDE_DIR_NUM) -I $(INCLUDE_DIR_THREADS) -I $(INCL
 # As I said: only tested on macOS.
 ../bin/verifast.bc: linux/Perf.cma $(VERIFAST_BC_OBJECTS)
 	@echo "    OCAMLC " $@
-	$(COMPILE_BC) $(OCAMLOPT_LINKFLAGS) -warn-error F -pp ${CAMLP4O} -o $@ \
+	$(COMPILE_BC) $(OCAMLOPT_LINKFLAGS) -warn-error F -o $@ \
 		$(VERIFAST_BC_INCLUDES) \
 		threads.cma z3ml.cma linux/Perf.cma \
 		$(VERIFAST_BC_OBJECTS)
@@ -537,7 +532,7 @@ clean::
 
 ../bin/explorer$(DOTEXE): explorer.cmx $(VERIFAST_PLUGINS:%=verifastPlugin%.cmx) $(Z3DEPS)
 	@echo "  OCAMLOPT " $@
-	$(COMPILE) $(OCAMLOPT_LINKFLAGS) $(CAPNP_LINK_FLAGS) -warn-error F -pp ${CAMLP4O} -o ../bin/explorer$(DOTEXE) \
+	$(COMPILE) $(OCAMLOPT_LINKFLAGS) $(CAPNP_LINK_FLAGS) -warn-error F -o ../bin/explorer$(DOTEXE) \
 	$(INCLUDES) Perf.cmxa proverapi.cmx \
 	  util.cmx ast.cmx stats.cmx lexer.cmx parser.cmx \
 	  ${JAVA_FE_INCLS} $(CXX_FE_DEPS) verifast0.cmx verifast1.cmx assertions.cmx \
@@ -662,7 +657,7 @@ depend: $(META_DEPS)
 	@echo "  OCAMLDEP "
 	echo "# These dependencies are automatically generated." > .depend
 	echo "# Do not edit by hand. To generate, run 'make depend'." >> .depend
-	$(OCAMLDEP) -slash -pp ${CAMLP4O} $(INCLUDES) $(META_DEPS) >> .depend
+	$(OCAMLDEP) -slash $(INCLUDES) $(META_DEPS) >> .depend
 .PHONY: depend
 
 .depend:
@@ -684,8 +679,8 @@ release_core:  build-cxx-ast-exporter test build
 	cp -R ../bin verifast-$(VFVERSION)
 ifeq ($(OS), Windows_NT)
 	cd $(GTK)/bin && cp -v \
-    FREETYPE6.DLL \
-    INTL.DLL \
+    LIBFREETYPE-6.DLL \
+    LIBINTL-8.DLL \
     LIBATK-1.0-0.DLL \
     LIBCAIRO-2.DLL \
     LIBEXPAT-1.DLL \

--- a/src/cxx_frontend/Makefile
+++ b/src/cxx_frontend/Makefile
@@ -45,7 +45,7 @@ $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.h $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.c++ &:
 	cp -f $< $@
 
 ifeq ($(OS), Windows_NT)
-../bin/vf-cxx-ast-exporter$(DOTEXE): ..bin/libstdc++-6.dll
+../bin/vf-cxx-ast-exporter$(DOTEXE): ../bin/libstdc++-6.dll
 endif
 ../bin/vf-cxx-ast-exporter$(DOTEXE): $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.h $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.c++ $(CXX_FE_AST_EXPORTER_DIR)/*.h $(CXX_FE_AST_EXPORTER_DIR)/*.cpp
 	@echo "  MAKE " $@

--- a/src/cxx_frontend/Makefile
+++ b/src/cxx_frontend/Makefile
@@ -12,12 +12,8 @@ CAPNP_LINK_FLAGS	= -package capnp,capnp.unix
 
 
 ifeq ($(OS), Windows_NT)
-include $(CXX_FE_AST_EXPORTER_DIR)/MSVC_CACHE
 CAPNP_INCLUDE := "$(shell cygpath -w $(CAPNP_INCLUDE))"
 CAPNP_LIBS := "$(shell cygpath -w $(CAPNP_LIBS))"
-BUILD_TYPE ?= Release
-# cd to the dir where vcvarsall is located, because it could contain spaces and cygwin/make would not recognise the path properly
-SET_MSV_ENV = pushd "%CD%" && cd /D "$(VCVARSALL_BAT_DIR)" && vcvarsall.bat x86 && popd
 endif
 
 # we specify rules here if we don't want the makefile in src to compile specific files
@@ -45,22 +41,16 @@ CXX_FE_DEPS = $(CXX_FE_STUBS_DIR)/stubs_ast.cmx $(CXX_FE_DIR)/cxx_annotation_par
 $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.h $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.c++ &:: $(CXX_FE_STUBS_DIR)/stubs_ast.capnp
 	DYLD_LIBRARY_PATH=$(CAPNP_LIBS) capnp compile -I $(CAPNP_INCLUDE) -o c++ $<
 
-..bin/vcruntime140.dll ../bin/msvcp140.dll:
-	cp "$(shell cygpath ""$(MSVC_REDIST_DIR)"")/$(notdir $@)" ../bin
+../bin/libstdc++-6.dll: /usr/x86_64-w64-mingw32/sys-root/mingw/bin/libstdc++-6.dll
+	cp -f $< $@
 
 ifeq ($(OS), Windows_NT)
-../bin/vf-cxx-ast-exporter$(DOTEXE): ..bin/vcruntime140.dll ../bin/msvcp140.dll
+../bin/vf-cxx-ast-exporter$(DOTEXE): ..bin/libstdc++-6.dll
 endif
 ../bin/vf-cxx-ast-exporter$(DOTEXE): $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.h $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.c++ $(CXX_FE_AST_EXPORTER_DIR)/*.h $(CXX_FE_AST_EXPORTER_DIR)/*.cpp
 	@echo "  MAKE " $@
-	@echo $(VC_REDIST_PATH_UNIX)
-ifeq ($(OS), Windows_NT)
-	cd $(CXX_FE_AST_EXPORTER_DIR)/build && cmd /C "$(SET_MSV_ENV) && msbuild VF_AST_Exporter.sln -p:Configuration=$(BUILD_TYPE) -p:Platform=Win32 -m"
-	cd $(CXX_FE_AST_EXPORTER_DIR)/build && mv $(BUILD_TYPE)/vf-cxx-ast-exporter$(DOTEXE) ../../../$@
-else
-	cd $(CXX_FE_AST_EXPORTER_DIR)/build && make -j$(NUMCPU)
+	cd $(CXX_FE_AST_EXPORTER_DIR) && cmake --build build
 	cd $(CXX_FE_AST_EXPORTER_DIR)/build && mv vf-cxx-ast-exporter$(DOTEXE) ../../../$@
-endif
 
 stubs: $(CXX_FE_STUBS_DIR)/stubs_ast.mli $(CXX_FE_STUBS_DIR)/stubs_ast.ml $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.h $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.c++
 .PHONY: stubs
@@ -68,11 +58,7 @@ stubs: $(CXX_FE_STUBS_DIR)/stubs_ast.mli $(CXX_FE_STUBS_DIR)/stubs_ast.ml $(CXX_
 clean::
 	rm -f $(CXX_FE_STUBS_DIR)/stubs_ast.capnp.*
 	rm -f ../bin/vf-cxx-ast-exporter$(DOTEXE)
-ifeq ($(OS), Windows_NT)
-	cd $(CXX_FE_AST_EXPORTER_DIR)/build && cmd /C "$(SET_MSV_ENV) && msbuild VF_AST_Exporter.sln -p:Configuration=$(BUILD_TYPE) -p:Platform=Win32 -t:Clean -m"
-else
-	cd $(CXX_FE_AST_EXPORTER_DIR)/build && make clean
-endif
+	cd $(CXX_FE_AST_EXPORTER_DIR) && cmake --build build --target clean
 	rm -f $(CXX_FE_DIR)/*.cm* $(CXX_FE_STUBS_DIR)/*.cm* $(CXX_FE_DIR)/*.cm*
 	rm -f $(CXX_FE_DIR)/*.o $(CXX_FE_STUBS_DIR)/*.o $(CXX_FE_DIR)/*.o
 	rm -f $(CXX_FE_STUBS_DIR)/stubs_ast.ml*

--- a/src/cxx_frontend/ast_exporter/AstSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/AstSerializer.cpp
@@ -163,7 +163,7 @@ void AstSerializer::serializeTU(stubs::TU::Builder &builder,
   // Serialize ghost includes at start of file
   for (size_t i(0); i < fileEntries.size(); ++i) {
     auto fileEntry = fileEntries[i];
-    if (fileEntry && fileEntry->isValid()) {
+    if (fileEntry) {
       anns.clear();
       m_store.getGhostIncludeSequence(fileEntry, anns, m_SM);
       for (auto &ann : anns) {

--- a/src/cxx_frontend/ast_exporter/CMakeLists.txt
+++ b/src/cxx_frontend/ast_exporter/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(vf-cxx-ast-exporter
 )
 
 if(NOT LLVM_ENABLE_RTTI)
-  target_compile_options(vf-cxx-ast-exporter PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,/GR-,-fno-rtti>)
+  target_compile_options(vf-cxx-ast-exporter PRIVATE -fno-rtti)
 endif()
 
 llvm_map_components_to_libnames(LLVM_LIBS support)
@@ -56,7 +56,7 @@ foreach(LIB IN LISTS CAPNP_LIBS KJ_LIBS)
   list(APPEND LIBS_PATHS ${${_LIB_VAR}})
 endforeach()
 
-set_property(TARGET vf-cxx-ast-exporter PROPERTY CXX_STANDARD 14)
+set_property(TARGET vf-cxx-ast-exporter PROPERTY CXX_STANDARD 17)
 
 target_include_directories(vf-cxx-ast-exporter
   PRIVATE

--- a/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.cpp
+++ b/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.cpp
@@ -113,7 +113,7 @@ void ContextFreePPCallbacks::FileSkipped(
 void ContextFreePPCallbacks::InclusionDirective(
     clang::SourceLocation hashLoc, const clang::Token &includeTok,
     clang::StringRef fileName, bool isAngled,
-    clang::CharSourceRange filenameRange, const clang::FileEntry *file,
+    clang::CharSourceRange filenameRange, clang::OptionalFileEntryRef file,
     clang::StringRef searchPath, clang::StringRef relativePath,
     const clang::Module *imported, clang::SrcMgr::CharacteristicKind fileType) {
   m_context.addRealInclDirective(filenameRange.getAsRange(), fileName, *file,

--- a/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.h
+++ b/src/cxx_frontend/ast_exporter/ContextFreePPCallbacks.h
@@ -85,7 +85,7 @@ public:
                           const clang::Token &IncludeTok,
                           clang::StringRef FileName, bool IsAngled,
                           clang::CharSourceRange FilenameRange,
-                          const clang::FileEntry *File,
+                          clang::OptionalFileEntryRef File,
                           clang::StringRef SearchPath,
                           clang::StringRef RelativePath,
                           const clang::Module *Imported,

--- a/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
@@ -77,6 +77,9 @@ bool DeclSerializer::VisitVarDecl(const clang::VarDecl *decl) {
       CASE_INIT(CInit, C_INIT)
       CASE_INIT(CallInit, CALL_INIT)
       CASE_INIT(ListInit, LIST_INIT)
+      case clang::VarDecl::InitializationStyle::ParenListInit:
+        errors().newError(decl->getSourceRange(), getSourceManager())
+          << "Parenthesized list-initialization is not supported.";
     }
 
 #undef CASE_INIT

--- a/src/cxx_frontend/ast_exporter/FixedWidthInt.h
+++ b/src/cxx_frontend/ast_exporter/FixedWidthInt.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Optional.h"
 
 namespace vf {

--- a/src/cxx_frontend/ast_exporter/InclusionContext.h
+++ b/src/cxx_frontend/ast_exporter/InclusionContext.h
@@ -34,14 +34,14 @@ public:
   void startInclusion(const clang::FileEntry &fileEntry);
 
   void addRealInclDirective(clang::SourceRange range, clang::StringRef fileName,
-                            const clang::FileEntry &fileEntry, bool isAngled) {
+                            const clang::FileEntryRef fileEntry, bool isAngled) {
     currentInclusion()->addRealInclDirective(range, fileName,
                                              fileEntry.getUID(), isAngled);
   }
 
   void addGhostInclDirective(const clang::FileEntry *entry, Annotation &ann) {
     auto uid = entry->getUID();
-    assert(m_includesMap.contains(uid) &&
+    assert(m_includesMap.find(uid) != m_includesMap.edn() &&
            "File has not been preprocessed and added to inclusion context");
     m_includesMap.at(uid).addGhostInclDirective(ann);
   }

--- a/src/cxx_frontend/ast_exporter/LocUtil.cpp
+++ b/src/cxx_frontend/ast_exporter/LocUtil.cpp
@@ -10,7 +10,7 @@ bool decomposeLocToLCF(const clang::SourceLocation &loc,
   auto decLoc = SM.getDecomposedLoc(SM.getSpellingLoc(loc));
   auto fileEntry = SM.getFileEntryForID(decLoc.first);
 
-  if (!fileEntry || !fileEntry->isValid())
+  if (!fileEntry)
     return false;
 
   auto uid = fileEntry->getUID();

--- a/src/cxx_frontend/ast_exporter/NodeSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeSerializer.h
@@ -39,7 +39,7 @@ protected:
     return getContext().getSourceManager();
   }
 
-  LLVM_ATTRIBUTE_NORETURN void unsupported(const clang::SourceRange range,
+  [[noreturn]] void unsupported(const clang::SourceRange range,
                                            const llvm::StringRef nodeName,
                                            const llvm::StringRef className) {
     llvm::report_fatal_error(nodeName + " of type '" + className + "' at '" +
@@ -47,7 +47,7 @@ protected:
                              "' is not supported.");
   }
 
-  LLVM_ATTRIBUTE_NORETURN void unsupported(const llvm::StringRef nodeName,
+  [[noreturn]] void unsupported(const llvm::StringRef nodeName,
                                            const llvm::StringRef className) {
     llvm::report_fatal_error(nodeName + " of type '" + className +
                              "' is not supported.");

--- a/src/explorer.ml
+++ b/src/explorer.ml
@@ -48,9 +48,9 @@ let _ =
       in
       let (loc, token_stream) = make_preprocessor (fun _ _ -> ()) make_lexer path verbose include_paths dataModel define_macros in
       let p =
-        parser
-          [< (headers, _) = parse_include_directives verbose enforceAnnotations dataModel; 
-                              ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:false; '(_, Eof) >] -> (headers, [PackageDecl(dummy_loc,"",[],ds)])
+        function%parser
+          [ [%l (headers, _d) = parse_include_directives verbose enforceAnnotations dataModel]; 
+                              [%l ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:false]; (_, Eof) ] -> (headers, [PackageDecl(dummy_loc,"",[],ds)])
       in
       try
         p token_stream

--- a/src/lexer.ml
+++ b/src/lexer.ml
@@ -1046,106 +1046,106 @@ let rec
 and
   parse_operators_rest stream = parse_disj_expr_rest stream
 and
-  parse_disj_expr = parser
-  [< e0 = parse_conj_expr; e = parse_disj_expr_rest e0 >] -> e
+  parse_disj_expr = function%parser
+  [ parse_conj_expr as e0; [%l e = parse_disj_expr_rest e0] ] -> e
 and
-  parse_conj_expr = parser
-  [< e0 = parse_bitor_expr; e = parse_conj_expr_rest e0 >] -> e
+  parse_conj_expr = function%parser
+  [ parse_bitor_expr as e0; [%l e = parse_conj_expr_rest e0] ] -> e
 and
-  parse_bitor_expr = parser
-  [< e0 = parse_bitxor_expr; e = parse_bitor_expr_rest e0 >] -> e
+  parse_bitor_expr = function%parser
+  [ parse_bitxor_expr as e0; [%l e = parse_bitor_expr_rest e0] ] -> e
 and
-  parse_bitxor_expr = parser
-  [< e0 = parse_bitand_expr; e = parse_bitxor_expr_rest e0 >] -> e
+  parse_bitxor_expr = function%parser
+  [ parse_bitand_expr as e0; [%l e = parse_bitxor_expr_rest e0] ] -> e
 and
-  parse_bitand_expr = parser
-  [< e0 = parse_expr_rel; e = parse_bitand_expr_rest e0 >] -> e
+  parse_bitand_expr = function%parser
+  [ parse_expr_rel as e0; [%l e = parse_bitand_expr_rest e0] ] -> e
 and
-  parse_expr_rel = parser
-  [< e0 = parse_truncating_expr; e = parse_expr_rel_rest e0 >] -> e
+  parse_expr_rel = function%parser
+  [ parse_truncating_expr as e0; [%l e = parse_expr_rel_rest e0] ] -> e
 and
-  parse_truncating_expr = parser
-  [< e = parse_shift >] -> e
+  parse_truncating_expr = function%parser
+  [ parse_shift as e ] -> e
 and
-  parse_shift = parser
-  [< e0 = parse_expr_arith; e = parse_shift_rest e0 >] -> e
+  parse_shift = function%parser
+  [ parse_expr_arith as e0; [%l e = parse_shift_rest e0] ] -> e
 and
-  parse_expr_arith = parser
-  [< e0 = parse_expr_mul; e = parse_expr_arith_rest e0 >] -> e
+  parse_expr_arith = function%parser
+  [ parse_expr_mul as e0; [%l e = parse_expr_arith_rest e0] ] -> e
 and
-  parse_expr_mul = parser
-  [< e0 = parse_expr_suffix; e = parse_expr_mul_rest e0 >] -> e
+  parse_expr_mul = function%parser
+  [ parse_expr_suffix as e0; [%l e = parse_expr_mul_rest e0] ] -> e
 and
-  parse_expr_suffix = parser
-  [< e = parse_expr_primary >] -> e
+  parse_expr_suffix = function%parser
+  [ parse_expr_primary as e ] -> e
 and
-  parse_expr_primary = parser
-  [< '(l, Ident _) >] -> IntLit (l, zero_big_int, false, false, NoLSuffix)
-| [< '(l, Int (n, dec, usuffix, lsuffix, _)) >] -> IntLit (l, n, dec, usuffix, lsuffix)
-| [< '(l, Kwd "-"); '(l, Int (n, dec, usuffix, lsuffix, _)) >] -> IntLit (l, minus_big_int n, dec, usuffix, lsuffix)
-| [< '(l, Kwd "("); e0 = parse_operators; '(_, Kwd ")"); e = parse_operators_rest e0 >] -> e
-| [< '(l, Kwd "!"); e = parse_expr_suffix >] -> Operation(l, Not, [e])
-| [< '(l, Kwd "INT_MIN") >] -> (match dataModel with Some {int_width} -> IntLit (l, min_signed_big_int int_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
-| [< '(l, Kwd "INT_MAX") >] -> (match dataModel with Some {int_width} -> IntLit (l, max_signed_big_int int_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
-| [< '(l, Kwd "UINTPTR_MAX") >] -> (match dataModel with Some {ptr_width} -> IntLit (l, max_unsigned_big_int ptr_width, true, true, NoLSuffix) | _ -> construct_not_supported ())
-| [< '(l, Kwd "CHAR_MIN") >] -> IntLit (l, big_int_of_string "-128", true, false, NoLSuffix)
-| [< '(l, Kwd "CHAR_MAX") >] -> IntLit (l, big_int_of_string "127", true, false, NoLSuffix)
-| [< '(l, Kwd "UCHAR_MAX") >] -> IntLit (l, big_int_of_string "255", true, false, NoLSuffix)
-| [< '(l, Kwd "SHRT_MIN") >] -> IntLit (l, big_int_of_string "-32768", true, false, NoLSuffix)
-| [< '(l, Kwd "SHRT_MAX") >] -> IntLit (l, big_int_of_string "32767", true, false, NoLSuffix)
-| [< '(l, Kwd "USHRT_MAX") >] -> IntLit (l, big_int_of_string "65535", true, false, NoLSuffix)
-| [< '(l, Kwd "UINT_MAX") >] -> (match dataModel with Some {int_width} -> IntLit (l, max_unsigned_big_int int_width, true, true, NoLSuffix) | _ -> construct_not_supported ())
-| [< '(l, Kwd "LLONG_MIN") >] -> IntLit (l, big_int_of_string "-9223372036854775808", true, false, NoLSuffix)
-| [< '(l, Kwd "LLONG_MAX") >] -> IntLit (l, big_int_of_string "9223372036854775807", true, false, NoLSuffix)
-| [< '(l, Kwd "ULLONG_MAX") >] -> IntLit (l, big_int_of_string "18446744073709551615", true, true, NoLSuffix)
-| [< '(l, Kwd "LONG_MIN") >] -> (match dataModel with Some {long_width} -> IntLit (l, min_signed_big_int long_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
-| [< '(l, Kwd "LONG_MAX") >] -> (match dataModel with Some {long_width} -> IntLit (l, max_signed_big_int long_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
-| [< '(l, Kwd "ULONG_MAX") >] -> (match dataModel with Some {long_width} -> IntLit (l, max_unsigned_big_int long_width, true, true, NoLSuffix) | _ -> construct_not_supported ())
+  parse_expr_primary = function%parser
+  [ (l, Ident _) ] -> IntLit (l, zero_big_int, false, false, NoLSuffix)
+| [ (l, Int (n, dec, usuffix, lsuffix, _)) ] -> IntLit (l, n, dec, usuffix, lsuffix)
+| [ (l, Kwd "-"); (l, Int (n, dec, usuffix, lsuffix, _)) ] -> IntLit (l, minus_big_int n, dec, usuffix, lsuffix)
+| [ (l, Kwd "("); parse_operators as e0; (_, Kwd ")"); [%l e = parse_operators_rest e0] ] -> e
+| [ (l, Kwd "!"); parse_expr_suffix as e ] -> Operation(l, Not, [e])
+| [ (l, Kwd "INT_MIN") ] -> (match dataModel with Some {int_width} -> IntLit (l, min_signed_big_int int_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
+| [ (l, Kwd "INT_MAX") ] -> (match dataModel with Some {int_width} -> IntLit (l, max_signed_big_int int_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
+| [ (l, Kwd "UINTPTR_MAX") ] -> (match dataModel with Some {ptr_width} -> IntLit (l, max_unsigned_big_int ptr_width, true, true, NoLSuffix) | _ -> construct_not_supported ())
+| [ (l, Kwd "CHAR_MIN") ] -> IntLit (l, big_int_of_string "-128", true, false, NoLSuffix)
+| [ (l, Kwd "CHAR_MAX") ] -> IntLit (l, big_int_of_string "127", true, false, NoLSuffix)
+| [ (l, Kwd "UCHAR_MAX") ] -> IntLit (l, big_int_of_string "255", true, false, NoLSuffix)
+| [ (l, Kwd "SHRT_MIN") ] -> IntLit (l, big_int_of_string "-32768", true, false, NoLSuffix)
+| [ (l, Kwd "SHRT_MAX") ] -> IntLit (l, big_int_of_string "32767", true, false, NoLSuffix)
+| [ (l, Kwd "USHRT_MAX") ] -> IntLit (l, big_int_of_string "65535", true, false, NoLSuffix)
+| [ (l, Kwd "UINT_MAX") ] -> (match dataModel with Some {int_width} -> IntLit (l, max_unsigned_big_int int_width, true, true, NoLSuffix) | _ -> construct_not_supported ())
+| [ (l, Kwd "LLONG_MIN") ] -> IntLit (l, big_int_of_string "-9223372036854775808", true, false, NoLSuffix)
+| [ (l, Kwd "LLONG_MAX") ] -> IntLit (l, big_int_of_string "9223372036854775807", true, false, NoLSuffix)
+| [ (l, Kwd "ULLONG_MAX") ] -> IntLit (l, big_int_of_string "18446744073709551615", true, true, NoLSuffix)
+| [ (l, Kwd "LONG_MIN") ] -> (match dataModel with Some {long_width} -> IntLit (l, min_signed_big_int long_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
+| [ (l, Kwd "LONG_MAX") ] -> (match dataModel with Some {long_width} -> IntLit (l, max_signed_big_int long_width, true, false, NoLSuffix) | _ -> construct_not_supported ())
+| [ (l, Kwd "ULONG_MAX") ] -> (match dataModel with Some {long_width} -> IntLit (l, max_unsigned_big_int long_width, true, true, NoLSuffix) | _ -> construct_not_supported ())
 and
-  parse_expr_mul_rest e0 = parser
-  [< '(l, Kwd "*"); e1 = parse_expr_suffix; e = parse_expr_mul_rest (Operation (l, Mul, [e0; e1])) >] -> e
-| [< '(l, Kwd "/"); e1 = parse_expr_suffix; e = parse_expr_mul_rest (Operation (l, Div, [e0; e1])) >] -> e
-| [< '(l, Kwd "%"); e1 = parse_expr_suffix; e = parse_expr_mul_rest (Operation (l, Mod, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_expr_mul_rest e0 = function%parser
+  [ (l, Kwd "*"); parse_expr_suffix as e1; [%l e = parse_expr_mul_rest (Operation (l, Mul, [e0; e1]))] ] -> e
+| [ (l, Kwd "/"); parse_expr_suffix as e1; [%l e = parse_expr_mul_rest (Operation (l, Div, [e0; e1]))] ] -> e
+| [ (l, Kwd "%"); parse_expr_suffix as e1; [%l e = parse_expr_mul_rest (Operation (l, Mod, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_expr_arith_rest e0 = parser
-  [< '(l, Kwd "+"); e1 = parse_expr_mul; e = parse_expr_arith_rest (Operation (l, Add, [e0; e1])) >] -> e
-| [< '(l, Kwd "-"); e1 = parse_expr_mul; e = parse_expr_arith_rest (Operation (l, Sub, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_expr_arith_rest e0 = function%parser
+  [ (l, Kwd "+"); parse_expr_mul as e1; [%l e = parse_expr_arith_rest (Operation (l, Add, [e0; e1]))] ] -> e
+| [ (l, Kwd "-"); parse_expr_mul as e1; [%l e = parse_expr_arith_rest (Operation (l, Sub, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_shift_rest e0 = parser
-  [< '(l, Kwd "<<"); e1 = parse_expr_arith; e = parse_shift_rest (Operation (l, ShiftLeft, [e0; e1])) >] -> e
-| [< '(l, Kwd ">>"); e1 = parse_expr_arith; e = parse_shift_rest (Operation (l, ShiftRight, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_shift_rest e0 = function%parser
+  [ (l, Kwd "<<"); parse_expr_arith as e1; [%l e = parse_shift_rest (Operation (l, ShiftLeft, [e0; e1]))] ] -> e
+| [ (l, Kwd ">>"); parse_expr_arith as e1; [%l e = parse_shift_rest (Operation (l, ShiftRight, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_expr_rel_rest e0 = parser
-  [< '(l, Kwd "=="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Eq, [e0; e1])) >] -> e
-| [< '(l, Kwd "!="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Neq, [e0; e1])) >] -> e
-| [< '(l, Kwd "<"); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Lt, [e0; e1])) >] -> e
-| [< '(l, Kwd "<="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Le, [e0; e1])) >] -> e
-| [< '(l, Kwd ">"); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Gt, [e0; e1])) >] -> e
-| [< '(l, Kwd ">="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Ge, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_expr_rel_rest e0 = function%parser
+  [ (l, Kwd "=="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Eq, [e0; e1]))] ] -> e
+| [ (l, Kwd "!="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Neq, [e0; e1]))] ] -> e
+| [ (l, Kwd "<"); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Lt, [e0; e1]))] ] -> e
+| [ (l, Kwd "<="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Le, [e0; e1]))] ] -> e
+| [ (l, Kwd ">"); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Gt, [e0; e1]))] ] -> e
+| [ (l, Kwd ">="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Ge, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_bitand_expr_rest e0 = parser
-  [< '(l, Kwd "&"); e1 = parse_expr_rel; e = parse_bitand_expr_rest (Operation (l, BitAnd, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_bitand_expr_rest e0 = function%parser
+  [ (l, Kwd "&"); parse_expr_rel as e1; [%l e = parse_bitand_expr_rest (Operation (l, BitAnd, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_bitxor_expr_rest e0 = parser
-  [< '(l, Kwd "^"); e1 = parse_bitand_expr; e = parse_bitxor_expr_rest (Operation (l, BitXor, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_bitxor_expr_rest e0 = function%parser
+  [ (l, Kwd "^"); parse_bitand_expr as e1; [%l e = parse_bitxor_expr_rest (Operation (l, BitXor, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_bitor_expr_rest e0 = parser
-  [< '(l, Kwd "|"); e1 = parse_bitxor_expr; e = parse_bitor_expr_rest (Operation (l, BitOr, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_bitor_expr_rest e0 = function%parser
+  [ (l, Kwd "|"); parse_bitxor_expr as e1; [%l e = parse_bitor_expr_rest (Operation (l, BitOr, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_conj_expr_rest e0 = parser
-  [< '(l, Kwd "&&"); e1 = parse_bitor_expr; e = parse_conj_expr_rest (Operation (l, And, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_conj_expr_rest e0 = function%parser
+  [ (l, Kwd "&&"); parse_bitor_expr as e1; [%l e = parse_conj_expr_rest (Operation (l, And, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_disj_expr_rest e0 = parser
-  [< '(l, Kwd "||"); e1 = parse_conj_expr; e = parse_disj_expr_rest (Operation (l, Or, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_disj_expr_rest e0 = function%parser
+  [ (l, Kwd "||"); parse_conj_expr as e1; [%l e = parse_disj_expr_rest (Operation (l, Or, [e0; e1]))] ] -> e
+| [ ] -> e0
 in
 parse_operators
 

--- a/src/linemarks/Makefile
+++ b/src/linemarks/Makefile
@@ -12,7 +12,7 @@ linemarks.cmxa: liblinemarks.a
 	${OCAMLOPT} ${OCAMLCFLAGS} -a -o linemarks.cmxa $(LABLGTK_FLAGS) GtkLineMarks.mli GtkLineMarks.ml GLineMarks.ml -cclib -L$(shell pwd) -cclib -llinemarks -cclib "`pkg-config --libs gtksourceview-2.0`"
 
 ifeq ($(OS), Windows_NT)
-  AR=i686-w64-mingw32-ar
+  AR=x86_64-w64-mingw32-ar
 else
   AR=ar
 endif

--- a/src/linux/caml_stopwatch.c
+++ b/src/linux/caml_stopwatch.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 
 value caml_stopwatch_getpid() {
-    return copy_int32(getpid());
+    return caml_copy_int32(getpid());
 }
 
 value caml_lock_process_to_processor_1() {
@@ -21,7 +21,7 @@ value caml_lock_process_to_processor_1() {
 }
 
 value caml_stopwatch_processor_ticks() {
-    return copy_int64(__rdtsc());
+    return caml_copy_int64(__rdtsc());
 }
 
 struct stopwatch {
@@ -54,5 +54,5 @@ value caml_stopwatch_stop(value stopwatch) {
 
 value caml_stopwatch_ticks(value stopwatch) {
     struct stopwatch *s = (void *)stopwatch;
-    return copy_int64(s->counter);
+    return caml_copy_int64(s->counter);
 }

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -160,10 +160,10 @@ let file_type path =
 let lang_dialect path =
   let _, d = file_specs path in
   d
-let opt p = parser [< v = p >] -> Some v | [< >] -> None
-let rec comma_rep p = parser [< '(_, Kwd ","); v = p; vs = comma_rep p >] -> v::vs | [< >] -> []
-let rep_comma p = parser [< v = p; vs = comma_rep p >] -> v::vs | [< >] -> []
-let rec rep p = parser [< v = p; vs = rep p >] -> v::vs | [< >] -> []
+let opt p = function%parser [ p as v ] -> Some v | [ ] -> None
+let rec comma_rep p = function%parser [ (_, Kwd ","); p as v; [%l vs = comma_rep p] ] -> v::vs | [ ] -> []
+let rep_comma p = function%parser [ p as v; [%l vs = comma_rep p] ] -> v::vs | [ ] -> []
+let rec rep p = function%parser [ p as v; [%l vs = rep p] ] -> v::vs | [ ] -> []
 let rec adjacent_locs l0 l1 =
   match l0, l1 with
     MacroExpansion (lcall1, lbody1), MacroExpansion (lcall2, lbody2) when lcall1 == lcall2 ->
@@ -173,7 +173,7 @@ let rec adjacent_locs l0 l1 =
     let (sp1, _) = root_caller_token l1 in
     sp0 = sp1
 let parse_angle_brackets l0 p =
-  parser [< '(l1, Kwd "<") when adjacent_locs l0 l1; v = p; '(_, Kwd ">") >] -> v
+  function%parser [ (l1, Kwd "<"); p as v; (_, Kwd ">") ] when adjacent_locs l0 l1 -> v
 
 (* Does a two-token lookahead.
    Succeeds if it sees a /*@ followed by something that matches [p].
@@ -211,26 +211,26 @@ module Scala = struct
   ]
 
   let rec
-    parse_decl = parser
-      [< '(l, Kwd "object"); '(_, Ident cn); '(_, Kwd "{"); ms = rep parse_method; '(_, Kwd "}") >] ->
+    parse_decl = function%parser
+      [ (l, Kwd "object"); (_, Ident cn); (_, Kwd "{"); [%l ms = rep parse_method]; (_, Kwd "}") ] ->
       Class (l, false, FinalClass, cn, ms, [], [], ("Object", []), [], [], [])
   and
-    parse_method = parser
-      [< '(l, Kwd "def"); '(_, Ident mn); ps = parse_paramlist; t = parse_type_ann; co = parse_contract; '(_, Kwd "=");'(_, Kwd "{"); ss = rep parse_stmt; '(closeBraceLoc, Kwd "}")>] ->
+    parse_method = function%parser
+      [ (l, Kwd "def"); (_, Ident mn); parse_paramlist as ps; parse_type_ann as t; parse_contract as co; (_, Kwd "=");(_, Kwd "{"); [%l ss = rep parse_stmt]; (closeBraceLoc, Kwd "}") ] ->
       let rt = match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t in
       Meth (l, Real, rt, mn, ps, Some co, Some ((ss, closeBraceLoc), next_body_rank ()), Static, Public, false, [])
   and
-    parse_paramlist = parser
-      [< '(_, Kwd "("); ps = rep_comma parse_param; '(_, Kwd ")") >] -> ps
+    parse_paramlist = function%parser
+      [ (_, Kwd "("); [%l ps = rep_comma parse_param]; (_, Kwd ")") ] -> ps
   and
-    parse_param = parser
-      [< '(_, Ident x); t = parse_type_ann >] -> (t, x)
+    parse_param = function%parser
+      [ (_, Ident x); parse_type_ann as t ] -> (t, x)
   and
-    parse_type_ann: (loc * token) Stream.t -> type_expr = parser
-      [< '(_, Kwd ":"); t = parse_type >] -> t
+    parse_type_ann: (loc * token) Stream.t -> type_expr = function%parser
+      [ (_, Kwd ":"); parse_type as t ] -> t
   and
-    parse_type = parser
-      [< '(l, Ident tn); targs = parse_targlist >] ->
+    parse_type = function%parser
+      [ (l, Ident tn); parse_targlist as targs ] ->
       begin
         match (tn, targs) with
           ("Unit", []) -> ManifestTypeExpr (l, Void)
@@ -240,43 +240,43 @@ module Scala = struct
         | _ -> raise (ParseException (l, "Type arguments are not supported."))
       end
   and
-    parse_targlist = parser
-      [< '(_, Kwd "["); ts = rep_comma parse_type; '(_, Kwd "]") >] -> ts
-    | [< >] -> []
+    parse_targlist = function%parser
+      [ (_, Kwd "["); [%l ts = rep_comma parse_type]; (_, Kwd "]") ] -> ts
+    | [ ] -> []
   and
-    parse_contract = parser
-      [< '(_, Kwd "/*@"); '(_, Kwd "requires"); pre = parse_asn; '(_, Kwd "@*/");
-         '(_, Kwd "/*@"); '(_, Kwd "ensures"); post = parse_asn; '(_, Kwd "@*/") >] -> (pre, post, [], false)
+    parse_contract = function%parser
+      [ (_, Kwd "/*@"); (_, Kwd "requires"); parse_asn as pre; (_, Kwd "@*/");
+         (_, Kwd "/*@"); (_, Kwd "ensures"); parse_asn as post; (_, Kwd "@*/") ] -> (pre, post, [], false)
   and
-    parse_asn = parser
-      [< '(_, Kwd "("); a = parse_asn; '(_, Kwd ")") >] -> a
-    | [< e = parse_expr >] -> e
+    parse_asn = function%parser
+      [ (_, Kwd "("); parse_asn as a; (_, Kwd ")") ] -> a
+    | [ parse_expr as e ] -> e
   and
-    parse_primary_expr = parser
-      [< '(l, Kwd "true") >] -> True l
-    | [< '(l, Kwd "false") >] -> False l
-    | [< '(l, Int (n, dec, usuffix, lsuffix, _)) >] -> IntLit (l, n, dec, usuffix, lsuffix)
-    | [< '(l, Ident x) >] -> Var (l, x)
+    parse_primary_expr = function%parser
+      [ (l, Kwd "true") ] -> True l
+    | [ (l, Kwd "false") ] -> False l
+    | [ (l, Int (n, dec, usuffix, lsuffix, _)) ] -> IntLit (l, n, dec, usuffix, lsuffix)
+    | [ (l, Ident x) ] -> Var (l, x)
   and
-    parse_add_expr = parser
-      [< e0 = parse_primary_expr; e = parse_add_expr_rest e0 >] -> e
+    parse_add_expr = function%parser
+      [ parse_primary_expr as e0; [%l e = parse_add_expr_rest e0] ] -> e
   and
-    parse_add_expr_rest e0 = parser
-      [< '(l, Kwd "+"); e1 = parse_primary_expr; e = parse_add_expr_rest (Operation (l, Add, [e0; e1])) >] -> e
-    | [< >] -> e0
+    parse_add_expr_rest e0 = function%parser
+      [ (l, Kwd "+"); parse_primary_expr as e1; [%l e = parse_add_expr_rest (Operation (l, Add, [e0; e1]))] ] -> e
+    | [ ] -> e0
   and
-    parse_rel_expr = parser
-      [< e0 = parse_add_expr; e = parse_rel_expr_rest e0 >] -> e
+    parse_rel_expr = function%parser
+      [ parse_add_expr as e0; [%l e = parse_rel_expr_rest e0] ] -> e
   and
-    parse_rel_expr_rest e0 = parser
-      [< '(l, Kwd "=="); e1 = parse_add_expr; e = parse_rel_expr_rest (Operation (l, Eq, [e0; e1])) >] -> e
-    | [< >] -> e0
+    parse_rel_expr_rest e0 = function%parser
+      [ (l, Kwd "=="); parse_add_expr as e1; [%l e = parse_rel_expr_rest (Operation (l, Eq, [e0; e1]))] ] -> e
+    | [ ] -> e0
   and
     parse_expr stream = parse_rel_expr stream
   and
-    parse_stmt = parser
-      [< '(l, Kwd "var"); '(_, Ident x); t = parse_type_ann; '(_, Kwd "="); e = parse_expr; '(_, Kwd ";") >] -> DeclStmt (l, [l, t, x, Some(e), (ref false, ref None)])
-    | [< '(l, Kwd "assert"); a = parse_asn; '(_, Kwd ";") >] -> Assert (l, a)
+    parse_stmt = function%parser
+      [ (l, Kwd "var"); (_, Ident x); parse_type_ann as t; (_, Kwd "="); parse_expr as e; (_, Kwd ";") ] -> DeclStmt (l, [l, t, x, Some(e), (ref false, ref None)])
+    | [ (l, Kwd "assert"); parse_asn as a; (_, Kwd ";") ] -> Assert (l, a)
 
 end
 
@@ -352,46 +352,59 @@ let rec parse_decls ?inGhostHeader =
   else
     parse_decls_core
 and
-  parse_decls_core = parser
-  [< '(_, Kwd "/*@"); ds = parse_pure_decls; '(_, Kwd "@*/"); ds' = parse_decls_core >] -> ds @ ds'
-| [< _ = opt (parser [< '(_, Kwd "public") >] -> ());
-     abstract = (parser [< '(_, Kwd "abstract") >] -> true | [< >] -> false); 
-     final = (parser [< '(_, Kwd "final") >] -> FinalClass | [< >] -> ExtensibleClass);
-     ds = begin parser
-       [< '(l, Kwd "class"); '(_, Ident s); tparams = type_params_parse;
-          super = parse_super_class l; il = parse_interfaces; mem = parse_java_members s tparams; ds = parse_decls_core >]
-       -> Class (l, abstract, final, s, methods s mem, fields mem, constr mem, super, tparams, il, instance_preds mem)::ds
-     | [< '(l, Kwd "interface"); '(_, Ident cn); tparams = type_params_parse;
-          il = parse_extended_interfaces; mem = parse_java_members cn tparams; ds = parse_decls_core >]
-       -> Interface (l, cn, il, fields mem, methods cn mem, tparams, instance_preds mem)::ds
-     | [< d = parse_decl; ds = parse_decls_core >] -> d@ds
-     | [< '(_, Kwd ";"); ds = parse_decls_core >] -> ds
-     | [< >] -> []
-     end
-  >] -> ds
-and parse_qualified_type loc = parser
-  [< t = parse_type >] -> 
+  parse_decls_core = function%parser
+  [ (_, Kwd "/*@"); parse_pure_decls as ds; (_, Kwd "@*/"); parse_decls_core as ds' ] -> ds @ ds'
+| [ [%l _d = opt (function%parser [ (_, Kwd "public") ] -> ()) ];
+    [%l abstract = (function%parser [ (_, Kwd "abstract") ] -> true | [ ] -> false)]; 
+    [%l final = (function%parser [ (_, Kwd "final") ] -> FinalClass | [ ] -> ExtensibleClass)];
+    [%l ds = begin function%parser
+    | [ (l, Kwd "class"); (_, Ident s); type_params_parse as tparams;
+        [%l super = parse_super_class l]; parse_interfaces as il; [%l mem = parse_java_members s tparams]; parse_decls_core as ds ]
+      -> Class (l, abstract, final, s, methods s mem, fields mem, constr mem, super, tparams, il, instance_preds mem)::ds
+    | [ (l, Kwd "interface"); (_, Ident cn); type_params_parse as tparams;
+        parse_extended_interfaces as il; [%l mem = parse_java_members cn tparams]; parse_decls_core as ds ]
+      -> Interface (l, cn, il, fields mem, methods cn mem, tparams, instance_preds mem)::ds
+    | [ parse_decl as d; parse_decls_core as ds ] -> d@ds
+    | [ (_, Kwd ";"); parse_decls_core as ds ] -> ds
+    | [ ] -> []
+     end]
+  ] -> ds
+and parse_qualified_type loc = function%parser
+  [ parse_type as t ] -> 
     match t with 
       IdentTypeExpr(l, p, n) -> ((match p with Some(s) -> s ^ "." ^ n | None -> n), []) 
       | ConstructedTypeExpr(l, n, targs) -> (n, targs)
       | _ -> raise (ParseException (loc, "Invalid type"))
   
 and
-  parse_super_class loc = parser
-    [<'(l, Kwd "extends"); (s, targs) = parse_qualified_type l>] -> (s, targs)
-  | [<>] -> ("java.lang.Object", [])
+  parse_super_class loc = function%parser
+    [ (l, Kwd "extends"); [%l (s, targs) = parse_qualified_type l] ] -> (s, targs)
+  | [ ] -> ("java.lang.Object", [])
 and
-  parse_interfaces = parser
-  [< '(l, Kwd "implements"); is = rep_comma (parser 
-    [< i = parse_qualified_type l; e=parser
-      [<>]->(i)>] -> e); '(_, Kwd "{") >] -> is
-  | [<'(_, Kwd "{")>]-> []
+  parse_interfaces = function%parser
+| [
+    (l, Kwd "implements"); 
+    [%l is = rep_comma (function%parser 
+    | [ 
+        [%l i = parse_qualified_type l]; 
+        [%l e = function%parser [ ] -> i]
+      ] -> e)
+    ];
+    (_, Kwd "{") 
+  ] -> is
+  | [ (_, Kwd "{") ]-> []
 and
-  parse_extended_interfaces = parser
-  [< '(l, Kwd "extends"); is = rep_comma (parser 
-    [< i = parse_qualified_type l; e=parser
-      [<>] -> (i)>] -> e); '(_, Kwd "{") >] -> is
-  | [<'(_, Kwd "{")>] -> []
+  parse_extended_interfaces = function%parser
+| [ (l, Kwd "extends"); 
+    [%l is = rep_comma (function%parser 
+    | [ [%l i = parse_qualified_type l]; 
+        [%l e = function%parser
+        | [ ] -> i
+        ]
+      ] -> e)
+    ]; 
+    (_, Kwd "{") ] -> is
+| [ (_, Kwd "{") ] -> []
 and
   methods cn m=
   match m with
@@ -413,139 +426,191 @@ and
 and
   instance_preds mems = flatmap (function PredMember p -> [p] | _ -> []) mems
 and
-  parse_visibility = parser
-  [<'(_, Kwd "public")>] -> Public
-| [<'(_, Kwd "private")>] -> Private
-| [<'(_, Kwd "protected")>] -> Protected
-| [<>] -> Package
+  parse_visibility = function%parser
+| [ (_, Kwd "public") ] -> Public
+| [ (_, Kwd "private") ] -> Private
+| [ (_, Kwd "protected") ] -> Protected
+| [ ] -> Package
 and
-  parse_java_members cn ctparams= parser
-  [<'(_, Kwd "}")>] -> []
-| [< '(_, Kwd "/*@"); mems1 = parse_ghost_java_members cn; mems2 = parse_java_members cn ctparams >] -> mems1 @ mems2
-| [< m=parse_java_member cn ctparams;mr=parse_java_members cn ctparams>] -> m::mr
+  parse_java_members cn ctparams = function%parser
+| [ (_, Kwd "}") ] -> []
+| [ (_, Kwd "/*@"); [%l mems1 = parse_ghost_java_members cn]; [%l mems2 = parse_java_members cn ctparams] ] -> mems1 @ mems2
+| [ [%l m = parse_java_member cn ctparams]; [%l mr = parse_java_members cn ctparams] ] -> m::mr
 and
-  parse_ghost_java_members cn = parser
-  [< '(_, Kwd "@*/") >] -> []
-| [< m = parse_ghost_java_member cn; mems = parse_ghost_java_members cn >] -> m::mems
+  parse_ghost_java_members cn = function%parser
+  [ (_, Kwd "@*/") ] -> []
+| [ [%l m = parse_ghost_java_member cn]; [%l mems = parse_ghost_java_members cn] ] -> m::mems
 and
-  parse_ghost_java_member cn = parser
-  | [< vis = parse_visibility; m = begin parser
-       [< '(l, Kwd "predicate"); '(_, Ident g); ps = parse_paramlist;
-          body = begin parser
-            [< '(_, Kwd "="); p = parse_asn >] -> Some p
-          | [< >] -> None
-          end;
-         '(_, Kwd ";") >] -> PredMember(InstancePredDecl (l, g, ps, body))
-     | [< '(l, Kwd "lemma"); t = parse_return_type; 
-          '(l, Ident x); (ps, co, ss) = parse_method_rest l >] -> 
+  parse_ghost_java_member cn = function%parser
+| [ parse_visibility as vis; 
+    [%l m = begin function%parser
+    | [ (l, Kwd "predicate"); 
+        (_, Ident g); 
+        parse_paramlist as ps;
+        [%l 
+          body = begin function%parser
+          | [ (_, Kwd "="); parse_asn as p ] -> Some p
+          | [ ] -> None
+          end
+        ];
+        (_, Kwd ";") 
+      ] -> PredMember(InstancePredDecl (l, g, ps, body))
+    | [ (l, Kwd "lemma"); 
+        parse_return_type as t; 
+        (l, Ident x); 
+        [%l (ps, co, ss) = parse_method_rest l] 
+      ] -> 
         let ps = (IdentTypeExpr (l, None, cn), "this")::ps in
         MethMember(Meth (l, Ghost, t, x, ps, co, ss, Instance, vis, false, []))
-     | [< binding = (parser [< '(_, Kwd "static") >] -> Static | [< >] -> Instance); t = parse_type; '(l, Ident x); '(_, Kwd ";") >] ->
-       FieldMember [Field (l, Ghost, t, x, binding, vis, false, None)]
+    | [ [%l binding = (function%parser 
+        | [ (_, Kwd "static") ] -> Static 
+        | [ ] -> Instance)
+        ]; 
+        parse_type as t; 
+        (l, Ident x); 
+        (_, Kwd ";") 
+      ] -> FieldMember [Field (l, Ghost, t, x, binding, vis, false, None)]
     end
-  >] -> m
+    ]
+  ] -> m
 and
-  parse_thrown l = parser 
-  [< tp = parse_type; epost =
-    begin
-      parser
-        [< '(_, Kwd "/*@"); '(_, Kwd "ensures"); epost = parse_asn; '(_, Kwd ";"); '(_, Kwd "@*/") >] -> Some epost
-      | [< >] -> None
+  parse_thrown l = function%parser 
+| [ parse_type as tp; 
+    [%l 
+    epost = begin function%parser
+    | [ (_, Kwd "/*@"); (_, Kwd "ensures"); parse_asn as epost; (_, Kwd ";"); (_, Kwd "@*/") ] -> Some epost
+    | [ ] -> None
     end
-   >] -> (tp, epost)
+    ]
+  ] -> (tp, epost)
 and
-  parse_throws_clause = parser
-  [< '(l, Kwd "throws"); epost = rep_comma (parse_thrown l) >] -> epost
+  parse_throws_clause = function%parser
+  [ (l, Kwd "throws"); [%l epost = rep_comma (parse_thrown l)] ] -> epost
 and
-  parse_array_dims t = parser
-  [< '(l, Kwd "["); '(_, Kwd "]"); t = parse_array_dims (ArrayTypeExpr (l, t)) >] -> t
-| [< >] -> t
+  parse_array_dims t = function%parser
+| [ (l, Kwd "["); (_, Kwd "]"); [%l t = parse_array_dims (ArrayTypeExpr (l, t))] ] -> t
+| [ ] -> t
 and 
-  id x = parser [< >] -> x
+  id x = function%parser [ ] -> x
 and 
-  parse_java_modifier = parser [< '(_, Kwd "public") >] -> VisibilityModifier(Public) | [< '(_, Kwd "protected") >] -> VisibilityModifier(Protected) | [< '(_, Kwd "private") >] -> VisibilityModifier(Private) | [< '(_, Kwd "static") >] -> StaticModifier | [< '(_, Kwd "final") >] -> FinalModifier | [< '(_, Kwd "abstract") >] -> AbstractModifier
+  parse_java_modifier = function%parser [ (_, Kwd "public") ] -> VisibilityModifier(Public) | [ (_, Kwd "protected") ] -> VisibilityModifier(Protected) | [ (_, Kwd "private") ] -> VisibilityModifier(Private) | [ (_, Kwd "static") ] -> StaticModifier | [ (_, Kwd "final") ] -> FinalModifier | [ (_, Kwd "abstract") ] -> AbstractModifier
 and
-  parse_java_member cn classTparams = parser
-  [< modifiers = rep parse_java_modifier;
-     binding = (fun _ -> if List.mem StaticModifier modifiers then Static else Instance);
-     final = (fun _ -> List.mem FinalModifier modifiers);
-     abstract = (fun _ -> List.mem AbstractModifier modifiers);
-     vis = (fun _ -> (match (try_find (function VisibilityModifier(_) -> true | _ -> false) modifiers) with None -> Package | Some(VisibilityModifier(vis)) -> vis));
-     tparams = parse_type_params_general;
-     t = parse_return_type;
-     member = parser
-       [< '(l, Ident x);
-          member = parser
-            [< (ps, co, ss) = parse_method_rest l >] ->
-            let this = if classTparams <> [] then ConstructedTypeExpr(l,cn,List.map (fun tparam -> IdentTypeExpr(l, None, tparam) ) classTparams) else IdentTypeExpr (l, None, cn) in
-            let ps = if binding = Instance then (this, "this")::ps 
-                else ps in
-            MethMember (Meth (l, Real, t, x, ps, co, ss, binding, vis, abstract, tparams))
-          | [< t = id (match t with None -> raise (ParseException (l, "A field cannot be void.")) | Some(t) -> t);
-               tx = parse_array_braces t;
-               init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);
-               ds = comma_rep (parse_declarator t); '(_, Kwd ";")
-            >] ->
-            let fds =
+  parse_java_member cn classTparams = function%parser
+| [ [%l modifiers = rep parse_java_modifier];
+    [%l binding = (fun _ -> if List.mem StaticModifier modifiers then Static else Instance)];
+    [%l final = (fun _ -> List.mem FinalModifier modifiers)];
+    [%l abstract = (fun _ -> List.mem AbstractModifier modifiers)];
+    [%l vis = (fun _ -> (match (try_find (function VisibilityModifier(_) -> true | _ -> false) modifiers) with None -> Package | Some(VisibilityModifier(vis)) -> vis))];
+    parse_type_params_general as tparams;
+    parse_return_type as t;
+    [%l 
+      member = function%parser
+      | [ (l, Ident x);
+          [%l 
+            member = function%parser
+            | [ [%l (ps, co, ss) = parse_method_rest l] ] ->
+              let this = if classTparams <> [] then ConstructedTypeExpr(l,cn,List.map (fun tparam -> IdentTypeExpr(l, None, tparam) ) classTparams) else IdentTypeExpr (l, None, cn) in
+              let ps = 
+                if binding = Instance then (this, "this")::ps 
+                else ps 
+              in
+              MethMember (Meth (l, Real, t, x, ps, co, ss, binding, vis, abstract, tparams))
+            | [ [%l t = id (match t with None -> raise (ParseException (l, "A field cannot be void.")) | Some(t) -> t)];
+                [%l tx = parse_array_braces t];
+                [%l init = opt (function%parser [ (_, Kwd "="); [%l e = parse_declaration_rhs tx] ] -> e)];
+                [%l ds = comma_rep (parse_declarator t)];
+                (_, Kwd ";")
+              ] ->
+              let fds =
               ((l, tx, x, init, (ref false, ref None))::ds) |> List.map begin fun (l, tx, x, init, _) ->
                 Field (l, Real, tx, x, binding, vis, final, init)
               end
-            in
-            FieldMember fds
-       >] -> member
-     | [< (ps, co, ss) = parse_method_rest (match t with Some t -> type_expr_loc t | None -> dummy_loc) >] ->
-       let l =
-         match t with
-           None -> raise (Stream.Error "Keyword 'void' cannot be followed by a parameter list.")
-         | Some (IdentTypeExpr (l, None, x)) -> if x = cn then l else raise (ParseException (l, "Constructor name does not match class name."))
-         | Some t -> raise (ParseException (type_expr_loc t, "Constructor name expected."))
-       in
-       if binding = Static then raise (ParseException (l, "A constructor cannot be static."));
-       if final then raise (ParseException (l, "A constructor cannot be final."));
-       ConsMember (Cons (l, ps, co, ss, vis))
-  >] -> member
-and parse_array_init_rest = parser
-  [< '(_, Kwd ","); es = opt(parser [< e = parse_expr; es = parse_array_init_rest >] -> e :: es) >] -> (match es with None -> [] | Some(es) -> es)
-| [< >] -> []
-and parse_array_init = parser
-  [< '(_, Kwd ","); '(_, Kwd "}") >] -> []
-| [< '(_, Kwd "}") >] -> []
-| [< e = parse_expr; es = parse_array_init_rest; '(_, Kwd "}") >] -> e :: es
-and parse_declaration_rhs te = parser
-  [< '(linit, Kwd "{"); es = parse_array_init >] ->
+              in
+              FieldMember fds
+          ]
+        ] -> member
+      | [ [%l (ps, co, ss) = parse_method_rest (match t with Some t -> type_expr_loc t | None -> dummy_loc)] ] ->
+        let l =
+          match t with
+          | None -> raise (Stream.Error "Keyword 'void' cannot be followed by a parameter list.")
+          | Some (IdentTypeExpr (l, None, x)) -> if x = cn then l else raise (ParseException (l, "Constructor name does not match class name."))
+          | Some t -> raise (ParseException (type_expr_loc t, "Constructor name expected."))
+          in
+          if binding = Static then raise (ParseException (l, "A constructor cannot be static."));
+          if final then raise (ParseException (l, "A constructor cannot be final."));
+          ConsMember (Cons (l, ps, co, ss, vis))
+    ]
+  ] -> member
+and parse_array_init_rest = function%parser
+| [ (_, Kwd ","); 
+    [%l es = opt (function%parser [ parse_expr as e; parse_array_init_rest as es ] -> e :: es)]
+  ] -> (match es with None -> [] | Some(es) -> es)
+| [ ] -> []
+and parse_array_init = function%parser
+| [ (_, Kwd ","); 
+    (_, Kwd "}") 
+  ] -> []
+| [ (_, Kwd "}") ] -> []
+| [ parse_expr as e; parse_array_init_rest as es; (_, Kwd "}") ] -> e :: es
+and parse_declaration_rhs te = function%parser
+| [ (linit, Kwd "{"); 
+    parse_array_init as es 
+  ] ->
   (match te with ArrayTypeExpr (_, elem_te) when language = Java -> NewArrayWithInitializer (linit, elem_te, es) | _ -> InitializerList (linit, es))
-| [< e = parse_expr >] -> e
+| [ parse_expr as e ] -> e
 and
-  parse_declarator0 = parser
-  [< '(l, Kwd "(");
-     f = begin parser
-       [< p = parse_param; ps = comma_rep parse_param; '(_, Kwd ")") >] -> fun t ->
+  parse_declarator0 = function%parser
+| [ (l, Kwd "(");
+    [%l 
+    f = begin function%parser
+    | [ parse_param as p; 
+        [%l ps = comma_rep parse_param]; 
+        (_, Kwd ")") 
+      ] -> fun t ->
        let ps = List.filter filter_void_params (p::ps) in
        (FuncTypeExpr (l, t, ps), None)
-     | [< '(_, Kwd ")") >] -> fun t -> (FuncTypeExpr (l, t, []), None)
-     | [< f = parse_declarator0; '(_, Kwd ")") >] -> f
-     end;
-     f = parse_declarator_suffix f
-   >] -> f
-| [< '(l, Kwd "*"); f = parse_declarator0 >] -> fun t -> f (PtrTypeExpr (l, t))
-| [< x = opt (parser [< '(l, Ident x) >] -> (l, x)); f = parse_declarator_suffix (fun t -> (t, x)) >] -> f
+    | [ (_, Kwd ")") ] -> fun t -> (FuncTypeExpr (l, t, []), None)
+    | [ parse_declarator0 as f; 
+        (_, Kwd ")") 
+      ] -> f
+    end
+    ];
+    [%l f = parse_declarator_suffix f]
+  ] -> f
+| [ (l, Kwd "*"); 
+    parse_declarator0 as f 
+  ] -> fun t -> f (PtrTypeExpr (l, t))
+| [ [%l x = opt (function%parser [ (l, Ident x) ] -> (l, x))];
+    [%l f = parse_declarator_suffix (fun t -> (t, x))] 
+  ] -> f
 and
-  parse_declarator_suffix f = parser
-  [< '(l, Kwd "["); f = begin parser
-       [< '(_, Kwd "]") >] -> fun t -> f (ArrayTypeExpr (l, t))
-     | [< '(lsize, Int (size, _, _, _, _)); '(_, Kwd "]") >] ->
-       if sign_big_int size <= 0 then raise (ParseException (lsize, "Array must have size > 0."));
-       fun t -> f (StaticArrayTypeExpr (l, t, int_of_big_int size))
-     end; f = parse_declarator_suffix f >] -> f
-| [< '(l, Kwd "("); ps = rep_comma parse_param; '(_, Kwd ")"); f = parse_declarator_suffix (fun t -> f (FuncTypeExpr (l, t, List.filter filter_void_params ps))) >] -> f
-| [< >] -> f
+  parse_declarator_suffix f = function%parser
+| [ (l, Kwd "["); 
+    [%l 
+    f = begin function%parser
+    | [ (_, Kwd "]") ] -> fun t -> f (ArrayTypeExpr (l, t))
+    | [ (lsize, Int (size, _, _, _, _)); 
+        (_, Kwd "]") 
+      ] ->
+      if sign_big_int size <= 0 then raise (ParseException (lsize, "Array must have size > 0."));
+      fun t -> f (StaticArrayTypeExpr (l, t, int_of_big_int size))
+    end
+    ]; 
+    [%l f = parse_declarator_suffix f]
+  ] -> f
+| [ (l, Kwd "(");
+    [%l ps = rep_comma parse_param]; 
+    (_, Kwd ")"); 
+    [%l f = parse_declarator_suffix (fun t -> f (FuncTypeExpr (l, t, List.filter filter_void_params ps)))]
+  ] -> f
+| [ ] -> f
 and
-  parse_declarator t = parser
-  [< t = parse_type_suffix t;
-     '(l, Ident x);
-     tx = parse_array_braces t;
-     init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);
-  >] ->
+  parse_declarator t = function%parser
+| [ [%l t = parse_type_suffix t];
+    (l, Ident x);
+    [%l tx = parse_array_braces t];
+    [%l init = opt (function%parser [ (_, Kwd "="); [%l e = parse_declaration_rhs tx] ] -> e)];
+  ] ->
   let tx =
     match tx, init with
       ArrayTypeExpr (l, elemTp), Some (InitializerList (_, es)) when language = CLang ->
@@ -555,13 +620,15 @@ and
   register_varname x;
   (l, tx, x, init, (ref false, ref None))
 and
-  parse_method_rest l = parser
-  [< ps = parse_paramlist;
-    epost = opt parse_throws_clause;
-    (ss, co) = parser
-      [< '(_, Kwd ";"); spec = opt parse_spec >] -> (None, spec)
-    | [< spec = opt parse_spec; '(l, Kwd "{"); ss = parse_stmts; '(closeBraceLoc, Kwd "}") >] -> (Some ((ss, closeBraceLoc), next_body_rank ()), spec)
-    >] ->
+  parse_method_rest l = function%parser
+  [ parse_paramlist as ps;
+    [%l epost = opt parse_throws_clause];
+    [%l 
+    (ss, co) = function%parser
+    | [ (_, Kwd ";"); [%l spec = opt parse_spec] ] -> (None, spec)
+    | [ [%l spec = opt parse_spec]; (l, Kwd "{"); parse_stmts as ss; (closeBraceLoc, Kwd "}") ] -> (Some ((ss, closeBraceLoc), next_body_rank ()), spec)
+    ]
+  ] ->
     let contract =
       let epost = match epost with None -> [] | Some(epost) -> epost in
       match co with
@@ -583,110 +650,166 @@ and
     in
     (ps, contract, ss)
 and
-  parse_functype_paramlists = parser
-  [< ps1 = parse_paramlist; ps2 = opt parse_paramlist >] -> (match ps2 with None -> ([], ps1) | Some ps2 -> (ps1, ps2))
+  parse_functype_paramlists = function%parser
+| [ parse_paramlist as ps1; [%l ps2 = opt parse_paramlist] ] -> (match ps2 with None -> ([], ps1) | Some ps2 -> (ps1, ps2))
 and
   (** Parses
    * /*@<ttparams>(tparams)@*/(params) where
    * <ttparams> and (tparams) and /*@<ttparams>(tparams)@*/ are optional
    *)
-  parse_functypedecl_paramlist_in_real_context = parser
-  [< '(_, Kwd "/*@");
-     functiontypetypeparams = opt parse_type_params_free;
-     functiontypeparams = opt parse_paramlist;
-     '(_, Kwd "@*/");
-     params = parse_paramlist
-  >] ->
+  parse_functypedecl_paramlist_in_real_context = function%parser
+| [ (_, Kwd "/*@");
+    [%l functiontypetypeparams = opt parse_type_params_free];
+    [%l functiontypeparams = opt parse_paramlist];
+    (_, Kwd "@*/");
+    parse_paramlist as params
+  ] ->
     let noneToEmptyList value = 
       match value with 
         None -> []
         | Some x -> x
     in
     (noneToEmptyList functiontypetypeparams, noneToEmptyList functiontypeparams, params)
-  | [< params = parse_paramlist >] -> ([], [], params)
+| [ parse_paramlist as params ] -> ([], [], params)
 and
-  parse_ignore_inline = parser
-  [< '(l, Kwd "inline") >] -> ()
-| [< '(l, Kwd "__inline") >] -> ()
-| [< '(l, Kwd "__inline__") >] -> ()
-| [< '(l, Kwd "__forceinline") >] -> ()
-| [< '(l, Kwd "__always_inline") >] -> ()
-| [< >] -> ()
+  parse_ignore_inline = function%parser
+| [ (l, Kwd "inline") ] -> ()
+| [ (l, Kwd "__inline") ] -> ()
+| [ (l, Kwd "__inline__") ] -> ()
+| [ (l, Kwd "__forceinline") ] -> ()
+| [ (l, Kwd "__always_inline") ] -> ()
+| [ ] -> ()
 and
-  parse_static_visibility = parser
-  [< '(l, Kwd "static") >] -> Private
-| [< >] -> Public
+  parse_static_visibility = function%parser
+| [ (l, Kwd "static") ] -> Private
+| [ ] -> Public
 and
-  parse_enum_body = parser
-  [< '(_, Kwd "{");
-     elems = rep_comma (parser [< '(_, Ident e); init = opt (parser [< '(_, Kwd "="); e = parse_expr >] -> e) >] -> (e, init));
-     '(_, Kwd "}")
-   >] -> elems
+  parse_enum_body = function%parser
+| [ (_, Kwd "{");
+    [%l 
+    elems = rep_comma (function%parser 
+    | [ (_, Ident e); 
+        [%l 
+        init = opt (function%parser 
+        | [ (_, Kwd "="); 
+            parse_expr as e 
+          ] -> e) 
+        ]
+      ] -> (e, init))
+    ];
+    (_, Kwd "}")
+  ] -> elems
 and
-  parse_decl = parser
-  [< '(l, Kwd "struct"); '(_, Ident s); d = parser
-    [< fs = parse_fields; attrs = begin parser
-      [< '(_, Kwd "__attribute__"); res = parse_struct_attrs; >] -> res
-    | [< >] -> [] end;
-    '(_, Kwd ";") >] -> Struct (l, s, Some ([], fs, [], false), attrs)
-  | [< '(_, Kwd ";") >] -> Struct (l, s, None, [])
-  | [< t = parse_type_suffix (StructTypeExpr (l, Some s, None, [])); d = parse_func_rest Regular (Some t) >] -> d
-  >] -> check_function_for_contract d
-| [< '(l, Kwd "union"); '(_, Ident u); d = parser
-    [< fs = parse_fields; '(_, Kwd ";") >] -> Union (l, u, Some fs)
-  | [< '(_, Kwd ";") >] -> Union (l, u, None)
-  | [< t = parse_type_suffix (UnionTypeExpr (l, Some u, None)); d = parse_func_rest Regular (Some t) >] -> d
-  >] -> check_function_for_contract d
-| [< '(l, Kwd "typedef");
-     () = (fun _ -> push_typedef_scope ());
-     rt = parse_return_type;
-     g, ds = begin parser
-       [< '(_, Ident g);
-     ds = begin parser
-       [<
-         (tparams, ftps, ps) = parse_functypedecl_paramlist_in_real_context;
-         '(_, Kwd ";");
-         spec = opt parse_spec
-       >] ->
-         let contract = check_for_contract spec l "Function type declaration should have contract." (fun (pre, post) -> (pre, post, false)) in
-         [FuncTypeDecl (l, Real, rt, g, tparams, ftps, ps, contract)]
-       | [< '(_, Kwd ";") >] ->
-         begin
-           match rt with
-             None -> raise (ParseException (l, "Void not allowed here."))
-             | Some (EnumTypeExpr (le, en_opt, Some body)) ->
-               let en = match en_opt with None -> g | Some en -> en in
-               [EnumDecl (l, en, body); TypedefDecl (l, EnumTypeExpr (le, Some en, None), g)]
-             | Some (StructTypeExpr (ls, s_opt, Some fs, attrs)) ->
-               let s = match s_opt with None -> g | Some s -> s in
-               [Struct (l, s, Some ([], fs, [], false), attrs); TypedefDecl (l, StructTypeExpr (ls, Some s, None, attrs), g)]
-             | Some (UnionTypeExpr (ls, u_opt, Some fs)) ->
-               let u = match u_opt with None -> g | Some u -> u in
-               [Union (l, u, Some fs); TypedefDecl (l, UnionTypeExpr (ls, Some u, None), g)]
-             | Some PtrTypeExpr (lp, (StructTypeExpr (ls, s_opt, Some fs, attrs))) ->
-               let s = match s_opt with None -> g | Some s -> s in
-               [Struct (l, s, Some ([], fs, [], false), attrs); TypedefDecl (l, PtrTypeExpr (lp, StructTypeExpr (ls, Some s, None, attrs)), g)]
-             | Some te ->
-               [TypedefDecl (l, te, g)]
-         end
-     end
-       >] -> g, ds
-     | [< '(_, Kwd "("); '(lp, Kwd "*"); '(lg, Ident g); '(_, Kwd ")");
-          (tparams, ftps, ps) = parse_functypedecl_paramlist_in_real_context;
-          '(_, Kwd ";");
-          spec = opt parse_spec
-       >] ->
-         let contract = check_for_contract spec l "Function type declaration should have contract." (fun (pre, post) -> (pre, post, false)) in
-         g, [FuncTypeDecl (l, Real, rt, g, tparams, ftps, ps, contract); TypedefDecl (l, ManifestTypeExpr (lp, PtrType (FuncType g)), g)]
-     end
-  >] -> pop_typedef_scope (); register_typedef g; ds
-| [< '(_, Kwd "enum"); '(l, Ident n); d = parser
-    [< elems = parse_enum_body; '(_, Kwd ";"); >] -> EnumDecl(l, n, elems)
-  | [< t = parse_type_suffix (EnumTypeExpr (l, Some n, None)); d = parse_func_rest Regular (Some t) >] -> d
-  >] -> check_function_for_contract d
-| [< '(_, Kwd "static"); _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t >] -> check_function_for_contract d
-| [< '(_, Kwd "extern"); t = parse_return_type; d = parse_func_rest Regular t >] -> check_function_for_contract d
-| [< '(_, Kwd "_Noreturn"); _ = parse_static_visibility; _ = parse_ignore_inline; t = parse_return_type; d = parse_func_rest Regular t >] ->
+  parse_decl = function%parser
+| [ (l, Kwd "struct"); 
+    (_, Ident s); 
+    [%l
+    d = function%parser
+    | [ parse_fields as fs; 
+        [%l
+        attrs = begin function%parser
+        | [ (_, Kwd "__attribute__"); 
+            parse_struct_attrs as res; 
+          ] -> res
+        | [ ] -> [] 
+        end
+        ];
+        (_, Kwd ";") 
+      ] -> Struct (l, s, Some ([], fs, [], false), attrs)
+    | [ (_, Kwd ";") ] -> Struct (l, s, None, [])
+    | [ [%l t = parse_type_suffix (StructTypeExpr (l, Some s, None, []))]; 
+        [%l d = parse_func_rest Regular (Some t)]
+      ] -> d
+    ]
+  ] -> check_function_for_contract d
+| [ (l, Kwd "union"); 
+    (_, Ident u); 
+    [%l 
+    d = function%parser
+    | [ parse_fields as fs; 
+      (_, Kwd ";") 
+      ] -> Union (l, u, Some fs)
+    | [ (_, Kwd ";") ] -> Union (l, u, None)
+    | [ [%l t = parse_type_suffix (UnionTypeExpr (l, Some u, None))]; 
+        [%l d = parse_func_rest Regular (Some t)] 
+      ] -> d
+    ]
+  ] -> check_function_for_contract d
+| [ (l, Kwd "typedef");
+    [%l () = (fun _ -> push_typedef_scope ())];
+    parse_return_type as rt;
+    [%l
+    g, ds = begin function%parser
+    | [ (_, Ident g);
+        [%l 
+        ds = begin function%parser
+        | [ [%l (tparams, ftps, ps) = parse_functypedecl_paramlist_in_real_context];
+            (_, Kwd ";");
+            [%l spec = opt parse_spec]
+          ] ->
+          let contract = check_for_contract spec l "Function type declaration should have contract." (fun (pre, post) -> (pre, post, false)) in
+          [FuncTypeDecl (l, Real, rt, g, tparams, ftps, ps, contract)]
+        | [ (_, Kwd ";") ] ->
+          begin match rt with
+          | None -> raise (ParseException (l, "Void not allowed here."))
+          | Some (EnumTypeExpr (le, en_opt, Some body)) ->
+            let en = match en_opt with None -> g | Some en -> en in
+            [EnumDecl (l, en, body); TypedefDecl (l, EnumTypeExpr (le, Some en, None), g)]
+          | Some (StructTypeExpr (ls, s_opt, Some fs, attrs)) ->
+            let s = match s_opt with None -> g | Some s -> s in
+            [Struct (l, s, Some ([], fs, [], false), attrs); TypedefDecl (l, StructTypeExpr (ls, Some s, None, attrs), g)]
+          | Some (UnionTypeExpr (ls, u_opt, Some fs)) ->
+            let u = match u_opt with None -> g | Some u -> u in
+            [Union (l, u, Some fs); TypedefDecl (l, UnionTypeExpr (ls, Some u, None), g)]
+          | Some PtrTypeExpr (lp, (StructTypeExpr (ls, s_opt, Some fs, attrs))) ->
+            let s = match s_opt with None -> g | Some s -> s in
+            [Struct (l, s, Some ([], fs, [], false), attrs); TypedefDecl (l, PtrTypeExpr (lp, StructTypeExpr (ls, Some s, None, attrs)), g)]
+          | Some te ->
+            [TypedefDecl (l, te, g)]
+          end
+        end
+        ]
+      ] -> g, ds
+    | [ (_, Kwd "("); 
+        (lp, Kwd "*"); 
+        (lg, Ident g); 
+        (_, Kwd ")");
+        [%l (tparams, ftps, ps) = parse_functypedecl_paramlist_in_real_context];
+        (_, Kwd ";");
+        [%l spec = opt parse_spec]
+      ] -> 
+      let contract = check_for_contract spec l "Function type declaration should have contract." (fun (pre, post) -> (pre, post, false)) in
+      g, [FuncTypeDecl (l, Real, rt, g, tparams, ftps, ps, contract); TypedefDecl (l, ManifestTypeExpr (lp, PtrType (FuncType g)), g)]
+    end
+    ]
+  ] -> pop_typedef_scope (); register_typedef g; ds
+| [ (_, Kwd "enum"); 
+    (l, Ident n); 
+    [%l
+    d = function%parser
+    | [ parse_enum_body as elems; 
+        (_, Kwd ";"); 
+      ] -> EnumDecl(l, n, elems)
+    | [ [%l t = parse_type_suffix (EnumTypeExpr (l, Some n, None))]; 
+        [%l d = parse_func_rest Regular (Some t)] 
+      ] -> d
+    ]
+  ] -> check_function_for_contract d
+| [ (_, Kwd "static"); 
+    parse_ignore_inline as _d; 
+    parse_return_type as t; 
+    [%l d = parse_func_rest Regular t]
+  ] -> check_function_for_contract d
+| [ (_, Kwd "extern"); 
+    parse_return_type as t; 
+    [%l d = parse_func_rest Regular t]
+  ] -> check_function_for_contract d
+| [ (_, Kwd "_Noreturn"); 
+    parse_static_visibility as _d; 
+    parse_ignore_inline as _d; 
+    parse_return_type as t; 
+    [%l d = parse_func_rest Regular t]
+  ] ->
   let ds = check_function_for_contract d in
   begin match ds with
     [Func (l, k, tparams, t, g, ps, gc, ft, Some (pre, post), terminates, ss, _, _)] ->
@@ -697,7 +820,9 @@ and
   | _ -> ()
   end;
   ds
-| [< t = parse_return_type; d = parse_func_rest Regular t >] -> check_function_for_contract d
+| [ parse_return_type as t; 
+    [%l d = parse_func_rest Regular t] 
+  ] -> check_function_for_contract d
 and check_for_contract: 'a. 'a option -> loc -> string -> (asn * asn -> 'a) -> 'a = fun contract l m f ->
   match contract with
     | Some spec -> spec 
@@ -714,74 +839,183 @@ and check_function_for_contract d =
     [Func(l, k, tparams, t, g, ps, gc, ft, Some contract, terminates, ss, virt, overrides)]
   | _ -> [d]
 and
-  parse_pure_decls = parser
-  [< ds0 = parse_pure_decl; ds = parse_pure_decls >] -> ds0 @ ds
-| [< >] -> []
+  parse_pure_decls = function%parser
+| [ parse_pure_decl as ds0; 
+    parse_pure_decls as ds 
+  ] -> ds0 @ ds
+| [ ] -> []
 and
-  parse_index_list = parser
-  [< '(_, Kwd "("); is = rep_comma (parser 
-    [< '(l, Ident i); e=parser
-      [<'(_, Kwd ".");'(_, Kwd "class")>]-> (l,i)
-      |[<>]->(l,i)>] -> e); '(_, Kwd ")") >] -> is
+  parse_index_list = function%parser
+| [ (_, Kwd "("); 
+    [%l
+    is = rep_comma (function%parser 
+    | [ (l, Ident i); 
+        [%l 
+        e = function%parser
+        | [ (_, Kwd ".");
+            (_, Kwd "class")
+          ] -> (l, i)
+        | [ ]-> (l, i) 
+        ]
+      ] -> e
+    )
+    ]; 
+    (_, Kwd ")") 
+  ] -> is
 and
-  parse_type_params l = parser
-    [< xs = parse_angle_brackets l (rep_comma (parser [< '(_, Ident x) >] -> x)) >] -> xs
-  | [< >] -> []
+  parse_type_params l = function%parser
+| [ [%l xs = parse_angle_brackets l (rep_comma (function%parser [ (_, Ident x) ] -> x))] ] -> xs
+| [ ] -> []
 and
-  parse_pred_body = parser
-  | [< '(_, Kwd "="); p = parse_asn >] -> p
+  parse_pred_body = function%parser
+| [ (_, Kwd "="); 
+  parse_asn as p 
+  ] -> p
 and
-  parse_pred_paramlist = parser
-    [< 
-      '(_, Kwd "("); ps = rep_comma parse_param;
-      (ps, inputParamCount) = (parser [< '(_, Kwd ";"); ps' = rep_comma parse_param >] -> (ps @ ps', Some (List.length ps)) | [< >] -> (ps, None)); '(_, Kwd ")")
-    >] -> (ps, inputParamCount)
+  parse_pred_paramlist = function%parser
+| [ (_, Kwd "("); 
+    [%l ps = rep_comma parse_param];
+    [%l
+    (ps, inputParamCount) = (function%parser 
+    | [ (_, Kwd ";"); 
+        [%l ps' = rep_comma parse_param]
+      ] -> (ps @ ps', Some (List.length ps)) 
+    | [ ] -> (ps, None)
+    )
+    ]; 
+    (_, Kwd ")")
+  ] -> (ps, inputParamCount)
 and
-  parse_predicate_decl l (inductiveness: inductiveness) = parser 
-    [< '(li, Ident g); tparams = parse_type_params li; 
-     () = (fun _ -> push_typedef_scope ());
-     (ps, inputParamCount) = parse_pred_paramlist;
-     body = opt parse_pred_body;
-     '(_, Kwd ";");
-    >] ->
-    pop_typedef_scope ();
-    [PredFamilyDecl (l, g, tparams, 0, List.map (fun (t, p) -> t) ps, inputParamCount, inductiveness)] @
-    (match body with None -> [] | Some body -> [PredFamilyInstanceDecl (l, g, tparams, [], ps, body)])
+  parse_predicate_decl l (inductiveness: inductiveness) = function%parser 
+| [ (li, Ident g); 
+    [%l tparams = parse_type_params li]; 
+    [%l () = (fun _ -> push_typedef_scope ())];
+    [%l (ps, inputParamCount) = parse_pred_paramlist];
+    [%l body = opt parse_pred_body];
+    (_, Kwd ";");
+  ] ->
+  pop_typedef_scope ();
+  [PredFamilyDecl (l, g, tparams, 0, List.map (fun (t, p) -> t) ps, inputParamCount, inductiveness)] @
+  (match body with None -> [] | Some body -> [PredFamilyInstanceDecl (l, g, tparams, [], ps, body)])
 and
-  parse_pure_decl = parser
-    [< '(l, Kwd "inductive"); '(li, Ident i); tparams = parse_type_params li; '(_, Kwd "="); cs = (parser [< cs = parse_ctors >] -> cs | [< cs = parse_ctors_suffix >] -> cs); '(_, Kwd ";") >] -> [Inductive (l, i, tparams, cs)]
-  | [< '(l, Kwd "predicate"); result = parse_predicate_decl l Inductiveness_Inductive >] -> result
-  | [< '(l, Kwd "copredicate"); result = parse_predicate_decl l Inductiveness_CoInductive >] -> result
-  | [< '(l, Kwd "predicate_family"); '(_, Ident g); is = parse_paramlist; (ps, inputParamCount) = parse_pred_paramlist; '(_, Kwd ";") >]
-  -> [PredFamilyDecl (l, g, [], List.length is, List.map (fun (t, p) -> t) ps, inputParamCount, Inductiveness_Inductive)]
-  | [< '(l, Kwd "predicate_family_instance"); '(_, Ident g); is = parse_index_list; () = (fun _ -> push_typedef_scope ()); ps = parse_paramlist;
-     p = parse_pred_body; '(_, Kwd ";"); >] -> pop_typedef_scope (); [PredFamilyInstanceDecl (l, g, [], is, ps, p)]
-  | [< '(l, Kwd "predicate_ctor"); '(_, Ident g); () = (fun _ -> push_typedef_scope ()); ps1 = parse_paramlist; (ps2, inputParamCount) = parse_pred_paramlist;
-     p = parse_pred_body; '(_, Kwd ";"); >] -> pop_typedef_scope (); [PredCtorDecl (l, g, ps1, ps2, inputParamCount, p)]
-  | [< '(l, Kwd "lemma"); t = parse_return_type; d = parse_func_rest (Lemma(false, None)) t >] -> [d]
-  | [< '(l, Kwd "lemma_auto"); trigger = opt (parser [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); >] -> e); t = parse_return_type; d = parse_func_rest (Lemma(true, trigger)) t >] -> [d]
-  | [< '(l, Kwd "box_class"); '(_, Ident bcn); () = (fun _ -> push_typedef_scope ()); ps = parse_paramlist;
-       '(_, Kwd "{"); '(_, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";");
-       ads = parse_action_decls; hpds = parse_handle_pred_decls; '(_, Kwd "}") >] -> pop_typedef_scope (); [BoxClassDecl (l, bcn, ps, inv, ads, hpds)]
-  | [< '(l, Kwd "typedef"); '(_, Kwd "lemma"); rt = parse_return_type; '(li, Ident g); tps = parse_type_params li;
-       (ftps, ps) = parse_functype_paramlists; '(_, Kwd ";"); (pre, post, terminates) = parse_spec >] ->
-    [FuncTypeDecl (l, Ghost, rt, g, tps, ftps, ps, (pre, post, terminates))]
-  | [< '(l, Kwd "unloadable_module"); '(_, Kwd ";") >] -> [UnloadableModuleDecl l]
-  | [< '(l, Kwd "import_module"); '(_, Ident g); '(lx, Kwd ";") >] -> [ImportModuleDecl (l, g)]
-  | [< '(l, Kwd "require_module"); '(_, Ident g); '(lx, Kwd ";") >] -> [RequireModuleDecl (l, g)]
-  | [< '(l, Kwd "abstract_type"); '(_, Ident t); '(_, Kwd ";") >] -> [AbstractTypeDecl (l, t)]
-  | [< '(l, Kwd ("fixpoint"|"fixpoint_auto" as kwd)); rt = parse_return_type; '(lg, Ident g); tparams = parse_type_params_general;
-       () = (fun _ -> push_typedef_scope ());
-       ps = parse_paramlist;
-       decreases = begin parser
-         [< '(_, Kwd "decreases"); e = parse_expr; '(_, Kwd ";") >] -> Some e
-       | [< >] -> None
-       end;
-       body = begin parser
-         [< '(_, Kwd "{"); ss = parse_stmts; '(closeBraceLoc, Kwd "}") >] -> Some (ss, closeBraceLoc)
-       | [< '(_, Kwd ";") >] -> None
-       end
-    >] ->
+  parse_pure_decl = function%parser
+| [ (l, Kwd "inductive"); 
+    (li, Ident i); 
+    [%l tparams = parse_type_params li]; 
+    (_, Kwd "="); 
+    [%l
+    cs = (function%parser 
+    | [ parse_ctors as cs ] -> cs 
+    | [ parse_ctors_suffix as cs ] -> cs
+    )
+    ]; 
+    (_, Kwd ";") 
+  ] -> [Inductive (l, i, tparams, cs)]
+| [ (l, Kwd "predicate"); 
+    [%l result = parse_predicate_decl l Inductiveness_Inductive] 
+  ] -> result
+| [ (l, Kwd "copredicate"); 
+    [%l result = parse_predicate_decl l Inductiveness_CoInductive] 
+  ] -> result
+| [ (l, Kwd "predicate_family"); 
+    (_, Ident g); 
+    parse_paramlist as is; 
+    [%l (ps, inputParamCount) = parse_pred_paramlist]; 
+    (_, Kwd ";") 
+  ] -> [PredFamilyDecl (l, g, [], List.length is, List.map (fun (t, p) -> t) ps, inputParamCount, Inductiveness_Inductive)]
+| [ (l, Kwd "predicate_family_instance"); 
+    (_, Ident g); 
+    parse_index_list as is; 
+    [%l () = (fun _ -> push_typedef_scope ())]; 
+    parse_paramlist as ps;
+    parse_pred_body as p; 
+    (_, Kwd ";") 
+  ] -> pop_typedef_scope (); [PredFamilyInstanceDecl (l, g, [], is, ps, p)]
+| [ (l, Kwd "predicate_ctor"); 
+    (_, Ident g); 
+    [%l () = (fun _ -> push_typedef_scope ())]; 
+    parse_paramlist as ps1; 
+    [%l (ps2, inputParamCount) = parse_pred_paramlist];
+    parse_pred_body as p; 
+    (_, Kwd ";") 
+  ] -> pop_typedef_scope (); [PredCtorDecl (l, g, ps1, ps2, inputParamCount, p)]
+| [ (l, Kwd "lemma"); 
+    parse_return_type as t; 
+    [%l d = parse_func_rest (Lemma(false, None)) t] 
+  ] -> [d]
+| [ (l, Kwd "lemma_auto"); 
+    [%l
+    trigger = opt (function%parser 
+    | [ (_, Kwd "("); 
+      parse_expr as e; 
+      (_, Kwd ")") 
+      ] -> e
+    )
+    ]; 
+    parse_return_type as t; 
+    [%l d = parse_func_rest (Lemma(true, trigger)) t] 
+  ] -> [d]
+| [ (l, Kwd "box_class"); 
+    (_, Ident bcn); 
+    [%l () = (fun _ -> push_typedef_scope ())]; 
+    parse_paramlist as ps;
+    (_, Kwd "{"); 
+    (_, Kwd "invariant"); 
+    parse_asn as inv; 
+    (_, Kwd ";");
+    parse_action_decls as ads; 
+    parse_handle_pred_decls as hpds; 
+    (_, Kwd "}") 
+  ] -> pop_typedef_scope (); [BoxClassDecl (l, bcn, ps, inv, ads, hpds)]
+| [ (l, Kwd "typedef"); 
+    (_, Kwd "lemma"); 
+    parse_return_type as rt; 
+    (li, Ident g); 
+    [%l tps = parse_type_params li];
+    [%l (ftps, ps) = parse_functype_paramlists]; 
+    (_, Kwd ";"); 
+    [%l (pre, post, terminates) = parse_spec] 
+  ] -> [FuncTypeDecl (l, Ghost, rt, g, tps, ftps, ps, (pre, post, terminates))]
+| [ (l, Kwd "unloadable_module"); 
+    (_, Kwd ";") 
+  ] -> [UnloadableModuleDecl l]
+| [ (l, Kwd "import_module"); 
+    (_, Ident g); 
+    (lx, Kwd ";") 
+  ] -> [ImportModuleDecl (l, g)]
+| [ (l, Kwd "require_module"); 
+    (_, Ident g); 
+    (lx, Kwd ";") 
+  ] -> [RequireModuleDecl (l, g)]
+| [ (l, Kwd "abstract_type"); 
+    (_, Ident t); 
+    (_, Kwd ";") 
+  ] -> [AbstractTypeDecl (l, t)]
+| [ (l, Kwd ("fixpoint"|"fixpoint_auto" as kwd)); 
+    parse_return_type as rt; 
+    (lg, Ident g); 
+    parse_type_params_general as tparams;
+    [%l () = (fun _ -> push_typedef_scope ())];
+    parse_paramlist as ps;
+    [%l
+    decreases = begin function%parser
+    | [ (_, Kwd "decreases"); 
+        parse_expr as e; 
+        (_, Kwd ";") 
+      ] -> Some e
+    | [ ] -> None
+    end
+    ];
+    [%l
+    body = begin function%parser
+    | [ (_, Kwd "{"); 
+        parse_stmts as ss; 
+        (closeBraceLoc, Kwd "}") 
+      ] -> Some (ss, closeBraceLoc)
+    | [ (_, Kwd ";") ] -> None
+    end
+    ]
+  ] ->
     pop_typedef_scope ();
     let rec refers_to_g state e =
       match e with
@@ -841,77 +1075,135 @@ and
       [Func (l, Fixpoint, tparams, rt, g, ps, false, None, None, false, body, false, [])]
     end
 and
-  parse_action_decls = parser
-  [< ad = parse_action_decl; ads = parse_action_decls >] -> ad::ads
-| [< >] -> []
+  parse_action_decls = function%parser
+| [ parse_action_decl as ad; 
+    parse_action_decls as ads 
+  ] -> ad::ads
+| [ ] -> []
 and
-  parse_action_decl = parser
-  [< '(l, Kwd "action"); permbased = opt (parser [< '(_, Kwd "permbased") >] -> 0); '(_, Ident an); ps = parse_paramlist; '(_, Kwd ";");
-     '(_, Kwd "requires"); pre = parse_expr; '(_, Kwd ";");
-     '(_, Kwd "ensures"); post = parse_expr; '(_, Kwd ";") >] -> ActionDecl (l, an, (match permbased with None -> false | Some _ -> true), ps, pre, post)
-and
-  parse_handle_pred_decls = parser
-  [< hpd = parse_handle_pred_decl; hpds = parse_handle_pred_decls >] -> hpd::hpds
-| [< >] -> []
-and
-  parse_handle_pred_decl = parser
-  [< '(l, Kwd "handle_predicate"); '(_, Ident hpn); ps = parse_paramlist;
-     extends = opt (parser [< '(l, Kwd "extends"); '(_, Ident ehn) >] -> ehn);
-     '(_, Kwd "{"); '(_, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";"); pbcs = parse_preserved_by_clauses; '(_, Kwd "}") >]
-     -> HandlePredDecl (l, hpn, ps, extends, inv, pbcs)
-and
-  parse_preserved_by_clauses = parser
-  [< pbc = parse_preserved_by_clause; pbcs = parse_preserved_by_clauses >] -> pbc::pbcs
-| [< >] -> []
-and
-  parse_preserved_by_clause = parser
-  [< '(l, Kwd "preserved_by"); '(_, Ident an); '(_, Kwd "("); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ")");
-     ss = parse_block >] -> PreservedByClause (l, an, xs, ss)
-and
-  parse_type_params_free = parser [< '(_, Kwd "<"); xs = rep_comma (parser [< '(_, Ident x) >] -> x); '(_, Kwd ">") >] -> xs
-and
-  parse_type_params_general = parser
-  [< xs = parse_type_params_free >] -> xs
-| [<
-    xs = peek_in_ghost_range (
-      parser [<
-        xs = parse_type_params_free;
-        '(_, Kwd "@*/")
-      >] -> xs
+  parse_action_decl = function%parser
+| [ (l, Kwd "action"); 
+    [%l
+    permbased = opt (function%parser 
+    | [ (_, Kwd "permbased") ] -> 0
     )
-  >] -> xs
-| [< >] -> []
-and 
-  type_params_parse =
-    parser
-      [< xs = opt parse_type_params_general >] ->
-        match xs with
-         | Some(params) -> params
-         | None -> []
+    ]; 
+    (_, Ident an); 
+    parse_paramlist as ps; 
+    (_, Kwd ";");
+    (_, Kwd "requires"); 
+    parse_expr as pre; 
+    (_, Kwd ";");
+    (_, Kwd "ensures"); 
+    parse_expr as post; 
+    (_, Kwd ";") 
+  ] -> ActionDecl (l, an, (match permbased with None -> false | Some _ -> true), ps, pre, post)
 and
-  parse_func_rest k t = parser
-  [<
-    '(l, Ident g);
-    tparams = parse_type_params_general;
-    decl = parser
-      [<
-        '(_, Kwd "(");
-        () = (fun _ -> push_typedef_scope ());
-        ps = rep_comma parse_param;
-        ps = (fun _ -> List.filter filter_void_params ps);
-        '(_, Kwd ")");
-        f = parser
-          [< '(_, Kwd ";"); (nonghost_callers_only, ft, co, terminates) = parse_spec_clauses >] ->
-          Func (l, k, tparams, t, g, ps, nonghost_callers_only, ft, co, terminates, None, false, [])
-        | [< (nonghost_callers_only, ft, co, terminates) = parse_spec_clauses; '(_, Kwd "{"); ss = parse_stmts; '(closeBraceLoc, Kwd "}") >] ->
-          Func (l, k, tparams, t, g, ps, nonghost_callers_only, ft, co, terminates, Some (ss, closeBraceLoc), false, [])
-      >] -> pop_typedef_scope (); f
-    | [<
-        () = (fun s -> if k = Regular && tparams = [] && t <> None then () else raise Stream.Failure);
-        t = parse_array_braces (get t);
-        init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs t >] -> e);
-        '(_, Kwd ";")
-      >] ->
+  parse_handle_pred_decls = function%parser
+| [ parse_handle_pred_decl as hpd; 
+    parse_handle_pred_decls as hpds 
+  ] -> hpd::hpds
+| [ ] -> []
+and
+  parse_handle_pred_decl = function%parser
+  [ (l, Kwd "handle_predicate"); 
+  (_, Ident hpn); 
+  parse_paramlist as ps;
+  [%l 
+  extends = opt (function%parser 
+  | [ (l, Kwd "extends"); 
+      (_, Ident ehn) 
+    ] -> ehn
+  )
+  ];
+  (_, Kwd "{"); 
+  (_, Kwd "invariant"); 
+  parse_asn as inv; 
+  (_, Kwd ";"); 
+  parse_preserved_by_clauses as pbcs; 
+  (_, Kwd "}") 
+  ] -> HandlePredDecl (l, hpn, ps, extends, inv, pbcs)
+and
+  parse_preserved_by_clauses = function%parser
+| [ parse_preserved_by_clause as pbc; 
+    parse_preserved_by_clauses as pbcs 
+  ] -> pbc::pbcs
+| [ ] -> []
+and
+  parse_preserved_by_clause = function%parser
+| [ (l, Kwd "preserved_by"); 
+    (_, Ident an); 
+    (_, Kwd "("); 
+    [%l
+    xs = rep_comma (function%parser 
+    | [ (_, Ident x) ] -> x
+    )
+    ]; 
+    (_, Kwd ")");
+    parse_block as ss 
+  ] -> PreservedByClause (l, an, xs, ss)
+and
+  parse_type_params_free = function%parser 
+| [ (_, Kwd "<"); 
+    [%l 
+    xs = rep_comma (function%parser 
+    | [ (_, Ident x) ] -> x
+    )
+    ]; 
+    (_, Kwd ">") 
+  ] -> xs
+and
+  parse_type_params_general = function%parser
+| [ parse_type_params_free as xs ] -> xs
+| [ [%l
+    xs = peek_in_ghost_range (function%parser 
+    | [ parse_type_params_free as xs;
+        (_, Kwd "@*/")
+      ] -> xs
+    )
+    ]
+  ] -> xs
+| [ ] -> []
+and 
+  type_params_parse = function%parser
+| [ [%l xs = opt parse_type_params_general] ] ->
+    match xs with
+    | Some(params) -> params
+    | None -> []
+and
+  parse_func_rest k t = function%parser
+| [ (l, Ident g);
+    parse_type_params_general as tparams;
+    [%l
+    decl = function%parser
+    | [ (_, Kwd "(");
+        [%l () = (fun _ -> push_typedef_scope ())];
+        [%l ps = rep_comma parse_param];
+        [%l ps = (fun _ -> List.filter filter_void_params ps)];
+        (_, Kwd ")");
+        [%l
+        f = function%parser
+        | [ (_, Kwd ";"); 
+            [%l (nonghost_callers_only, ft, co, terminates) = parse_spec_clauses] 
+          ] -> Func (l, k, tparams, t, g, ps, nonghost_callers_only, ft, co, terminates, None, false, [])
+        | [ [%l (nonghost_callers_only, ft, co, terminates) = parse_spec_clauses]; 
+            (_, Kwd "{"); 
+            parse_stmts as ss; 
+            (closeBraceLoc, Kwd "}") 
+          ] -> Func (l, k, tparams, t, g, ps, nonghost_callers_only, ft, co, terminates, Some (ss, closeBraceLoc), false, [])
+        ]
+      ] -> pop_typedef_scope (); f
+    | [ [%l () = (fun s -> if k = Regular && tparams = [] && t <> None then () else raise Stream.Failure)];
+        [%l t = parse_array_braces (get t)];
+        [%l
+        init = opt (function%parser 
+        | [ (_, Kwd "="); 
+            [%l e = parse_declaration_rhs t] 
+          ] -> e
+        )
+        ];
+        (_, Kwd ";")
+      ] ->
       let t =
         match t, init with
           ArrayTypeExpr (l, elemTp), Some (InitializerList (_, es)) ->
@@ -919,175 +1211,271 @@ and
         | _ -> t
       in
       Global (l, t, g, init)
-  >] -> decl
+    ]
+  ] -> decl
 and
-  parse_ctors_suffix = parser
-  [< '(_, Kwd "|"); cs = parse_ctors >] -> cs
-| [< >] -> []
+  parse_ctors_suffix = function%parser
+| [ (_, Kwd "|"); 
+    parse_ctors as cs 
+  ] -> cs
+| [ ] -> []
 and
-  parse_ctors = parser
-  [< '(l, Ident cn);
-     ts = begin
-       parser
-         [< '(_, Kwd "(");
-             ts = rep_comma parse_paramtype_and_name;
-             '(_, Kwd ")")
-         >] -> ts
-       | [< >] -> []
-     end;
-     cs = parse_ctors_suffix
-  >] -> Ctor (l, cn, ts)::cs
+  parse_ctors = function%parser
+| [ (l, Ident cn);
+    [%l
+    ts = begin function%parser
+    | [ (_, Kwd "(");
+        [%l ts = rep_comma parse_paramtype_and_name];
+        (_, Kwd ")")
+      ] -> ts
+    | [ ] -> []
+    end
+    ];
+    parse_ctors_suffix as cs
+  ] -> Ctor (l, cn, ts)::cs
 and
-  parse_paramtype_and_name = parser
-  [< t = parse_type;
-     paramname_opt = opt (parser
-       [< '(_, Ident paramname) >] -> paramname
-     )
-  >] ->
+  parse_paramtype_and_name = function%parser
+| [ parse_type as t;
+    [%l 
+    paramname_opt = opt (function%parser
+    | [ (_, Ident paramname) ] -> paramname
+    )
+    ]
+  ] ->
     let paramname = match paramname_opt with None -> "" | Some(x) -> x in
     (paramname, t)
 and
-  parse_paramtype = parser [< t = parse_type; _ = opt (parser [< '(_, Ident _) >] -> ()) >] -> t
+  parse_paramtype = function%parser [ parse_type as t; [%l _d = opt (function%parser [ (_, Ident _) ] -> ())] ] -> t
 and
-  parse_fields = parser
-  [< '(_, Kwd "{"); fs = parse_fields_rest >] -> fs
+  parse_fields = function%parser
+| [ (_, Kwd "{"); 
+    parse_fields_rest as fs 
+  ] -> fs
 and
-  parse_fields_rest = parser
-  [< '(_, Kwd "}") >] -> []
-| [< f = parse_field; fs = parse_fields_rest >] -> f::fs
+  parse_fields_rest = function%parser
+| [ (_, Kwd "}") ] -> []
+| [ parse_field as f; 
+    parse_fields_rest as fs 
+  ] -> f::fs
 and
-  parse_field = parser
-  [< '(_, Kwd "/*@"); f = parse_field_core Ghost; '(_, Kwd "@*/") >] -> f
-| [< f = parse_field_core Real >] -> f
+  parse_field = function%parser
+| [ (_, Kwd "/*@"); 
+    [%l f = parse_field_core Ghost]; 
+    (_, Kwd "@*/") 
+  ] -> f
+| [ [%l f = parse_field_core Real] ] -> f
 and
-  parse_field_core gh = parser
-  [< te0 = parse_type; '(l, Ident f);
-     te = parser
-        [< '(_, Kwd ";") >] -> te0
-      | [< '(_, Kwd "["); '(ls, Int (size, _, _, _, _)); '(_, Kwd "]"); '(_, Kwd ";") >] ->
-            if int_of_big_int size <= 0 then
-              raise (ParseException (ls, "Array must have size > 0."));
-            StaticArrayTypeExpr (l, te0, int_of_big_int size)
-   >] -> Field (l, gh, te, f, Instance, Public, false, None)
+  parse_field_core gh = function%parser
+| [ parse_type as te0; 
+    (l, Ident f);
+    [%l
+    te = function%parser
+    | [ (_, Kwd ";") ] -> te0
+    | [ (_, Kwd "["); 
+        (ls, Int (size, _, _, _, _)); 
+        (_, Kwd "]"); 
+        (_, Kwd ";") 
+      ] ->
+        if int_of_big_int size <= 0 then
+          raise (ParseException (ls, "Array must have size > 0."));
+        StaticArrayTypeExpr (l, te0, int_of_big_int size)
+    ]
+  ] -> Field (l, gh, te, f, Instance, Public, false, None)
 and
-  parse_struct_attrs = parser (* GCC-style attributes are always in double parentheses, see https://gcc.gnu.org/onlinedocs/gcc/Variable-Attributes.html *)
-  [< '(_, Kwd "("); '(_, Kwd "("); attrs = rep_comma parse_struct_attr; '(_, Kwd ")"); '(_, Kwd ")"); >] -> attrs
+  parse_struct_attrs = function%parser (* GCC-style attributes are always in double parentheses, see https://gcc.gnu.org/onlinedocs/gcc/Variable-Attributes.html *)
+  [ (_, Kwd "("); 
+    (_, Kwd "("); 
+    [%l attrs = rep_comma parse_struct_attr]; 
+    (_, Kwd ")"); 
+    (_, Kwd ")"); 
+  ] -> attrs
 and
-  parse_struct_attr = parser
-  [< '(_, Ident "packed") >] -> Packed
+  parse_struct_attr = function%parser
+| [ (_, Ident "packed") ] -> Packed
 and
-  parse_return_type = parser
-  [< t = parse_type >] -> match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t
+  parse_return_type = function%parser
+| [ parse_type as t ] -> match t with ManifestTypeExpr (_, Void) -> None | _ -> Some t
 and
-  parse_type = parser
-  [< t0 = parse_primary_type; t = parse_type_suffix t0 >] -> t
+  parse_type = function%parser
+| [ parse_primary_type as t0; 
+    [%l t = parse_type_suffix t0] 
+  ] -> t
 and
-  parse_int_opt = parser
-  [< '(_, Kwd "int") >] -> ()
-| [< >] -> ()
+  parse_int_opt = function%parser
+| [ (_, Kwd "int") ] -> ()
+| [ ] -> ()
 and
-  parse_integer_type_keyword = parser
-  [< '(l, Kwd "int") >] -> (l, IntRank)
-| [< '(l, Kwd "__int8") >] -> (l, FixedWidthRank 0)
-| [< '(l, Kwd "__int16") >] -> (l, FixedWidthRank 1)
-| [< '(l, Kwd "__int32") >] -> (l, FixedWidthRank 2)
-| [< '(l, Kwd "__int64") >] -> (l, FixedWidthRank 3)
-| [< '(l, Kwd "__int128") >] -> (l, FixedWidthRank 4)
+  parse_integer_type_keyword = function%parser
+| [ (l, Kwd "int") ] -> (l, IntRank)
+| [ (l, Kwd "__int8") ] -> (l, FixedWidthRank 0)
+| [ (l, Kwd "__int16") ] -> (l, FixedWidthRank 1)
+| [ (l, Kwd "__int32") ] -> (l, FixedWidthRank 2)
+| [ (l, Kwd "__int64") ] -> (l, FixedWidthRank 3)
+| [ (l, Kwd "__int128") ] -> (l, FixedWidthRank 4)
 and
-  parse_integer_size_specifier = parser
-| [< '(_, Kwd "short") >] -> ShortRank
-| [< '(_, Kwd "long");
-     n = begin parser
-       [< '(_, Kwd "long") >] -> LongLongRank
-     | [< >] -> LongRank
-     end >] -> n
-| [< >] -> IntRank
+  parse_integer_size_specifier = function%parser
+| [ (_, Kwd "short") ] -> ShortRank
+| [ (_, Kwd "long");
+    [%l
+    n = begin function%parser
+    | [ (_, Kwd "long") ] -> LongLongRank
+    | [ ] -> LongRank
+    end
+    ] 
+  ] -> n
+| [ ] -> IntRank
 and
-  parse_integer_type_rest = parser
-  [< '(_, Kwd "char") >] -> CharRank
-| [< (_, k) = parse_integer_type_keyword >] -> k
-| [< n = parse_integer_size_specifier; _ = opt (parser [< '(_, Kwd "int") >] -> ()) >] -> n
+  parse_integer_type_rest = function%parser
+| [ (_, Kwd "char") ] -> CharRank
+| [ [%l (_d, k) = parse_integer_type_keyword] ] -> k
+| [ parse_integer_size_specifier as n; 
+    [%l _d = opt (function%parser [ (_, Kwd "int") ] -> ())] 
+  ] -> n
 and
-  parse_primary_type = parser
-  [< '(l, Kwd "volatile"); t0 = parse_primary_type >] -> t0
-| [< '(l, Kwd "const"); t0 = parse_primary_type >] -> t0
-| [< '(l, Kwd "register"); t0 = parse_primary_type >] -> t0
-| [< '(l, Kwd "struct"); sn = opt (parser [< '(_, Ident s) >] -> s); fs = opt parse_fields; attrs = begin parser
-    [< '(_, Kwd "__attribute__"); res = parse_struct_attrs >] -> res
-  | [< >] -> [] end >] ->
+  parse_primary_type = function%parser
+| [ (l, Kwd "volatile"); 
+    parse_primary_type as t0 
+  ] -> t0
+| [ (l, Kwd "const"); 
+    parse_primary_type as t0 
+  ] -> t0
+| [ (l, Kwd "register"); 
+    parse_primary_type as t0 
+  ] -> t0
+| [ (l, Kwd "struct"); 
+    [%l
+    sn = opt (function%parser 
+    | [ (_, Ident s) ] -> s
+    )
+    ]; 
+    [%l fs = opt parse_fields]; 
+    [%l
+    attrs = begin function%parser
+    | [ (_, Kwd "__attribute__"); 
+        parse_struct_attrs as res 
+      ] -> res
+    | [ ] -> [] 
+    end 
+    ]
+  ] ->
   if sn = None && fs = None then raise (ParseException (l, "Struct name or body expected"));
   StructTypeExpr (l, sn, fs, attrs)
-| [< '(l, Kwd "union"); un = opt (parser [< '(_, Ident u) >] -> u); fs = opt parse_fields >] ->
+| [ (l, Kwd "union"); 
+    [%l un = opt (function%parser [ (_, Ident u) ] -> u)]; 
+    [%l fs = opt parse_fields]
+  ] ->
   if un = None && fs = None then raise (ParseException (l, "Union name or body expected"));
   UnionTypeExpr (l, un, fs)
-| [< '(l, Kwd "enum"); en = opt (parser [< '(_, Ident en) >] -> en); body = opt parse_enum_body >] ->
+| [ (l, Kwd "enum"); 
+    [%l en = opt (function%parser [ (_, Ident en) ] -> en)]; 
+    [%l body = opt parse_enum_body] 
+  ] ->
   if en = None && body = None then raise (ParseException (l, "Enum name or body expected"));
   EnumTypeExpr (l, en, body)
-| [< (l, k) = parse_integer_type_keyword >] -> ManifestTypeExpr (l, Int (Signed, k))
-| [< '(l, Kwd "float") >] -> ManifestTypeExpr (l, Float)
-| [< '(l, Kwd "double") >] -> ManifestTypeExpr (l, Double)
-| [< '(l, Kwd "short") >] -> ManifestTypeExpr(l, Int (Signed, ShortRank))
-| [< '(l, Kwd "long");
-     t = begin parser
-       [< '(_, Kwd "int") >] -> ManifestTypeExpr (l, longType);
-     | [< '(_, Kwd "double") >] -> ManifestTypeExpr (l, LongDouble);
-     | [< '(_, Kwd "long"); _ = opt (parser [< '(_, Kwd "int") >] -> ()) >] -> ManifestTypeExpr (l, Int (Signed, LongLongRank))
-     | [< >] -> ManifestTypeExpr (l, longType)
-     end
-   >] -> t
-| [< '(l, Kwd "signed"); n = parse_integer_type_rest >] -> ManifestTypeExpr (l, Int (Signed, n))
-| [< '(l, Kwd "__signed__"); n = parse_integer_type_rest >] -> ManifestTypeExpr (l, Int (Signed, n))
-| [< '(l, Kwd "unsigned"); n = parse_integer_type_rest >] -> ManifestTypeExpr (l, Int (Unsigned, n))
-| [< '(l, Kwd "uintptr_t") >] -> ManifestTypeExpr (l, Int (Unsigned, PtrRank))
-| [< '(l, Kwd "intptr_t") >] -> ManifestTypeExpr (l, Int (Signed, PtrRank))
-| [< '(l, Kwd "real") >] -> ManifestTypeExpr (l, RealType)
-| [< '(l, Kwd "bool") >] -> ManifestTypeExpr (l, Bool)
-| [< '(l, Kwd "boolean") >] -> ManifestTypeExpr (l, Bool)
-| [< '(l, Kwd "void") >] -> ManifestTypeExpr (l, Void)
-| [< '(l, Kwd "char") >] -> ManifestTypeExpr (l, match language with CLang -> Int (Signed, CharRank) | Java -> java_char_type)
-| [< '(l, Kwd "byte") >] -> ManifestTypeExpr (l, java_byte_type)
-| [< '(l, Kwd "predicate");
-     '(_, Kwd "(");
-     ts = rep_comma parse_paramtype;
-     ts' = opt (parser [< '(_, Kwd ";"); ts' = rep_comma parse_paramtype >] -> ts');
-     '(_, Kwd ")")
-  >] -> begin match ts' with None -> PredTypeExpr (l, ts, None) | Some ts' -> PredTypeExpr (l, ts @ ts', Some (List.length ts)) end
-| [< '(l, Kwd "fixpoint"); '(_, Kwd "("); ts = rep_comma parse_paramtype; '(_, Kwd ")") >] -> PureFuncTypeExpr (l, ts)
-| [< '(l, Kwd "box") >] -> ManifestTypeExpr (l, BoxIdType)
-| [< '(l, Kwd "handle") >] -> ManifestTypeExpr (l, HandleIdType)
-| [< '(l, Kwd "any") >] -> ManifestTypeExpr (l, AnyType)
-| [< '(l, Ident n); rest = rep(parser [< '(l, Kwd "."); '(l, Ident n) >] -> n); (targs, diamond) = parse_type_args_with_diamond l >] -> 
-    if diamond then ConstructedTypeExpr(l,n, []) else
-    if targs <> [] then 
-      match rest with
-      | [] -> ConstructedTypeExpr (l, n, targs) 
-      | _ -> raise (ParseException (l, "Package name not supported for generic types."))
-    else
-      match rest with
-        [] -> IdentTypeExpr(l, None, n)
-      | _ -> 
-      let pac = (String.concat "." (n :: (take ((List.length rest) -1) rest))) in
-      IdentTypeExpr(l, Some (pac), List.nth rest ((List.length rest) - 1))
+| [ [%l (l, k) = parse_integer_type_keyword] ] -> ManifestTypeExpr (l, Int (Signed, k))
+| [ (l, Kwd "float") ] -> ManifestTypeExpr (l, Float)
+| [ (l, Kwd "double") ] -> ManifestTypeExpr (l, Double)
+| [ (l, Kwd "short") ] -> ManifestTypeExpr(l, Int (Signed, ShortRank))
+| [ (l, Kwd "long");
+    [%l
+    t = begin function%parser
+    | [ (_, Kwd "int") ] -> ManifestTypeExpr (l, longType);
+    | [ (_, Kwd "double") ] -> ManifestTypeExpr (l, LongDouble);
+    | [ (_, Kwd "long"); 
+        [%l 
+        _d = opt (function%parser 
+        | [ (_, Kwd "int") ] -> ()
+        ) 
+        ]
+      ] -> ManifestTypeExpr (l, Int (Signed, LongLongRank))
+    | [ ] -> ManifestTypeExpr (l, longType)
+    end
+    ]
+  ] -> t
+| [ (l, Kwd "signed"); 
+    parse_integer_type_rest as n 
+  ] -> ManifestTypeExpr (l, Int (Signed, n))
+| [ (l, Kwd "__signed__"); 
+    parse_integer_type_rest as n
+  ] -> ManifestTypeExpr (l, Int (Signed, n))
+| [ (l, Kwd "unsigned"); 
+    parse_integer_type_rest as n 
+  ] -> ManifestTypeExpr (l, Int (Unsigned, n))
+| [ (l, Kwd "uintptr_t") ] -> ManifestTypeExpr (l, Int (Unsigned, PtrRank))
+| [ (l, Kwd "intptr_t") ] -> ManifestTypeExpr (l, Int (Signed, PtrRank))
+| [ (l, Kwd "real") ] -> ManifestTypeExpr (l, RealType)
+| [ (l, Kwd "bool") ] -> ManifestTypeExpr (l, Bool)
+| [ (l, Kwd "boolean") ] -> ManifestTypeExpr (l, Bool)
+| [ (l, Kwd "void") ] -> ManifestTypeExpr (l, Void)
+| [ (l, Kwd "char") ] -> ManifestTypeExpr (l, match language with CLang -> Int (Signed, CharRank) | Java -> java_char_type)
+| [ (l, Kwd "byte") ] -> ManifestTypeExpr (l, java_byte_type)
+| [ (l, Kwd "predicate");
+    (_, Kwd "(");
+    [%l ts = rep_comma parse_paramtype];
+    [%l ts' = opt (function%parser [ (_, Kwd ";"); [%l ts' = rep_comma parse_paramtype] ] -> ts')];
+    (_, Kwd ")")
+  ] -> begin match ts' with None -> PredTypeExpr (l, ts, None) | Some ts' -> PredTypeExpr (l, ts @ ts', Some (List.length ts)) end
+| [ (l, Kwd "fixpoint"); 
+    (_, Kwd "("); 
+    [%l ts = rep_comma parse_paramtype]; 
+    (_, Kwd ")") 
+  ] -> PureFuncTypeExpr (l, ts)
+| [ (l, Kwd "box") ] -> ManifestTypeExpr (l, BoxIdType)
+| [ (l, Kwd "handle") ] -> ManifestTypeExpr (l, HandleIdType)
+| [ (l, Kwd "any") ] -> ManifestTypeExpr (l, AnyType)
+| [ (l, Ident n); 
+    [%l
+    rest = rep (function%parser 
+    | [ (l, Kwd "."); 
+        (l, Ident n) 
+      ] -> n
+    )
+    ]; 
+    [%l (targs, diamond) = parse_type_args_with_diamond l] 
+  ] -> 
+  if diamond then ConstructedTypeExpr(l,n, []) else
+  if targs <> [] then 
+    match rest with
+    | [] -> ConstructedTypeExpr (l, n, targs) 
+    | _ -> raise (ParseException (l, "Package name not supported for generic types."))
+  else
+    match rest with
+      [] -> IdentTypeExpr(l, None, n)
+    | _ -> 
+    let pac = (String.concat "." (n :: (take ((List.length rest) -1) rest))) in
+    IdentTypeExpr(l, Some (pac), List.nth rest ((List.length rest) - 1))
 and
-  parse_type_suffix t0 = parser
-  [< '(l, Kwd "*"); t = parse_type_suffix (PtrTypeExpr (l, t0)) >] -> t
-| [< '(l, Kwd "volatile"); t = parse_type_suffix t0 >] -> t
-| [< '(l, Kwd "const"); t = parse_type_suffix t0 >] -> t
-| [< '(l, Kwd "[") when language = Java; '(_, Kwd "]"); t = parse_type_suffix (ArrayTypeExpr (l,t0)) >] -> t
-| [< >] -> t0
+  parse_type_suffix t0 = function%parser
+| [ (l, Kwd "*"); 
+    [%l t = parse_type_suffix (PtrTypeExpr (l, t0))] 
+  ] -> t
+| [ (l, Kwd "volatile"); 
+    [%l t = parse_type_suffix t0] 
+  ] -> t
+| [ (l, Kwd "const"); 
+    [%l t = parse_type_suffix t0] 
+  ] -> t
+| [ (l, Kwd "["); 
+    (_, Kwd "]"); 
+    [%l t = parse_type_suffix (ArrayTypeExpr (l,t0))] 
+  ] when language = Java -> t
+| [ ] -> t0
 and
 (* parse function parameters: *)
-  parse_paramlist =
-  parser
-    [< '(_, Kwd "("); ps = rep_comma parse_param; '(_, Kwd ")") >] ->
-    List.filter filter_void_params ps
+  parse_paramlist = function%parser
+| [ (_, Kwd "("); 
+    [%l ps = rep_comma parse_param]; 
+    (_, Kwd ")") 
+  ] -> List.filter filter_void_params ps
 and
   filter_void_params ps = match ps with
     (ManifestTypeExpr (_, Void), "") -> false
   | _ -> true
 and
-  parse_param = parser
-    [< t = parse_type; f = parse_declarator0 >] ->
+  parse_param = function%parser
+| [ parse_type as t; 
+    parse_declarator0 as f 
+  ] ->
     let (t, pn) = f t in
     begin match t with
       ManifestTypeExpr (_, Void) -> 
@@ -1103,91 +1491,182 @@ and
         (t, pname)
       end
     end
-  | [< '(l, Kwd "...") >] -> (ConstructedTypeExpr (l, "list", [IdentTypeExpr (l, None, "vararg")]), "varargs")
+| [ (l, Kwd "...") ] -> (ConstructedTypeExpr (l, "list", [IdentTypeExpr (l, None, "vararg")]), "varargs")
 and
-  parse_functypeclause_args = parser
-  [< '(_, Kwd "("); args = rep_comma (parser [< '(l, Ident x) >] -> (l, x)); '(_, Kwd ")") >] -> args
-| [< >] -> []
+  parse_functypeclause_args = function%parser
+| [ (_, Kwd "("); 
+    [%l 
+    args = rep_comma (function%parser 
+    | [ (l, Ident x) ] -> (l, x)
+    )
+    ]; 
+    (_, Kwd ")") 
+  ] -> args
+| [ ] -> []
 and
-  parse_pure_spec_clause = parser
-  [< '(_, Kwd "nonghost_callers_only") >] -> NonghostCallersOnlyClause
-| [< '(l, Kwd "terminates"); '(_, Kwd ";") >] -> TerminatesClause l
-| [< '(_, Kwd ":"); '(li, Ident ft); targs = parse_type_args li; ftargs = parse_functypeclause_args >] -> FuncTypeClause (ft, targs, ftargs)
-| [< '(_, Kwd "requires"); p = parse_asn; '(_, Kwd ";") >] -> RequiresClause p
-| [< '(_, Kwd "ensures"); p = parse_asn; '(_, Kwd ";") >] -> EnsuresClause p
+  parse_pure_spec_clause = function%parser
+| [ (_, Kwd "nonghost_callers_only") ] -> NonghostCallersOnlyClause
+| [ (l, Kwd "terminates"); 
+    (_, Kwd ";") 
+  ] -> TerminatesClause l
+| [ (_, Kwd ":"); 
+    (li, Ident ft); 
+    [%l targs = parse_type_args li]; 
+    parse_functypeclause_args as ftargs 
+  ] -> FuncTypeClause (ft, targs, ftargs)
+| [ (_, Kwd "requires"); 
+    parse_asn as p; 
+    (_, Kwd ";") 
+  ] -> RequiresClause p
+| [ (_, Kwd "ensures"); 
+    parse_asn as p; 
+    (_, Kwd ";") 
+  ] -> EnsuresClause p
 and
-  parse_spec_clause = parser
-  [< c = peek_in_ghost_range (parser [< c = parse_pure_spec_clause; '(_, Kwd "@*/") >] -> c) >] -> c
-| [< c = parse_pure_spec_clause >] -> c
+  parse_spec_clause = function%parser
+| [ [%l
+    c = peek_in_ghost_range (function%parser 
+        | [ parse_pure_spec_clause as c; 
+            (_, Kwd "@*/") 
+          ] -> c
+        )
+    ] 
+  ] -> c
+| [ parse_pure_spec_clause as c ] -> c
 and
   parse_spec_clauses = fun token_stream ->
     let in_count = ref 0 in
     let out_count = ref 0 in
     let clause_stream = Stream.from (fun _ -> try let clause = Some (parse_spec_clause token_stream) in in_count := !in_count + 1; clause with Stream.Failure -> None) in
-    let nonghost_callers_only = (parser [< 'NonghostCallersOnlyClause >] -> out_count := !out_count + 1; true | [< >] -> false) clause_stream in
-    let ft = (parser [< 'FuncTypeClause (ft, fttargs, ftargs) >] -> out_count := !out_count + 1; Some (ft, fttargs, ftargs) | [< >] -> None) clause_stream in
-    let pre_post = (parser [< 'RequiresClause pre; 'EnsuresClause post; >] -> out_count := !out_count + 2; Some (pre, post) | [< >] -> None) clause_stream in
-    let terminates = (parser [< '(TerminatesClause l) >] -> out_count := !out_count + 1; true | [< >] -> false) clause_stream in
+    let nonghost_callers_only = (function%parser [ NonghostCallersOnlyClause ] -> out_count := !out_count + 1; true | [ ] -> false) clause_stream in
+    let ft = (function%parser [ FuncTypeClause (ft, fttargs, ftargs) ] -> out_count := !out_count + 1; Some (ft, fttargs, ftargs) | [ ] -> None) clause_stream in
+    let pre_post = (function%parser [ RequiresClause pre; EnsuresClause post; ] -> out_count := !out_count + 2; Some (pre, post) | [ ] -> None) clause_stream in
+    let terminates = (function%parser [ (TerminatesClause l) ] -> out_count := !out_count + 1; true | [ ] -> false) clause_stream in
     if !in_count > !out_count then raise (Stream.Error "The number, kind, or order of specification clauses is incorrect. Expected: nonghost_callers_only clause (optional), function type clause (optional), contract (optional), terminates clause (optional).");
     (nonghost_callers_only, ft, pre_post, terminates)
 and
-  parse_spec = parser
-    [< (nonghost_callers_only, ft, pre_post, terminates) = parse_spec_clauses >] ->
+  parse_spec = function%parser
+| [ [%l (nonghost_callers_only, ft, pre_post, terminates) = parse_spec_clauses] ] ->
     match (nonghost_callers_only, ft, pre_post) with
       (false, None, None) -> raise Stream.Failure
     | (false, None, (Some (pre, post))) -> (pre, post, terminates)
     | _ -> raise (Stream.Error "Incorrect kind, number, or order of specification clauses. Expected: requires clause, ensures clause, terminates clause (optional).")
 and
-  parse_block = parser
-  [< '(l, Kwd "{"); ss = parse_stmts; '(_, Kwd "}") >] -> ss
+  parse_block = function%parser
+| [ (l, Kwd "{"); 
+    parse_stmts as ss; 
+    (_, Kwd "}") 
+  ] -> ss
 and
-  parse_block_stmt = parser
-  [< '(l, Kwd "{");
-     (l, ds, ss, locals_to_free) = (parser
-       [< '(Lexed (sp1, _), Kwd "/*@");
-          b = parser
-          | [< d = parse_pure_decl; ds = parse_pure_decls; '(_, Kwd "@*/"); ss = parse_stmts >] -> (l, d @ ds, ss, ref [])
-          | [< s = parse_stmt0; '(Lexed (_, sp2), Kwd "@*/"); ss = parse_stmts >] -> (l, [], PureStmt (Lexed (sp1, sp2), s)::ss, ref [])
-       >] -> b
-     | [< ds = parse_pure_decls; ss = parse_stmts >] -> (l, ds, ss, ref []));
-     '(closeBraceLoc, Kwd "}")
-  >] -> BlockStmt(l, ds, ss, closeBraceLoc, locals_to_free)
+  parse_block_stmt = function%parser
+| [ (l, Kwd "{");
+    [%l
+    (l, ds, ss, locals_to_free) = (function%parser
+    | [ (Lexed (sp1, _), Kwd "/*@");
+        [%l
+        b = function%parser
+        | [ parse_pure_decl as d; 
+            parse_pure_decls as ds; 
+            (_, Kwd "@*/"); 
+            parse_stmts as ss 
+          ] -> (l, d @ ds, ss, ref [])
+        | [ parse_stmt0 as s; 
+            (Lexed (_, sp2), Kwd "@*/"); 
+            parse_stmts as ss 
+          ] -> (l, [], PureStmt (Lexed (sp1, sp2), s)::ss, ref [])
+        ]
+       ] -> b
+    | [ parse_pure_decls as ds; 
+        parse_stmts as ss 
+      ] -> (l, ds, ss, ref [])
+    )
+    ];
+    (closeBraceLoc, Kwd "}")
+  ] -> BlockStmt(l, ds, ss, closeBraceLoc, locals_to_free)
 and
-  parse_stmts = parser
-  [< s = parse_stmt; ss = parse_stmts >] -> s::ss
-| [< >] -> []
+  parse_stmts = function%parser
+| [ parse_stmt as s; 
+    parse_stmts as ss 
+  ] -> s::ss
+| [ ] -> []
 and
-  parse_stmt = parser [< s = parse_stmt0 >] -> !stats#stmtParsed; s
+  parse_stmt = function%parser [ parse_stmt0 as s ] -> !stats#stmtParsed; s
 and
-  parse_coef = parser
-  [< '(l, Kwd "["); pat = parse_pattern; '(_, Kwd "]") >] -> pat
-and parse_producing_handle_predicate = parser
-  [< '(lph, Ident post_hpn); post_hp_args = parse_arglist; >] -> (lph, post_hpn, post_hp_args)
+  parse_coef = function%parser
+| [ (l, Kwd "["); 
+    parse_pattern as pat; 
+    (_, Kwd "]") 
+  ] -> pat
+and parse_producing_handle_predicate = function%parser
+| [ (lph, Ident post_hpn); 
+    parse_arglist as post_hp_args; 
+  ] -> (lph, post_hpn, post_hp_args)
 and
-  parse_producing_handle_predicate_list = parser
-  [< '(l, Kwd "if"); '(_, Kwd "("); condition = parse_expr; '(_, Kwd ")"); (lph, post_hpn, post_hp_args) = parse_producing_handle_predicate; '(_, Kwd "else"); rest = parse_producing_handle_predicate_list >] -> ConditionalProducingHandlePredicate(lph, condition, post_hpn, post_hp_args, rest); 
-| [< (lph, post_hpn, post_hp_args) = parse_producing_handle_predicate >] -> BasicProducingHandlePredicate(lph, post_hpn, post_hp_args)
+  parse_producing_handle_predicate_list = function%parser
+| [ (l, Kwd "if"); 
+    (_, Kwd "("); 
+    parse_expr as condition; 
+    (_, Kwd ")"); 
+    [%l (lph, post_hpn, post_hp_args) = parse_producing_handle_predicate]; 
+    (_, Kwd "else"); 
+    parse_producing_handle_predicate_list as rest 
+  ] -> ConditionalProducingHandlePredicate(lph, condition, post_hpn, post_hp_args, rest); 
+| [ [%l (lph, post_hpn, post_hp_args) = parse_producing_handle_predicate] ] -> BasicProducingHandlePredicate(lph, post_hpn, post_hp_args)
 and
-  parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause = parser
-  [< '(li, Ident ftn);
-     targs = parse_type_args li;
-     args = parse_arglist;
-     '(_, Kwd "("); params = rep_comma (parser [< '(l, Ident x) >] -> (l, x)); '(_, Kwd ")");
-     '(openBraceLoc, Kwd "{"); ss = parse_stmts; '(closeBraceLoc, Kwd "}") >] ->
-     (ftn, targs, args, params, openBraceLoc, ss, closeBraceLoc)
+  parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause = function%parser
+| [ (li, Ident ftn);
+    [%l targs = parse_type_args li];
+    parse_arglist as args;
+    (_, Kwd "("); 
+    [%l params = rep_comma (function%parser [ (l, Ident x) ] -> (l, x))]; 
+    (_, Kwd ")");
+    (openBraceLoc, Kwd "{"); 
+    parse_stmts as ss; 
+    (closeBraceLoc, Kwd "}") 
+  ] -> (ftn, targs, args, params, openBraceLoc, ss, closeBraceLoc)
 and
-  parse_stmt0 = parser
-  [< '(Lexed (sp1, _), Kwd "/*@"); s = parse_stmt0; '(Lexed (_, sp2), Kwd "@*/") >] -> PureStmt (Lexed (sp1, sp2), s)
-| [< '(Lexed (sp1, _), Kwd "@*/"); s = parse_stmt; '(Lexed (_, sp2), Kwd "/*@") >] -> NonpureStmt (Lexed (sp1, sp2), false, s)
-| [< '(l, Kwd "if"); '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); s1 = parse_stmt;
-     s = parser
-       [< '(_, Kwd "else"); s2 = parse_stmt >] -> IfStmt (l, e, [s1], [s2])
-     | [< >] -> IfStmt (l, e, [s1], [])
-  >] -> s
-| [< '(l, Kwd "switch"); '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); '(_, Kwd "{"); sscs = parse_switch_stmt_clauses; '(_, Kwd "}") >] -> SwitchStmt (l, e, sscs)
-| [< '(l, Kwd "assert"); p = parse_asn; '(_, Kwd ";") >] -> Assert (l, p)
-| [< '(l, Kwd "leak"); p = parse_asn; '(_, Kwd ";") >] -> Leak (l, p)
-| [< '(l, Kwd "open"); coef = opt parse_coef; e = parse_expr; '(_, Kwd ";") >] ->
+  parse_stmt0 = function%parser
+| [ (Lexed (sp1, _), Kwd "/*@"); 
+    parse_stmt0 as s; (Lexed (_, sp2), Kwd "@*/") 
+  ] -> PureStmt (Lexed (sp1, sp2), s)
+| [ (Lexed (sp1, _), Kwd "@*/"); 
+    parse_stmt as s; 
+    (Lexed (_, sp2), Kwd "/*@") 
+  ] -> NonpureStmt (Lexed (sp1, sp2), false, s)
+| [ (l, Kwd "if"); 
+    (_, Kwd "("); 
+    parse_expr as e; 
+    (_, Kwd ")"); 
+    parse_stmt as s1;
+    [%l
+    s = function%parser
+    | [ (_, Kwd "else"); 
+        parse_stmt as s2 
+      ] -> IfStmt (l, e, [s1], [s2])
+    | [ ] -> IfStmt (l, e, [s1], [])
+    ]
+  ] -> s
+| [ (l, Kwd "switch"); 
+    (_, Kwd "("); 
+    parse_expr as e; 
+    (_, Kwd ")"); 
+    (_, Kwd "{"); 
+    parse_switch_stmt_clauses as sscs; 
+    (_, Kwd "}") 
+  ] -> SwitchStmt (l, e, sscs)
+| [ (l, Kwd "assert"); 
+    parse_asn as p; 
+    (_, Kwd ";") 
+  ] -> Assert (l, p)
+| [ (l, Kwd "leak"); 
+    parse_asn as p; 
+    (_, Kwd ";") 
+  ] -> Leak (l, p)
+| [ (l, Kwd "open"); 
+    [%l coef = opt parse_coef]; 
+    parse_expr as e; 
+    (_, Kwd ";") 
+  ] ->
   (match e with
      CallExpr (_, g, targs, es1, es2, Static) ->
        !stats#openParsed;
@@ -1196,7 +1675,11 @@ and
        !stats#openParsed;
        Open (l, Some target, g, targs, es1, es2, coef)
    | _ -> raise (ParseException (l, "Body of open statement must be call expression.")))
-| [< '(l, Kwd "close"); coef = opt parse_coef; e = parse_expr; '(_, Kwd ";") >] ->
+| [ (l, Kwd "close"); 
+    [%l coef = opt parse_coef]; 
+    parse_expr as e; 
+    (_, Kwd ";") 
+  ] ->
   (match e with
      CallExpr (_, g, targs, es1, es2, Static) ->
        !stats#closeParsed;
@@ -1205,134 +1688,298 @@ and
        !stats#closeParsed;
        Close (l, Some target, g, targs, es1, es2, coef)
    | _ -> raise (ParseException (l, "Body of close statement must be call expression.")))
-| [< '(l, Kwd "split_fraction"); '(li, Ident p); targs = parse_type_args li; pats = parse_patlist;
-     coefopt = (parser [< '(_, Kwd "by"); e = parse_expr >] -> Some e | [< >] -> None);
-     '(_, Kwd ";") >] -> SplitFractionStmt (l, p, targs, pats, coefopt)
-| [< '(l, Kwd "merge_fractions"); a = parse_asn; '(_, Kwd ";") >]
+| [ (l, Kwd "split_fraction"); 
+    (li, Ident p); 
+    [%l targs = parse_type_args li]; 
+    parse_patlist as pats;
+    [%l
+    coefopt = (function%parser 
+    | [ (_, Kwd "by"); 
+        parse_expr as e 
+      ] -> Some e 
+    | [ ] -> None
+    )
+    ];
+    (_, Kwd ";") 
+  ] -> SplitFractionStmt (l, p, targs, pats, coefopt)
+| [ (l, Kwd "merge_fractions"); 
+    parse_asn as a; 
+    (_, Kwd ";") 
+  ]
   -> MergeFractionsStmt (l, a)
-| [< '(l, Kwd "dispose_box"); '(_, Ident bcn); pats = parse_patlist;
-     handleClauses = rep (parser [< '(l, Kwd "and_handle"); '(_, Ident hpn); pats = parse_patlist >] -> (l, hpn, pats));
-     '(_, Kwd ";") >] -> DisposeBoxStmt (l, bcn, pats, handleClauses)
-| [< '(l, Kwd "create_box"); '(_, Ident x); '(_, Kwd "="); '(_, Ident bcn); args = parse_arglist;
-     lower_bounds = opt (parser [< '(l, Kwd "above"); es = rep_comma parse_expr >] -> es);
-     upper_bounds = opt (parser [< '(l, Kwd "below"); es = rep_comma parse_expr >] -> es);
-     handleClauses = rep (parser 
-       [< '(l, Kwd "and_handle"); '(_, Ident x); '(_, Kwd "="); '(_, Ident hpn); args = parse_arglist >] -> (l, x, false, hpn, args)
-     | [< '(l, Kwd "and_fresh_handle"); '(_, Ident x); '(_, Kwd "="); '(_, Ident hpn); args = parse_arglist >] -> (l, x, true, hpn, args)
-     );
-     '(_, Kwd ";")
-     >] -> CreateBoxStmt (l, x, bcn, args, (match lower_bounds with None -> [] | Some lbs -> lbs), (match upper_bounds with None -> [] | Some ubs -> ubs), handleClauses)
-| [< '(l, Kwd "produce_lemma_function_pointer_chunk");
-     (e, ftclause) = begin parser
-       [< '(_, Kwd "("); e = parse_expr; '(_, Kwd ")");
-          ftclause = opt (parser [< '(_, Kwd ":"); ftclause = parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause >] -> ftclause)
-          >] -> (Some e, ftclause)
-     | [< ftclause = parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause >] -> (None, Some ftclause)
-     end;
-     body = parser
-       [< '(_, Kwd ";") >] -> None
-     | [< s = parse_stmt >] -> Some s
-  >] -> ProduceLemmaFunctionPointerChunkStmt (l, e, ftclause, body)
-| [< '(l, Kwd "duplicate_lemma_function_pointer_chunk"); '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); '(_, Kwd ";")
-  >] -> DuplicateLemmaFunctionPointerChunkStmt (l, e)
-| [< '(l, Kwd "produce_function_pointer_chunk"); '(li, Ident ftn);
-     targs = parse_type_args li;
-     '(_, Kwd "("); fpe = parse_expr; '(_, Kwd ")");
-     args = parse_arglist;
-     '(_, Kwd "("); params = rep_comma (parser [< '(l, Ident x) >] -> (l, x)); '(_, Kwd ")");
-     '(openBraceLoc, Kwd "{"); ss = parse_stmts; '(closeBraceLoc, Kwd "}") >] ->
+| [ (l, Kwd "dispose_box"); 
+    (_, Ident bcn); 
+    parse_patlist as pats;
+    [%l
+    handleClauses = rep (function%parser 
+    | [ (l, Kwd "and_handle"); 
+        (_, Ident hpn); 
+        parse_patlist as pats 
+      ] -> (l, hpn, pats)
+    )
+    ];
+    (_, Kwd ";") 
+  ] -> DisposeBoxStmt (l, bcn, pats, handleClauses)
+| [ (l, Kwd "create_box"); 
+    (_, Ident x); 
+    (_, Kwd "="); 
+    (_, Ident bcn); 
+    parse_arglist as args;
+    [%l lower_bounds = opt (function%parser [ (l, Kwd "above"); [%l es = rep_comma parse_expr] ] -> es)];
+    [%l upper_bounds = opt (function%parser [ (l, Kwd "below"); [%l es = rep_comma parse_expr] ] -> es)];
+    [%l
+    handleClauses = rep (function%parser 
+    | [ (l, Kwd "and_handle"); 
+        (_, Ident x); 
+        (_, Kwd "="); 
+        (_, Ident hpn); 
+        parse_arglist as args 
+      ] -> (l, x, false, hpn, args)
+    | [ (l, Kwd "and_fresh_handle"); 
+        (_, Ident x); 
+        (_, Kwd "="); 
+        (_, Ident hpn); 
+        parse_arglist as args 
+      ] -> (l, x, true, hpn, args)
+    )
+    ];
+    (_, Kwd ";")
+  ] -> CreateBoxStmt (l, x, bcn, args, (match lower_bounds with None -> [] | Some lbs -> lbs), (match upper_bounds with None -> [] | Some ubs -> ubs), handleClauses)
+| [ (l, Kwd "produce_lemma_function_pointer_chunk");
+    [%l
+    (e, ftclause) = begin function%parser
+    | [ (_, Kwd "("); 
+        parse_expr as e; 
+        (_, Kwd ")");
+        [%l
+        ftclause = opt (function%parser 
+        | [ (_, Kwd ":"); 
+            parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause as ftclause 
+          ] -> ftclause
+        )
+        ]
+      ] -> (Some e, ftclause)
+    | [ parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause as ftclause ] -> (None, Some ftclause)
+    end
+    ];
+    [%l
+    body = function%parser
+    | [ (_, Kwd ";") ] -> None
+    | [ parse_stmt as s ] -> Some s
+    ]
+  ] -> ProduceLemmaFunctionPointerChunkStmt (l, e, ftclause, body)
+| [ (l, Kwd "duplicate_lemma_function_pointer_chunk"); 
+    (_, Kwd "("); 
+    parse_expr as e; 
+    (_, Kwd ")"); 
+    (_, Kwd ";")
+  ] -> DuplicateLemmaFunctionPointerChunkStmt (l, e)
+| [ (l, Kwd "produce_function_pointer_chunk"); 
+    (li, Ident ftn);
+    [%l targs = parse_type_args li];
+    (_, Kwd "("); 
+    parse_expr as fpe; 
+    (_, Kwd ")");
+    parse_arglist as args;
+    (_, Kwd "("); 
+    [%l
+    params = rep_comma (function%parser 
+    | [ (l, Ident x) ] -> (l, x)
+    )
+    ]; 
+    (_, Kwd ")");
+    (openBraceLoc, Kwd "{"); 
+    parse_stmts as ss; 
+    (closeBraceLoc, Kwd "}") 
+  ] ->
   ProduceFunctionPointerChunkStmt (l, ftn, fpe, targs, args, params, openBraceLoc, ss, closeBraceLoc)
-| [< '(l, Kwd "goto"); '(_, Ident lbl); '(_, Kwd ";") >] -> GotoStmt (l, lbl)
-| [< '(l, Kwd "invariant"); inv = parse_asn; '(_, Kwd ";") >] -> InvariantStmt (l, inv)
-| [< '(l, Kwd "return"); eo = parser [< '(_, Kwd ";") >] -> None | [< e = parse_expr; '(_, Kwd ";") >] -> Some e >] -> ReturnStmt (l, eo)
-| [< '(l, Kwd "while"); '(_, Kwd "("); e = parse_expr; '(_, Kwd ")");
-     (inv, dec, body) = parse_loop_core l
-  >] -> WhileStmt (l, e, inv, dec, body, [])
-| [< '(l, Kwd "do"); (inv, dec, body) = parse_loop_core l; '(lwhile, Kwd "while"); '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); '(_, Kwd ";") >] ->
+| [ (l, Kwd "goto"); 
+    (_, Ident lbl); 
+    (_, Kwd ";") 
+  ] -> GotoStmt (l, lbl)
+| [ (l, Kwd "invariant"); 
+    parse_asn as inv; 
+    (_, Kwd ";") 
+  ] -> InvariantStmt (l, inv)
+| [ (l, Kwd "return"); 
+    [%l
+    eo = function%parser 
+    | [ (_, Kwd ";") ] -> None 
+    | [ parse_expr as e; 
+        (_, Kwd ";") 
+      ] -> Some e 
+    ]
+  ] -> ReturnStmt (l, eo)
+| [ (l, Kwd "while"); 
+    (_, Kwd "("); 
+    parse_expr as e; 
+    (_, Kwd ")");
+    [%l (inv, dec, body) = parse_loop_core l]
+  ] -> WhileStmt (l, e, inv, dec, body, [])
+| [ (l, Kwd "do"); 
+    [%l (inv, dec, body) = parse_loop_core l]; 
+    (lwhile, Kwd "while"); 
+    (_, Kwd "("); 
+    parse_expr as e; 
+    (_, Kwd ")"); 
+    (_, Kwd ";") 
+  ] ->
   (* "do S while (E);" is translated to "while (true) { S if (E) {} else break; }" *)
   WhileStmt (l, True l, inv, dec, body,  [IfStmt (lwhile, e, [], [Break lwhile])])
-| [< '(l, Kwd "for");
-     '(_, Kwd "(");
-     init_stmts = begin parser
-       [< e = parse_expr;
-          ss = parser
-            [< '(l, Ident x); s = parse_decl_stmt_rest (type_expr_of_expr e) l x >] -> register_varname x; [s]
-          | [< es = comma_rep parse_expr; '(_, Kwd ";") >] -> List.map (fun e -> ExprStmt e) (e::es)
-       >] -> ss
-     | [< te = parse_type; '(l, Ident x); s = parse_decl_stmt_rest te l x >] -> register_varname x; [s]
-     | [< '(_, Kwd ";") >] -> []
-     end;
-     cond = opt parse_expr;
-     '(_, Kwd ";");
-     update_exprs = rep_comma parse_expr;
-     '(_, Kwd ")");
-     (inv, dec, b) = parse_loop_core l
-  >] ->
+| [ (l, Kwd "for");
+    (_, Kwd "(");
+    [%l
+    init_stmts = begin function%parser
+    | [ parse_expr as e;
+        [%l
+        ss = function%parser
+        | [ (l, Ident x); 
+            [%l s = parse_decl_stmt_rest (type_expr_of_expr e) l x] 
+          ] -> register_varname x; [s]
+        | [ [%l es = comma_rep parse_expr]; 
+            (_, Kwd ";") 
+          ] -> List.map (fun e -> ExprStmt e) (e::es)
+        ]
+      ] -> ss
+    | [ parse_type as te; 
+        (l, Ident x); 
+        [%l s = parse_decl_stmt_rest te l x] 
+      ] -> register_varname x; [s]
+    | [ (_, Kwd ";") ] -> []
+    end
+    ];
+    [%l cond = opt parse_expr];
+    (_, Kwd ";");
+    [%l update_exprs = rep_comma parse_expr];
+    (_, Kwd ")");
+    [%l (inv, dec, b) = parse_loop_core l]
+  ] ->
   let cond = match cond with None -> True l | Some e -> e in
   BlockStmt (l, [], init_stmts @ [WhileStmt (l, cond, inv, dec, b, List.map (fun e -> ExprStmt e) update_exprs)], l, ref [])
-| [< '(l, Kwd "throw"); e = parse_expr; '(_, Kwd ";") >] -> Throw (l, e)
-| [< '(l, Kwd "break"); '(_, Kwd ";") >] -> Break(l)
-| [< '(l, Kwd "try");
-     body = parse_block;
-     catches = rep (parser [< '(l, Kwd "catch"); '(_, Kwd "("); t = parse_type; '(_, Ident x); '(_, Kwd ")"); body = parse_block >] -> (l, t, x, body));
-     finally = opt (parser [< '(l, Kwd "finally"); body = parse_block >] -> (l, body))
-  >] ->
+| [ (l, Kwd "throw");
+    parse_expr as e; 
+    (_, Kwd ";") 
+  ] -> Throw (l, e)
+| [ (l, Kwd "break"); 
+    (_, Kwd ";") 
+  ] -> Break(l)
+| [ (l, Kwd "try");
+    parse_block as body;
+    [%l
+    catches = rep (function%parser 
+    | [ (l, Kwd "catch"); 
+        (_, Kwd "("); 
+        parse_type as t; 
+        (_, Ident x); 
+        (_, Kwd ")"); 
+        parse_block as body 
+      ] -> (l, t, x, body)
+    )
+    ];
+    [%l
+    finally = opt (function%parser 
+    | [ (l, Kwd "finally"); 
+        parse_block as body 
+      ] -> (l, body)
+    )
+    ]
+  ] ->
   begin match (catches, finally) with
     ([], Some (lf, finally)) -> TryFinally (l, body, lf, finally)
   | (catches, None) -> TryCatch (l, body, catches)
   | (catches, Some (lf, finally)) -> TryFinally (l, [TryCatch (l, body, catches)], lf, finally)
   end
-| [< s = parse_block_stmt >] -> s
-| [< '(lcb, Kwd "consuming_box_predicate"); '(_, Ident pre_bpn); pre_bp_args = parse_patlist;
-     consumed_handle_predicates = rep(parser
-       [< '(lch, Kwd "consuming_handle_predicate"); '(_, Ident pre_hpn); pre_hp_args = parse_patlist; >] -> ConsumingHandlePredicate(lch, pre_hpn, pre_hp_args)
-     );
-     '(lpa, Kwd "perform_action"); '(_, Ident an); aargs = parse_arglist;
-     '(_, Kwd "{"); ss = parse_stmts; '(closeBraceLoc, Kwd "}");
-     post_bp_args =
-       opt
-         begin
-           parser
-             [< '(lpb, Kwd "producing_box_predicate"); '(_, Ident post_bpn); post_bp_args = parse_arglist >] ->
-             if post_bpn <> pre_bpn then raise (ParseException (lpb, "The box predicate name cannot change."));
-             (lpb, post_bp_args)
-         end;
-     produced_handles = rep(parser
-       [< '(_, Kwd "producing_handle_predicate"); producing_hp_list = parse_producing_handle_predicate_list >] -> (false, producing_hp_list)
-     | [< '(_, Kwd "producing_fresh_handle_predicate"); producing_hp_list = parse_producing_handle_predicate_list >] -> (true, producing_hp_list));
-     '(_, Kwd ";") >] ->
-     PerformActionStmt (lcb, ref false, pre_bpn, pre_bp_args, consumed_handle_predicates, lpa, an, aargs, ss, closeBraceLoc, post_bp_args, produced_handles)
-| [< '(l, Kwd ";") >] -> NoopStmt l
-| [< '(l, Kwd "super"); s = parser 
-     [< '(_, Kwd "."); '(l2, Ident n); '(_, Kwd "("); es = rep_comma parse_expr; '(_, Kwd ")") >] -> ExprStmt(SuperMethodCall (l, n, es))
-   | [<'(_, Kwd "("); es = rep_comma parse_expr; '(_, Kwd ")"); '(_, Kwd ";") >] -> SuperConstructorCall (l, es)
-  >] -> s
-| [< e = parse_expr; s = parser
-    [< '(_, Kwd ";") >] ->
-    begin match e with
-      AssignExpr (l, Operation (llhs, Mul, [Var (lt, t); e1]), rhs) -> 
-      let rec iter te e1 =
-        match e1 with
-          Var (lx, x) -> register_varname x; DeclStmt (l, [l, te, x, Some(rhs), (ref false, ref None)])
-        | Deref (ld, e2) -> iter (PtrTypeExpr (ld, te)) e2
-        | _ -> ExprStmt e
-      in
-      iter (PtrTypeExpr (llhs, IdentTypeExpr (lt, None, t))) e1
-    | Operation (l, Mul, [Var (lt, t); e1]) ->
-      let rec iter te e1 =
-        match e1 with
-          Var (lx, x) -> register_varname x; DeclStmt (lx, [lx, te, x, None, (ref false, ref None)])
-        | Deref (ld, e2) -> iter (PtrTypeExpr (ld, te)) e2
-        | _ -> ExprStmt e
-      in
-      iter (PtrTypeExpr (l, IdentTypeExpr (lt, None, t))) e1
-    | _ -> ExprStmt e
+| [ parse_block_stmt as s ] -> s
+| [ (lcb, Kwd "consuming_box_predicate"); 
+    (_, Ident pre_bpn); 
+    parse_patlist as pre_bp_args;
+    [%l
+    consumed_handle_predicates = rep (function%parser
+    | [ (lch, Kwd "consuming_handle_predicate"); 
+        (_, Ident pre_hpn); 
+        parse_patlist as pre_hp_args; 
+      ] -> ConsumingHandlePredicate(lch, pre_hpn, pre_hp_args)
+    )
+    ];
+    (lpa, Kwd "perform_action"); 
+    (_, Ident an); 
+    parse_arglist as aargs;
+    (_, Kwd "{"); 
+    parse_stmts as ss; 
+    (closeBraceLoc, Kwd "}");
+    [%l
+    post_bp_args = opt begin function%parser
+    | [ (lpb, Kwd "producing_box_predicate"); 
+        (_, Ident post_bpn); 
+        parse_arglist as post_bp_args 
+      ] ->
+        if post_bpn <> pre_bpn then raise (ParseException (lpb, "The box predicate name cannot change."));
+        (lpb, post_bp_args)
     end
-  | [< '(l, Kwd ":") >] -> (match e with Var (_, lbl) -> LabelStmt (l, lbl) | _ -> raise (ParseException (l, "Label must be identifier.")))
-  | [< '(lx, Ident x); s = parse_decl_stmt_rest (type_expr_of_expr e) lx x >] -> register_varname x; s
-  >] -> s
+    ];
+    [%l
+    produced_handles = rep (function%parser
+    | [ (_, Kwd "producing_handle_predicate"); 
+        parse_producing_handle_predicate_list as producing_hp_list 
+      ] -> (false, producing_hp_list)
+    | [ (_, Kwd "producing_fresh_handle_predicate"); 
+        parse_producing_handle_predicate_list as producing_hp_list 
+      ] -> (true, producing_hp_list)
+    )
+    ];
+    (_, Kwd ";") 
+  ] -> PerformActionStmt (lcb, ref false, pre_bpn, pre_bp_args, consumed_handle_predicates, lpa, an, aargs, ss, closeBraceLoc, post_bp_args, produced_handles)
+| [ (l, Kwd ";") ] -> NoopStmt l
+| [ (l, Kwd "super"); 
+    [%l
+    s = function%parser 
+    | [ (_, Kwd "."); 
+        (l2, Ident n); 
+        (_, Kwd "("); 
+        [%l es = rep_comma parse_expr]; 
+        (_, Kwd ")") 
+      ] -> ExprStmt(SuperMethodCall (l, n, es))
+   | [ (_, Kwd "("); 
+      [%l es = rep_comma parse_expr]; 
+      (_, Kwd ")"); 
+      (_, Kwd ";") 
+      ] -> SuperConstructorCall (l, es)
+    ]
+  ] -> s
+| [ parse_expr as e; 
+    [%l
+    s = function%parser
+    | [ (_, Kwd ";") ] ->
+      begin match e with
+        AssignExpr (l, Operation (llhs, Mul, [Var (lt, t); e1]), rhs) -> 
+        let rec iter te e1 =
+          match e1 with
+            Var (lx, x) -> register_varname x; DeclStmt (l, [l, te, x, Some(rhs), (ref false, ref None)])
+          | Deref (ld, e2) -> iter (PtrTypeExpr (ld, te)) e2
+          | _ -> ExprStmt e
+        in
+        iter (PtrTypeExpr (llhs, IdentTypeExpr (lt, None, t))) e1
+      | Operation (l, Mul, [Var (lt, t); e1]) ->
+        let rec iter te e1 =
+          match e1 with
+            Var (lx, x) -> register_varname x; DeclStmt (lx, [lx, te, x, None, (ref false, ref None)])
+          | Deref (ld, e2) -> iter (PtrTypeExpr (ld, te)) e2
+          | _ -> ExprStmt e
+        in
+        iter (PtrTypeExpr (l, IdentTypeExpr (lt, None, t))) e1
+      | _ -> ExprStmt e
+      end
+    | [ (l, Kwd ":") ] -> (match e with Var (_, lbl) -> LabelStmt (l, lbl) | _ -> raise (ParseException (l, "Label must be identifier.")))
+    | [ (lx, Ident x); 
+        [%l s = parse_decl_stmt_rest (type_expr_of_expr e) lx x] 
+      ] -> register_varname x; s
+    ]
+  ] -> s
 (* parse variable declarations: *)
-| [< te = parse_type; '(lx, Ident x); s2 = parse_decl_stmt_rest te lx x >] ->
+| [ parse_type as te; 
+    (lx, Ident x); 
+    [%l s2 = parse_decl_stmt_rest te lx x] 
+  ] ->
   register_varname x;
   ( try match te with
      ManifestTypeExpr (l, Void) ->
@@ -1340,26 +1987,56 @@ and
     with
      Match_failure _ -> s2 )
 and
-  parse_loop_core l = parser [<
-    (inv, dec) = parse_loop_core0 l;
-    body = parse_stmt
-  >] -> (inv, dec, [body])
+  parse_loop_core l = function%parser 
+| [ [%l (inv, dec) = parse_loop_core0 l];
+    parse_stmt as body
+  ] -> (inv, dec, [body])
 and
-  parse_loop_core0 l = parser [<
-    inv =
-      opt
-        begin parser
-          [< '(_, Kwd "/*@");
-             inv = begin parser
-               [< '(_, Kwd "invariant"); p = parse_asn; '(_, Kwd ";"); '(_, Kwd "@*/") >] -> LoopInv p
-             | [< '(_, Kwd "requires"); pre = parse_asn; '(_, Kwd ";"); '(_, Kwd "@*/");
-                  '(_, Kwd "/*@"); '(_, Kwd "ensures"); post = parse_asn; '(_, Kwd ";"); '(_, Kwd "@*/") >] -> LoopSpec (pre, post)
-             end
-          >] -> inv
-        | [< '(_, Kwd "invariant"); p = parse_asn; '(_, Kwd ";"); >] -> LoopInv p
-        end;
-    dec = opt (parser [< '(_, Kwd "/*@"); '(_, Kwd "decreases"); decr = parse_expr; '(_, Kwd ";"); '(_, Kwd "@*/") >] -> decr | [< '(_, Kwd "decreases"); decr = parse_expr; '(_, Kwd ";"); >] -> decr );(* only allows decreases if invariant provided *)
-  >] -> (inv, dec)
+  parse_loop_core0 l = function%parser 
+| [ [%l 
+    inv = opt begin function%parser
+    | [ (_, Kwd "/*@");
+      [%l
+      inv = begin function%parser
+      | [ (_, Kwd "invariant"); 
+          parse_asn as p; 
+          (_, Kwd ";"); 
+          (_, Kwd "@*/") 
+        ] -> LoopInv p
+      | [ (_, Kwd "requires"); 
+          parse_asn as pre; 
+          (_, Kwd ";"); 
+          (_, Kwd "@*/");
+          (_, Kwd "/*@"); 
+          (_, Kwd "ensures"); 
+          parse_asn as post; 
+          (_, Kwd ";"); 
+          (_, Kwd "@*/") 
+        ] -> LoopSpec (pre, post)
+      end
+      ]
+      ] -> inv
+    | [ (_, Kwd "invariant"); 
+        parse_asn as p; 
+        (_, Kwd ";"); 
+      ] -> LoopInv p
+    end
+    ];
+    [%l
+    dec = opt (function%parser 
+    | [ (_, Kwd "/*@"); 
+        (_, Kwd "decreases"); 
+        parse_expr as decr; 
+        (_, Kwd ";"); 
+        (_, Kwd "@*/") 
+      ] -> decr 
+    | [ (_, Kwd "decreases"); 
+        parse_expr as decr; 
+        (_, Kwd ";"); 
+      ] -> decr 
+    )
+    ];(* only allows decreases if invariant provided *)
+  ] -> (inv, dec)
 and
   packagename_of_read l e =
   match e with
@@ -1374,40 +2051,62 @@ and
   | ArrayTypeExpr' (l, e) -> ArrayTypeExpr (l, type_expr_of_expr e)
   | Read(l, e, name) -> IdentTypeExpr(l, Some(packagename_of_read l e), name)
   | e -> raise (ParseException (expr_loc e, "Type expected."))
-and parse_array_braces te = parser
-  [< '(l, Kwd "[");
-     te = begin parser
-       [< '(lsize, Int (size, _, _, _, _)); '(_, Kwd "]"); te = parse_array_braces te >] ->
-       if sign_big_int size <= 0 then raise (ParseException (lsize, "Array must have size > 0."));
-       StaticArrayTypeExpr (l, te, int_of_big_int size)
-     | [< '(_, Kwd "]") >] ->
-       ArrayTypeExpr (l, te)
-     end >] -> te
-| [< >] -> te
-and parse_create_handle_keyword = parser 
-    [< '(l, Kwd "create_handle") >] -> (l, false)
-  | [< '(l, Kwd "create_fresh_handle") >] -> (l, true)
+and parse_array_braces te = function%parser
+| [ (l, Kwd "[");
+    [%l
+    te = begin function%parser
+    | [ (lsize, Lexer.Int (size, _, _, _, _)); 
+        (_, Kwd "]"); 
+        [%l te = parse_array_braces te] 
+      ] ->
+        if sign_big_int size <= 0 then raise (ParseException (lsize, "Array must have size > 0."));
+        StaticArrayTypeExpr (l, te, int_of_big_int size)
+    | [ (_, Kwd "]") ] ->
+      ArrayTypeExpr (l, te)
+    end
+    ]
+  ] -> te
+| [ ] -> te
+and parse_create_handle_keyword = function%parser 
+| [ (l, Kwd "create_handle") ] -> (l, false)
+| [ (l, Kwd "create_fresh_handle") ] -> (l, true)
 and
   get_ultimate_pointee_type = function
     PtrTypeExpr (l, te) -> get_ultimate_pointee_type te
   | te -> te
 and
-  parse_decl_stmt_rest te lx x = parser
-    [< '(l, Kwd "=");
-       s = parser
-         [< (l, fresh) = parse_create_handle_keyword; '(_, Ident hpn); '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); '(_, Kwd ";") >] ->
-         begin
-           match te with ManifestTypeExpr (_, HandleIdType) -> () | _ -> raise (ParseException (l, "Target variable of handle creation statement must have type 'handle'."))
-         end;
-         CreateHandleStmt (l, x, fresh, hpn, e)
-       | [< rhs = parse_declaration_rhs te; ds = comma_rep (parse_declarator (get_ultimate_pointee_type te)); '(_, Kwd ";") >] ->
-         DeclStmt (l, (l, te, x, Some(rhs), (ref false, ref None))::ds)
-    >] -> s
-  | [< tx = parse_array_braces te;
-       init = opt (parser [< '(_, Kwd "="); e = parse_declaration_rhs tx >] -> e);
-       ds = comma_rep (parse_declarator te);
-       '(_, Kwd ";")
-    >] ->
+  parse_decl_stmt_rest te lx x = function%parser
+| [ (l, Kwd "=");
+    [%l
+    s = function%parser
+    | [ [%l (l, fresh) = parse_create_handle_keyword]; 
+        (_, Ident hpn); 
+        (_, Kwd "("); 
+        parse_expr as e; 
+        (_, Kwd ")"); 
+        (_, Kwd ";") 
+      ] ->
+        begin
+          match te with ManifestTypeExpr (_, HandleIdType) -> () | _ -> raise (ParseException (l, "Target variable of handle creation statement must have type 'handle'."))
+        end;
+        CreateHandleStmt (l, x, fresh, hpn, e)
+    | [ [%l rhs = parse_declaration_rhs te]; 
+        [%l ds = comma_rep (parse_declarator (get_ultimate_pointee_type te))]; 
+        (_, Kwd ";") 
+      ] -> DeclStmt (l, (l, te, x, Some(rhs), (ref false, ref None))::ds)
+    ]
+  ] -> s
+| [ [%l tx = parse_array_braces te];
+    [%l
+    init = opt (function%parser 
+    | [ (_, Kwd "="); 
+        [%l e = parse_declaration_rhs tx] 
+      ] -> e
+    )
+    ];
+    [%l ds = comma_rep (parse_declarator te)];
+    (_, Kwd ";")
+  ] ->
     let tx =
       match tx, init with
         ArrayTypeExpr (l, elemTp), Some (InitializerList (_, es)) when language = CLang ->
@@ -1416,328 +2115,532 @@ and
     in
     DeclStmt(type_expr_loc te, (lx, tx, x, init, (ref false, ref None))::ds)
 and
-  parse_switch_stmt_clauses = parser
-  [< c = parse_switch_stmt_clause; cs = parse_switch_stmt_clauses >] -> c::cs
-| [< >] -> []
+  parse_switch_stmt_clauses = function%parser
+| [ parse_switch_stmt_clause as c; 
+    parse_switch_stmt_clauses as cs 
+  ] -> c::cs
+| [ ] -> []
 and
-  parse_switch_stmt_clause = parser
-  [<
-    '(l, Kwd "case");
-    typedefs_enabled = (fun _ -> set_typedefs_enabled false);
-    e = parse_expr;
-    _ = (fun _ -> set_typedefs_enabled typedefs_enabled);
-    '(_, Kwd ":");
-    _ = (fun _ -> register_pattern_varnames e);
-    ss = parse_stmts
-  >] -> SwitchStmtClause (l, e, ss)
-| [< '(l, Kwd "default"); '(_, Kwd ":"); ss = parse_stmts; >] -> SwitchStmtDefaultClause(l, ss)
+  parse_switch_stmt_clause = function%parser
+| [ (l, Kwd "case");
+    [%l typedefs_enabled = (fun _ -> set_typedefs_enabled false)];
+    parse_expr as e;
+    [%l _d = (fun _ -> set_typedefs_enabled typedefs_enabled)];
+    (_, Kwd ":");
+    [%l _d = (fun _ -> register_pattern_varnames e)];
+    parse_stmts as ss
+  ] -> SwitchStmtClause (l, e, ss)
+| [ (l, Kwd "default"); 
+    (_, Kwd ":"); 
+    parse_stmts as ss; 
+  ] -> SwitchStmtDefaultClause(l, ss)
 and
   register_pattern_varnames = function
     CallExpr (_, _, _, _, args, _) -> List.iter (function LitPat e -> register_pattern_varnames e | _ -> ()) args
   | Var (_, x) -> register_varname x
   | _ -> ()
 and
-  parse_more_pats = parser
-  [< '(_, Kwd ")") >] -> []
-| [< '(_, Kwd ","); '(lx, Ident x); xs = parse_more_pats >] -> register_varname x; x::xs
+  parse_more_pats = function%parser
+  [ (_, Kwd ")") ] -> []
+| [ (_, Kwd ","); 
+    (lx, Ident x); 
+    parse_more_pats as xs 
+  ] -> register_varname x; x::xs
 and
   parse_asn stream = parse_expr stream
 and
-  parse_asn0 = parser
-| [< '(l, Kwd "emp") >] -> EmpAsn l
-| [< '(l, Kwd "forall_"); '(_, Kwd "("); tp = parse_type; '(_, Ident x); '(_, Kwd ";"); e = parse_expr; '(_, Kwd ")") >] -> ForallAsn(l, tp, x, e)
-| [< '(l, Kwd "["); coef = parse_pattern; '(_, Kwd "]"); p = parse_pointsto_expr >] -> CoefAsn (l, coef, p)
-| [< '(l, Kwd "ensures"); p = parse_asn >] -> EnsuresAsn (l, p)
+  parse_asn0 = function%parser
+| [ (l, Kwd "emp") ] -> EmpAsn l
+| [ (l, Kwd "forall_"); 
+    (_, Kwd "("); 
+    parse_type as tp; 
+    (_, Ident x); 
+    (_, Kwd ";"); 
+    parse_expr as e; 
+    (_, Kwd ")") 
+  ] -> ForallAsn(l, tp, x, e)
+| [ (l, Kwd "["); 
+    parse_pattern as coef; 
+    (_, Kwd "]"); 
+    parse_pointsto_expr as p 
+  ] -> CoefAsn (l, coef, p)
+| [ (l, Kwd "ensures"); 
+    parse_asn as p 
+  ] -> EnsuresAsn (l, p)
 and
-  parse_pointsto_rhs = parser
-  [< '(_, Kwd "_") >] -> DummyPat
-| [< '(_, Kwd "?"); p = parser [< '(lx, Ident x) >] -> register_varname x; VarPat (lx, x) | [< '(_, Kwd "_") >] -> DummyVarPat >] -> p
-| [< '(_, Kwd "^"); e = parse_expr >] -> LitPat (WidenedParameterArgument e)
-| [< e = parse_cond_expr >] -> pat_of_expr e
+  parse_pointsto_rhs = function%parser
+| [ (_, Kwd "_") ] -> DummyPat
+| [ (_, Kwd "?"); 
+    [%l
+    p = function%parser 
+    | [ (lx, Ident x) ] -> register_varname x; VarPat (lx, x) 
+    | [ (_, Kwd "_") ] -> DummyVarPat 
+    ]
+  ] -> p
+| [ (_, Kwd "^"); 
+    parse_expr as e 
+  ] -> LitPat (WidenedParameterArgument e)
+| [ parse_cond_expr as e ] -> pat_of_expr e
 and
-  parse_pattern = parser
-  [< '(_, Kwd "_") >] -> DummyPat
-| [< '(_, Kwd "?"); '(lx, Ident x) >] -> register_varname x; VarPat (lx, x)
-| [< '(_, Kwd "^"); e = parse_expr >] -> LitPat (WidenedParameterArgument e)
-| [< e = parse_cond_expr >] -> pat_of_expr e
+  parse_pattern = function%parser
+| [ (_, Kwd "_") ] -> DummyPat
+| [ (_, Kwd "?"); (lx, Ident x) ] -> register_varname x; VarPat (lx, x)
+| [ (_, Kwd "^"); parse_expr as e ] -> LitPat (WidenedParameterArgument e)
+| [ parse_cond_expr as e ] -> pat_of_expr e
 and
-  parse_switch_asn_clauses = parser
-  [< c = parse_switch_asn_clause; cs = parse_switch_asn_clauses >] -> c::cs
-| [< >] -> []
+  parse_switch_asn_clauses = function%parser
+| [ parse_switch_asn_clause as c; parse_switch_asn_clauses as cs ] -> c::cs
+| [ ] -> []
 and
-  parse_switch_asn_clause = parser
-  [< '(l, Kwd "case"); '(_, Ident c); pats = (parser [< '(_, Kwd "("); '(lx, Ident x); () = (fun _ -> register_varname x); xs = parse_more_pats >] -> x::xs | [< >] -> []); '(_, Kwd ":"); '(_, Kwd "return"); p = parse_asn; '(_, Kwd ";") >] -> SwitchAsnClause (l, c, pats, p)
+  parse_switch_asn_clause = function%parser
+| [ (l, Kwd "case"); 
+    (_, Ident c); 
+    [%l
+    pats = (function%parser 
+    | [ (_, Kwd "("); 
+        (lx, Ident x); 
+        [%l () = (fun _ -> register_varname x)]; 
+        parse_more_pats as xs 
+      ] -> x::xs 
+    | [ ] -> []
+    )
+    ]; 
+    (_, Kwd ":"); 
+    (_, Kwd "return"); 
+    parse_asn as p; 
+    (_, Kwd ";") 
+  ] -> SwitchAsnClause (l, c, pats, p)
 and
   parse_expr stream = parse_assign_expr stream
 and
-  parse_assign_expr = parser
-  [< e0 = parse_sep_expr; e = parse_assign_expr_rest e0 >] -> e
+  parse_assign_expr = function%parser
+| [ parse_sep_expr as e0; [%l e = parse_assign_expr_rest e0] ] -> e
 and
-  parse_sep_expr = parser
-  [< e0 = parse_pointsto_expr; e = parser
-    [< '(l, Kwd "&*&"); e1 = parse_sep_expr >] -> Sep (l, e0, e1)
-  | [< >] -> e0
-  >] -> e
+  parse_sep_expr = function%parser
+| [ parse_pointsto_expr as e0; 
+    [%l
+    e = function%parser
+    | [ (l, Kwd "&*&"); 
+        parse_sep_expr as e1 
+      ] -> Sep (l, e0, e1)
+    | [ ] -> e0
+    ]
+  ] -> e
 and
-  parse_pointsto_expr = parser
-  [< e = parse_cond_expr; e = parser
-    [< '(l, Kwd "|->"); rhs = parse_pointsto_rhs >] -> 
-    begin match e with
-       ReadArray (_, _, SliceExpr (_, _, _)) -> PointsTo (l, e, rhs)
-     | ReadArray (lr, e0, e1) when language = CLang -> PointsTo (l, Deref(lr, Operation(lr, Add, [e0; e1])), rhs) 
-     | _ -> PointsTo (l, e, rhs)
-    end
-  | [< >] -> e
-  >] -> e
+  parse_pointsto_expr = function%parser
+| [ parse_cond_expr as e; 
+    [%l
+    e = function%parser
+    | [ (l, Kwd "|->"); 
+        parse_pointsto_rhs as rhs 
+      ] -> 
+        begin match e with
+          ReadArray (_, _, SliceExpr (_, _, _)) -> PointsTo (l, e, rhs)
+        | ReadArray (lr, e0, e1) when language = CLang -> PointsTo (l, Deref(lr, Operation(lr, Add, [e0; e1])), rhs) 
+        | _ -> PointsTo (l, e, rhs)
+        end
+    | [ ] -> e
+    ]
+  ] -> e
 and
-  parse_cond_expr = parser
-  [< e0 = parse_disj_expr; e = parser
-    [< '(l, Kwd "?"); e1 = parse_expr; '(_, Kwd ":"); e2 = parse_sep_expr >] -> IfExpr (l, e0, e1, e2)
-  | [< >] -> e0
-  >] -> e
+  parse_cond_expr = function%parser
+  [ parse_disj_expr as e0; 
+    [%l
+    e = function%parser
+    | [ (l, Kwd "?"); 
+        parse_expr as e1; 
+        (_, Kwd ":"); 
+        parse_sep_expr as e2 
+      ] -> IfExpr (l, e0, e1, e2)
+    | [ ] -> e0
+    ]
+  ] -> e
 and
-  parse_disj_expr = parser
-  [< e0 = parse_conj_expr; e = parse_disj_expr_rest e0 >] -> e
+  parse_disj_expr = function%parser
+| [ parse_conj_expr as e0; [%l e = parse_disj_expr_rest e0] ] -> e
 and
-  parse_conj_expr = parser
-  [< e0 = parse_bitor_expr; e = parse_conj_expr_rest e0 >] -> e
+  parse_conj_expr = function%parser
+| [ parse_bitor_expr as e0; [%l e = parse_conj_expr_rest e0] ] -> e
 and
-  parse_bitor_expr = parser
-  [< e0 = parse_bitxor_expr; e = parse_bitor_expr_rest e0 >] -> e
+  parse_bitor_expr = function%parser
+| [ parse_bitxor_expr as e0; [%l e = parse_bitor_expr_rest e0] ] -> e
 and
-  parse_bitxor_expr = parser
-  [< e0 = parse_bitand_expr; e = parse_bitxor_expr_rest e0 >] -> e
+  parse_bitxor_expr = function%parser
+| [ parse_bitand_expr as e0; [%l e = parse_bitxor_expr_rest e0] ] -> e
 and
-  parse_bitand_expr = parser
-  [< e0 = parse_expr_rel; e = parse_bitand_expr_rest e0 >] -> e
+  parse_bitand_expr = function%parser
+| [ parse_expr_rel as e0; [%l e = parse_bitand_expr_rest e0] ] -> e
 and
-  parse_expr_rel = parser
-  [< e0 = parse_truncating_expr; e = parse_expr_rel_rest e0 >] -> e
+  parse_expr_rel = function%parser
+| [ parse_truncating_expr as e0; [%l e = parse_expr_rel_rest e0] ] -> e
 and
-  parse_truncating_expr = parser
-  [< '(l, Kwd "truncating"); e = parse_expr_suffix >] -> TruncatingExpr (l, e)
-| [< e = peek_in_ghost_range (parser [< '(l, Kwd "truncating"); '(_, Kwd "@*/"); e = parse_expr_suffix >] -> TruncatingExpr (l, e)) >] -> e
-| [< e = parse_shift >] -> e
+  parse_truncating_expr = function%parser
+| [ (l, Kwd "truncating"); parse_expr_suffix as e ] -> TruncatingExpr (l, e)
+| [ [%l
+    e = peek_in_ghost_range (function%parser 
+    | [ (l, Kwd "truncating"); 
+        (_, Kwd "@*/"); 
+        parse_expr_suffix as e 
+      ] -> TruncatingExpr (l, e)) 
+    ]
+  ] -> e
+| [ parse_shift as e ] -> e
 and
-  parse_shift = parser
-  [< e0 = parse_expr_arith; e = parse_shift_rest e0 >] -> e
+  parse_shift = function%parser
+| [ parse_expr_arith as e0; [%l e = parse_shift_rest e0] ] -> e
 and
-  parse_expr_arith = parser
-  [< e0 = parse_expr_mul; e = parse_expr_arith_rest e0 >] -> e
+  parse_expr_arith = function%parser
+| [ parse_expr_mul as e0; [%l e = parse_expr_arith_rest e0] ] -> e
 and
-  parse_expr_mul = parser
-  [< e0 = parse_expr_suffix; e = parse_expr_mul_rest e0 >] -> e
+  parse_expr_mul = function%parser
+| [ parse_expr_suffix as e0; [%l e = parse_expr_mul_rest e0] ] -> e
 and
-  parse_expr_suffix0 allowCast = parser
-  [< e0 = parse_expr_primary0 allowCast; e = parse_expr_suffix_rest e0 >] -> e
+  parse_expr_suffix0 allowCast = function%parser
+| [ [%l e0 = parse_expr_primary0 allowCast]; [%l e = parse_expr_suffix_rest e0] ] -> e
 and
   parse_expr_suffix s = parse_expr_suffix0 true s
 and
-  parse_type_args l = parser
-    [< targs = parse_angle_brackets l (rep_comma parse_type) >] -> targs
-  | [< >] -> []
+  parse_type_args l = function%parser
+| [ [%l targs = parse_angle_brackets l (rep_comma parse_type)] ] -> targs
+| [ ] -> []
 and
-  parse_type_args_with_diamond l0 = parser
-    [< 
+  parse_type_args_with_diamond l0 = function%parser
+| [ [%l
     (targs, diamond) = match language with
-      CLang -> (parser [< targs = parse_type_args l0 >] -> (targs, false))
-      | Java -> (parser
-        [< '(l1, Kwd "<"); 
-          (targs, diamond) = parser
-            [< '(_, Kwd ">") >] -> ([], true)
-            | [< targs = rep_comma parse_type; '(_, Kwd ">") >] -> (targs, false) 
-        >] -> (targs,diamond)
-        | [< >] -> ([], false))
-    >] -> (targs, diamond)
+    | CLang -> 
+      (function%parser 
+      | [ [%l targs = parse_type_args l0] ] -> (targs, false)
+      )
+    | Java -> 
+      (function%parser
+      | [ (l1, Kwd "<"); 
+          [%l
+          (targs, diamond) = function%parser
+          | [ (_, Kwd ">") ] -> ([], true)
+          | [ [%l targs = rep_comma parse_type]; 
+              (_, Kwd ">") 
+            ] -> (targs, false) 
+          ]
+        ] -> (targs,diamond)
+      | [ ] -> ([], false)
+      )
+    ]
+  ] -> (targs, diamond)
 and
-  parse_new_array_expr_rest l elem_typ = parser
-  [< '(_, Kwd "[");
-     e = parser
-       [< length = parse_expr; '(_, Kwd "]"); >] -> NewArray(l, elem_typ, length)
-     | [< '(_, Kwd "]"); '(_, Kwd "{"); es = rep_comma parse_expr; '(_, Kwd "}") >] -> NewArrayWithInitializer (l, elem_typ, es)
-  >] -> e
+  parse_new_array_expr_rest l elem_typ = function%parser
+| [ (_, Kwd "[");
+    [%l
+    e = function%parser
+    | [ parse_expr as length; 
+        (_, Kwd "]"); 
+      ] -> NewArray(l, elem_typ, length)
+    | [ (_, Kwd "]"); 
+        (_, Kwd "{"); 
+        [%l es = rep_comma parse_expr]; 
+        (_, Kwd "}") 
+      ] -> NewArrayWithInitializer (l, elem_typ, es)
+    ]
+  ] -> e
 and
   parse_expr_primary s = parse_expr_primary0 true s
 and 
-  parse_instance_call_rest l g targs target = parser
-| [<
-    args0 = parse_patlist;
-    (args0, args) = begin parser
-    | [< args = parse_patlist >] -> args0, args
-    | [< >] -> [], args0
+  parse_instance_call_rest l g targs target = function%parser
+| [ parse_patlist as args0;
+    [%l
+    (args0, args) = begin function%parser
+    | [ parse_patlist as args ] -> args0, args
+    | [ ] -> [], args0
     end
-  >] -> CallExpr (l, g, targs, args0, LitPat(target) :: args, Instance)
+    ]
+  ] -> CallExpr (l, g, targs, args0, LitPat(target) :: args, Instance)
 and
   parse_instance_call l target = 
-    let parse_call_or_read lf f targs target read = parser
-    | [< e = parse_instance_call l read >] -> e
-    | [< e = parse_instance_call_rest lf f [] target >] -> e
-    | [< >] -> read
+    let parse_call_or_read lf f targs target read = function%parser
+    | [ [%l e = parse_instance_call l read] ] -> e
+    | [ [%l e = parse_instance_call_rest lf f [] target] ] -> e
+    | [ ] -> read
     in
-  parser
-| [< 
-    '(larrow, Kwd "->");
-    (lf, f, read) = begin parser
-    | [< '(lf, Ident f) >] -> lf, f, Read (larrow, target, f);
-    | [< '(_, Kwd "/*@"); '(_, Kwd "activating"); '(_, Kwd "@*/"); '(lf, Ident f) >] -> lf, f, ActivatingRead (larrow, target, f)
-    end;
-    e = parse_call_or_read lf f [] target read
-  >] -> e
-| [<
-    '(ldot, Kwd ".");
-    (lf, f, read) = begin parser
-    | [< '(lf, Ident f) >] -> lf, f, Select (ldot, target, f);
-    | [< '(_, Kwd "/*@"); '(_, Kwd "activating"); '(_, Kwd "@*/"); '(lf, Ident f) >] -> lf, f, ActivatingRead (ldot, AddressOf (ldot, target), f)
-    end;
-    e = parse_call_or_read lf f [] (AddressOf (ldot, target)) read
-  >] -> e
+  function%parser
+| [ (larrow, Kwd "->");
+    [%l
+    (lf, f, read) = begin function%parser
+    | [ (lf, Ident f) ] -> lf, f, Read (larrow, target, f);
+    | [ (_, Kwd "/*@"); 
+      (_, Kwd "activating"); 
+      (_, Kwd "@*/"); 
+      (lf, Ident f) 
+      ] -> lf, f, ActivatingRead (larrow, target, f)
+    end
+    ];
+   [%l e = parse_call_or_read lf f [] target read]
+  ] -> e
+| [ (ldot, Kwd ".");
+    [%l
+    (lf, f, read) = begin function%parser
+    | [ (lf, Ident f) ] -> lf, f, Select (ldot, target, f);
+    | [ (_, Kwd "/*@"); 
+        (_, Kwd "activating"); 
+        (_, Kwd "@*/"); 
+        (lf, Ident f) 
+      ] -> lf, f, ActivatingRead (ldot, AddressOf (ldot, target), f)
+    end
+    ];
+    [%l e = parse_call_or_read lf f [] (AddressOf (ldot, target)) read]
+  ] -> e
 and
-  parse_expr_primary0 allowCast = fun stream -> stream |> parser
-  [< '(l, Kwd "true") >] -> True l
-| [< '(l, Kwd "false") >] -> False l
-| [< '(l, CharToken c) >] ->
+  parse_expr_primary0 allowCast = fun stream -> stream |> function%parser
+| [ (l, Kwd "true") ] -> True l
+| [ (l, Kwd "false") ] -> False l
+| [ (l, CharToken c) ] ->
   if Char.code c > 127 then raise (ParseException (l, "Non-ASCII character literals are not yet supported"));
   let tp = match language with CLang -> Int (Signed, CharRank) | Java -> Int (Unsigned, ShortRank) in
   CastExpr (l, ManifestTypeExpr (l, tp), IntLit (l, big_int_of_int (Char.code c), true, false, NoLSuffix))
-| [< '(l, Kwd "null") >] -> Null l
-| [< '(l, Kwd "currentThread") >] -> Var (l, "currentThread")
-| [< '(l, Kwd "varargs") >] -> Var (l, "varargs")
-| [< '(l, Kwd "new"); 
-  tp = parse_primary_type; 
-  res = (parser 
-    [< args0 = parse_patlist >] -> 
-      begin match tp with
-        IdentTypeExpr(_, pac, cn) -> 
-          NewObject (l, 
-            (match pac with None -> "" | Some(pac) -> pac ^ ".") ^ cn, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0, None)
-        | ConstructedTypeExpr(loc, name, targs) -> 
-          NewObject (loc,
-              name, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0,
-              Some (targs))
-        | _ -> raise (ParseException (type_expr_loc tp, "Class name expected"))
+| [ (l, Kwd "null") ] -> Null l
+| [ (l, Kwd "currentThread") ] -> Var (l, "currentThread")
+| [ (l, Kwd "varargs") ] -> Var (l, "varargs")
+| [ (l, Kwd "new"); 
+    parse_primary_type as tp; 
+    [%l
+    res = (function%parser 
+    | [ parse_patlist as args0 ] -> 
+        begin match tp with
+          IdentTypeExpr(_, pac, cn) -> 
+            NewObject (l, 
+              (match pac with None -> "" | Some(pac) -> pac ^ ".") ^ cn, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0, None)
+          | ConstructedTypeExpr(loc, name, targs) -> 
+            NewObject (loc,
+                name, List.map (function LitPat e -> e | _ -> raise (Stream.Error "Patterns are not allowed in this position")) args0,
+                Some (targs))
+          | _ -> raise (ParseException (type_expr_loc tp, "Class name expected"))
+        end
+    | [ [%l e = parse_new_array_expr_rest l tp] ] -> e
+  )
+  ]
+  ] -> res
+| [ (* TODO: parse type arguments for java generic methods *)
+    (lx, Ident x);
+    [%l
+    ex = function%parser
+    | [ parse_patlist as args0;
+        [%l
+        e = function%parser
+        | [ parse_patlist as args ] -> CallExpr (lx, x, [], args0, args, Static)
+        | [ ] -> CallExpr (lx, x, [], [], args0, Static)
+        ]
+      ] -> e
+    | [ (ldot, Kwd ".");
+        [%l targs = parse_type_args ldot];
+        [%l
+        r = function%parser
+        | [ (lc, Kwd "class") ] -> ClassLit(ldot,x)
+        | [ (lf, Ident f);
+            [%l
+            e = function%parser
+            | [ [%l e = parse_instance_call_rest lf f targs (Var (lx, x))] ] -> e
+            | [ ] -> Read (ldot, Var (lx, x), f)
+            ]
+          ] -> e 
+        ]
+      ] when language = Java -> r
+    | [ [%l e = parse_instance_call lx (Var (lx, x))] ] -> e
+    | [ ] -> Var (lx, x)
+    ]
+  ] when not (is_typedef x) || (match Stream.npeek 2 stream with [_; (_, Kwd ("("|"<"))] -> true | _ -> false) -> ex
+| [ (l, Int (i, dec, usuffix, lsuffix, _)) ] -> IntLit (l, i, dec, usuffix, lsuffix)
+| [ (l, RealToken i) ] -> RealLit (l, num_of_big_int i, None)
+| [ (l, RationalToken (n, suffix)) ] -> RealLit (l, n, suffix)
+| [ (l, Kwd "INT_MIN") ] -> (match int_width with LitWidth k -> IntLit (l, min_signed_big_int k, true, false, NoLSuffix) | IntWidth -> Operation (l, MinValue (Int (Signed, IntRank)), []))
+| [ (l, Kwd "INT_MAX") ] -> (match int_width with LitWidth k -> IntLit (l, max_signed_big_int k, true, false, NoLSuffix) | IntWidth -> Operation (l, MaxValue (Int (Signed, IntRank)), []))
+| [ (l, Kwd "UINTPTR_MAX") ] -> (match ptr_width with LitWidth k -> IntLit (l, max_unsigned_big_int k, true, true, NoLSuffix) | PtrWidth -> Operation (l, MaxValue (Int (Unsigned, PtrRank)), []))
+| [ (l, Kwd "CHAR_MIN") ] -> IntLit (l, big_int_of_string "-128", true, false, NoLSuffix)
+| [ (l, Kwd "CHAR_MAX") ] -> IntLit (l, big_int_of_string "127", true, false, NoLSuffix)
+| [ (l, Kwd "UCHAR_MAX") ] -> IntLit (l, big_int_of_string "255", true, false, NoLSuffix)
+| [ (l, Kwd "SHRT_MIN") ] -> IntLit (l, big_int_of_string "-32768", true, false, NoLSuffix)
+| [ (l, Kwd "SHRT_MAX") ] -> IntLit (l, big_int_of_string "32767", true, false, NoLSuffix)
+| [ (l, Kwd "USHRT_MAX") ] -> IntLit (l, big_int_of_string "65535", true, false, NoLSuffix)
+| [ (l, Kwd "LONG_MIN") ] -> (match long_width with LitWidth k -> IntLit (l, min_signed_big_int k, true, false, NoLSuffix) | LongWidth -> Operation (l, MinValue (Int (Signed, LongRank)), []))
+| [ (l, Kwd "LONG_MAX") ] -> (match long_width with LitWidth k -> IntLit (l, max_signed_big_int k, true, false, NoLSuffix) | LongWidth -> Operation (l, MaxValue (Int (Signed, LongRank)), []))
+| [ (l, Kwd "ULONG_MAX") ] -> (match long_width with LitWidth k -> IntLit (l, max_unsigned_big_int k, true, true, NoLSuffix) | LongWidth -> Operation (l, MaxValue (Int (Unsigned, LongRank)), []))
+| [ (l, Kwd "UINT_MAX") ] -> (match int_width with LitWidth k -> IntLit (l, max_unsigned_big_int k, true, true, NoLSuffix) | IntWidth -> Operation (l, MaxValue (Int (Unsigned, IntRank)), []))
+| [ (l, Kwd "LLONG_MIN") ] -> IntLit (l, big_int_of_string "-9223372036854775808", true, false, LLSuffix)
+| [ (l, Kwd "LLONG_MAX") ] -> IntLit (l, big_int_of_string "9223372036854775807", true, false, LLSuffix)
+| [ (l, Kwd "ULLONG_MAX") ] -> IntLit (l, big_int_of_string "18446744073709551615", true, true, LLSuffix)
+| [ (l, Kwd "__minvalue"); 
+    (_, Kwd "("); 
+    parse_type as te; 
+    (_, Kwd ")") 
+  ] -> (match te with ManifestTypeExpr (_, t) -> Operation (l, MinValue t, []))
+| [ (l, Kwd "__maxvalue"); 
+    (_, Kwd "("); 
+    parse_type as te; 
+    (_, Kwd ")") 
+  ] -> (match te with ManifestTypeExpr (_, t) -> Operation (l, MaxValue t, []))
+| [ (l, String s); 
+    [%l
+    ss = rep (function%parser 
+    | [ (_, String s) ] -> s
+    ) 
+    ]
+  ] -> 
+    let s = String.concat "" (s::ss) in
+    StringLit (l, s)
+| [ (l, Kwd "(");
+    [%l
+    e =
+      let parse_cast = function%parser 
+      | [ parse_type as te; 
+          (_, Kwd ")"); 
+          [%l
+          e = 
+            if allowCast then 
+              (function%parser [ parse_expr_suffix as e ] -> CastExpr (l, te, e) | [ ] -> TypeExpr te) 
+            else 
+              (function%parser [ ] -> TypeExpr te) 
+          ]
+        ] -> e 
+      in
+      let parse_expr_rest e0 = function%parser
+      | [ (l', Ident y); 
+          [%l e = parse_expr_suffix_rest (Var (l', y))] 
+        ] ->
+          begin match e0 with
+          (* This isn't quite right I think, but I really can't figure out another way to allow casts of paramterised types *)
+          | CallExpr (lt, x, targs, [], [], Static) -> CastExpr (l, ConstructedTypeExpr(lt, x, targs), e)
+          | Var (lt, x) -> CastExpr (l, IdentTypeExpr (lt, None, x), e)
+          | _ -> raise (ParseException (l, "Type expression of cast expression must be identifier: "))
+          end
+      | [ ] -> e0
+      in
+      let parse =
+        function%parser
+        | [ parse_expr as e0; 
+            (_, Kwd ")"); 
+            [%l e = parse_expr_rest e0] 
+          ] -> e
+        | [ parse_cast as e ] -> e
+      in
+      begin fun stream -> 
+        match Stream.peek stream with
+          Some (_, Ident x) when is_typedef x -> parse_cast stream
+        | _ -> parse stream
       end
-    | [< e = parse_new_array_expr_rest l tp >] -> e)
-  >] -> res
-| [<
-    (* TODO: parse type arguments for java generic methods *)
-  '(lx, Ident x) when not (is_typedef x) || (match Stream.npeek 2 stream with [_; (_, Kwd ("("|"<"))] -> true | _ -> false);
-    ex = parser
-      [<
-        args0 = parse_patlist;
-        e = parser
-          [< args = parse_patlist >] -> CallExpr (lx, x, [], args0, args, Static)
-        | [< >] -> CallExpr (lx, x, [], [], args0, Static)
-      >] -> e
-    | [<
-        '(ldot, Kwd ".") when language = Java;
-        targs = parse_type_args ldot;
-        r = parser
-          [<'(lc, Kwd "class")>] -> ClassLit(ldot,x)
-        | [<
-            '(lf, Ident f);
-            e = parser
-            | [< e = parse_instance_call_rest lf f targs (Var (lx, x)) >] -> e
-            | [< >] -> Read (ldot, Var (lx, x), f)
-          >]->e 
-      >]-> r
-    | [< e = parse_instance_call lx (Var (lx, x)) >] -> e
-    | [< >] -> Var (lx, x)
-  >] -> ex
-| [< '(l, Int (i, dec, usuffix, lsuffix, _)) >] -> IntLit (l, i, dec, usuffix, lsuffix)
-| [< '(l, RealToken i) >] -> RealLit (l, num_of_big_int i, None)
-| [< '(l, RationalToken (n, suffix)) >] -> RealLit (l, n, suffix)
-| [< '(l, Kwd "INT_MIN") >] -> (match int_width with LitWidth k -> IntLit (l, min_signed_big_int k, true, false, NoLSuffix) | IntWidth -> Operation (l, MinValue (Int (Signed, IntRank)), []))
-| [< '(l, Kwd "INT_MAX") >] -> (match int_width with LitWidth k -> IntLit (l, max_signed_big_int k, true, false, NoLSuffix) | IntWidth -> Operation (l, MaxValue (Int (Signed, IntRank)), []))
-| [< '(l, Kwd "UINTPTR_MAX") >] -> (match ptr_width with LitWidth k -> IntLit (l, max_unsigned_big_int k, true, true, NoLSuffix) | PtrWidth -> Operation (l, MaxValue (Int (Unsigned, PtrRank)), []))
-| [< '(l, Kwd "CHAR_MIN") >] -> IntLit (l, big_int_of_string "-128", true, false, NoLSuffix)
-| [< '(l, Kwd "CHAR_MAX") >] -> IntLit (l, big_int_of_string "127", true, false, NoLSuffix)
-| [< '(l, Kwd "UCHAR_MAX") >] -> IntLit (l, big_int_of_string "255", true, false, NoLSuffix)
-| [< '(l, Kwd "SHRT_MIN") >] -> IntLit (l, big_int_of_string "-32768", true, false, NoLSuffix)
-| [< '(l, Kwd "SHRT_MAX") >] -> IntLit (l, big_int_of_string "32767", true, false, NoLSuffix)
-| [< '(l, Kwd "USHRT_MAX") >] -> IntLit (l, big_int_of_string "65535", true, false, NoLSuffix)
-| [< '(l, Kwd "LONG_MIN") >] -> (match long_width with LitWidth k -> IntLit (l, min_signed_big_int k, true, false, NoLSuffix) | LongWidth -> Operation (l, MinValue (Int (Signed, LongRank)), []))
-| [< '(l, Kwd "LONG_MAX") >] -> (match long_width with LitWidth k -> IntLit (l, max_signed_big_int k, true, false, NoLSuffix) | LongWidth -> Operation (l, MaxValue (Int (Signed, LongRank)), []))
-| [< '(l, Kwd "ULONG_MAX") >] -> (match long_width with LitWidth k -> IntLit (l, max_unsigned_big_int k, true, true, NoLSuffix) | LongWidth -> Operation (l, MaxValue (Int (Unsigned, LongRank)), []))
-| [< '(l, Kwd "UINT_MAX") >] -> (match int_width with LitWidth k -> IntLit (l, max_unsigned_big_int k, true, true, NoLSuffix) | IntWidth -> Operation (l, MaxValue (Int (Unsigned, IntRank)), []))
-| [< '(l, Kwd "LLONG_MIN") >] -> IntLit (l, big_int_of_string "-9223372036854775808", true, false, LLSuffix)
-| [< '(l, Kwd "LLONG_MAX") >] -> IntLit (l, big_int_of_string "9223372036854775807", true, false, LLSuffix)
-| [< '(l, Kwd "ULLONG_MAX") >] -> IntLit (l, big_int_of_string "18446744073709551615", true, true, LLSuffix)
-| [< '(l, Kwd "__minvalue"); '(_, Kwd "("); te = parse_type; '(_, Kwd ")") >] -> (match te with ManifestTypeExpr (_, t) -> Operation (l, MinValue t, []))
-| [< '(l, Kwd "__maxvalue"); '(_, Kwd "("); te = parse_type; '(_, Kwd ")") >] -> (match te with ManifestTypeExpr (_, t) -> Operation (l, MaxValue t, []))
-| [< '(l, String s); ss = rep (parser [< '(_, String s) >] -> s) >] -> 
-     let s = String.concat "" (s::ss) in
-     StringLit (l, s)
-| [< '(l, Kwd "(");
-     e =
-       let parse_cast = parser [< te = parse_type; '(_, Kwd ")"); e = if allowCast then (parser [< e = parse_expr_suffix >] -> CastExpr (l, te, e) | [< >] -> TypeExpr te) else (parser [< >] -> TypeExpr te) >] -> e in
-       let parse_expr_rest e0 =
-         parser
-           [< '(l', Ident y); e = parse_expr_suffix_rest (Var (l', y)) >] ->
-           begin match e0 with
-           (* This isn't quite right I think, but I really can't figure out another way to allow casts of paramterised types *)
-           | CallExpr (lt, x, targs, [], [], Static) -> CastExpr (l, ConstructedTypeExpr(lt, x, targs), e)
-           | Var (lt, x) -> CastExpr (l, IdentTypeExpr (lt, None, x), e)
-           | _ -> raise (ParseException (l, "Type expression of cast expression must be identifier: "))
-           end
-         | [<>] -> e0
-       in
-       let parse =
-         parser
-           [< e0 = parse_expr; '(_, Kwd ")"); e = parse_expr_rest e0 >] -> e
-         | [< e = parse_cast >] -> e
-       in
-       begin fun stream -> 
-         match Stream.peek stream with
-           Some (_, Ident x) when is_typedef x -> parse_cast stream
-         | _ -> parse stream
-       end
-   >] -> e
+    ]
+  ] -> e
 (*
 | [< '(l, Kwd "(");
      e = parser
      [< e = parse_expr; '(_, Kwd ")") >] -> e
    | [< te = parse_type; '(_, Kwd ")"); e = parse_expr_suffix >] -> CastExpr (l, te, e)
    >] -> e*)
-| [< '(l, Kwd "switch"); '(_, Kwd "("); e = parse_expr; '(_, Kwd ")"); '(_, Kwd "{"); cs = parse_switch_expr_clauses;
-     cdef_opt = opt (parser [< '(l, Kwd "default"); '(_, Kwd ":"); '(_, Kwd "return"); e = parse_expr; '(_, Kwd ";") >] -> (l, e));
-     '(_, Kwd "}")
-  >] -> SwitchExpr (l, e, cs, cdef_opt)
-| [< '(l, Kwd "sizeof"); e = parse_expr_suffix0 false >] -> SizeofExpr (l, e)
-| [< '(l, Kwd "typeid") when language <> Java; '(_, Kwd "("); te = parse_type; '(_, Kwd ")") >] -> Typeid (l, TypeExpr te)
-| [< '(l, Kwd "super"); '(_, Kwd "."); '(l2, Ident n); '(_, Kwd "("); es = rep_comma parse_expr; '(_, Kwd ")") >] -> SuperMethodCall (l, n, es)
-| [< '(l, Kwd "!"); e = parse_expr_suffix >] -> Operation(l, Not, [e])
-| [< '(l, Kwd "@"); '(_, Ident g) >] -> PredNameExpr (l, g)
-| [< '(l, Kwd "*"); e = parse_expr_suffix >] -> Deref (l, e)
-| [< '(l, Kwd "&"); e = parse_expr_suffix >] -> AddressOf (l, e)
-| [< '(l, Kwd "~"); e = parse_expr_suffix >] -> Operation (l, BitNot, [e])
-| [< '(l, Kwd "-"); e = parse_expr_suffix >] ->
+| [ (l, Kwd "switch"); 
+    (_, Kwd "("); 
+    parse_expr as e; 
+    (_, Kwd ")"); 
+    (_, Kwd "{"); 
+    parse_switch_expr_clauses as cs;
+    [%l
+    cdef_opt = opt (function%parser 
+    | [ (l, Kwd "default"); 
+        (_, Kwd ":"); 
+        (_, Kwd "return"); 
+        parse_expr as e; 
+        (_, Kwd ";") 
+      ] -> (l, e)
+    )
+    ];
+    (_, Kwd "}")
+  ] -> SwitchExpr (l, e, cs, cdef_opt)
+| [ (l, Kwd "sizeof"); [%l e = parse_expr_suffix0 false] ] -> SizeofExpr (l, e)
+| [ (l, Kwd "typeid"); 
+    (_, Kwd "("); 
+    parse_type as te; 
+    (_, Kwd ")") 
+  ] when language <> Java -> Typeid (l, TypeExpr te)
+| [ (l, Kwd "super"); 
+    (_, Kwd "."); 
+    (l2, Ident n); 
+    (_, Kwd "("); 
+    [%l es = rep_comma parse_expr]; 
+    (_, Kwd ")") 
+  ] -> SuperMethodCall (l, n, es)
+| [ (l, Kwd "!"); 
+    parse_expr_suffix as e 
+  ] -> Operation(l, Not, [e])
+| [ (l, Kwd "@"); 
+    (_, Ident g) 
+  ] -> PredNameExpr (l, g)
+| [ (l, Kwd "*"); 
+    parse_expr_suffix as e 
+  ] -> Deref (l, e)
+| [ (l, Kwd "&"); 
+    parse_expr_suffix as e 
+  ] -> AddressOf (l, e)
+| [ (l, Kwd "~"); 
+    parse_expr_suffix as e 
+  ] -> Operation (l, BitNot, [e])
+| [ (l, Kwd "-"); 
+    parse_expr_suffix as e 
+  ] ->
   begin match e with
     IntLit (_, n, true, false, lsuffix) when language = Java && sign_big_int n >= 0 -> IntLit (l, minus_big_int n, true, false, lsuffix)
   | _ -> Operation (l, Sub, [IntLit (l, zero_big_int, true, false, NoLSuffix); e])
   end
-| [< '(l, Kwd "++"); e = parse_expr_suffix >] -> AssignOpExpr (l, e, Add, IntLit (l, unit_big_int, true, false, NoLSuffix), false)
-| [< '(l, Kwd "--"); e = parse_expr_suffix >] -> AssignOpExpr (l, e, Sub, IntLit (l, unit_big_int, true, false, NoLSuffix), false)
-| [< '(l, Kwd "{"); es = rep_comma parse_expr; '(_, Kwd "}") >] -> InitializerList (l, es)
-| [< '(l, Kwd "_Generic"); '(_, Kwd "("); e = parse_expr; (cs, d) = parse_generic_cases l; '(_, Kwd ")") >] -> GenericExpr (l, e, cs, d)
-| [< a = parse_asn0 >] -> a
+| [ (l, Kwd "++"); parse_expr_suffix as e ] -> AssignOpExpr (l, e, Add, IntLit (l, unit_big_int, true, false, NoLSuffix), false)
+| [ (l, Kwd "--"); parse_expr_suffix as e ] -> AssignOpExpr (l, e, Sub, IntLit (l, unit_big_int, true, false, NoLSuffix), false)
+| [ (l, Kwd "{"); [%l es = rep_comma parse_expr]; (_, Kwd "}") ] -> InitializerList (l, es)
+| [ (l, Kwd "_Generic"); 
+    (_, Kwd "("); 
+    parse_expr as e; 
+    [%l (cs, d) = parse_generic_cases l]; 
+    (_, Kwd ")") 
+  ] -> GenericExpr (l, e, cs, d)
+| [ parse_asn0 as a ] -> a
 and
-  parse_generic_cases l = parser
-  [< '(_, Kwd ","); (cs, d) = begin parser
-    [< '(_, Kwd "default"); '(_, Kwd ":"); e = parse_expr; (cs, d) = parse_generic_cases l >] ->
-    begin match d with
-      Some e -> raise (ParseException (l, "A _Generic expression must not have multiple default clauses"))
-    | None -> (cs, Some e)
-    end
-  | [< te = parse_type; '(_, Kwd ":"); e = parse_expr; (cs, d) = parse_generic_cases l >] -> ((te, e)::cs, d)
-  end >] -> (cs, d)
-| [< >] -> ([], None)
+  parse_generic_cases l = function%parser
+| [ (_, Kwd ","); 
+    [%l
+    (cs, d) = begin function%parser
+    | [ (_, Kwd "default"); 
+        (_, Kwd ":"); 
+        parse_expr as e; 
+        [%l (cs, d) = parse_generic_cases l] 
+      ] ->
+        begin match d with
+          Some e -> raise (ParseException (l, "A _Generic expression must not have multiple default clauses"))
+        | None -> (cs, Some e)
+        end
+    | [ parse_type as te; 
+        (_, Kwd ":");
+        parse_expr as e; 
+        [%l (cs, d) = parse_generic_cases l] 
+      ] -> ((te, e)::cs, d)
+    end 
+    ]
+  ] -> (cs, d)
+| [ ] -> ([], None)
 and
-  parse_switch_expr_clauses = parser
-  [< c = parse_switch_expr_clause; cs = parse_switch_expr_clauses >] -> c::cs
-| [< >] -> []
+  parse_switch_expr_clauses = function%parser
+| [ parse_switch_expr_clause as c; parse_switch_expr_clauses as cs ] -> c::cs
+| [ ] -> []
 and
-  parse_switch_expr_clause = parser
-    [< '(l, Kwd "case"); '(_, Ident c); pats = (parser [< '(_, Kwd "("); '(lx, Ident x); () = (fun _ -> register_varname x); xs = parse_more_pats >] -> x::xs | [< >] -> []); '(_, Kwd ":"); '(_, Kwd "return"); e = parse_expr; '(_, Kwd ";") >] -> SwitchExprClause (l, c, pats, e)
+  parse_switch_expr_clause = function%parser
+| [ (l, Kwd "case"); 
+    (_, Ident c); 
+    [%l
+    pats = (function%parser 
+    | [ (_, Kwd "("); 
+        (lx, Ident x); 
+        [%l () = (fun _ -> register_varname x)]; 
+        parse_more_pats as xs 
+      ] -> x::xs 
+    | [ ] -> []
+    )
+    ]; 
+    (_, Kwd ":"); 
+    (_, Kwd "return"); 
+    parse_expr as e; 
+    (_, Kwd ";") 
+  ] -> SwitchExprClause (l, c, pats, e)
 and
   expr_to_class_name e =
     match e with
@@ -1745,62 +2648,118 @@ and
     | Read (_, e, f) -> expr_to_class_name e ^ "." ^ f
     | _ -> raise (ParseException (expr_loc e, "Class name expected"))
 and
-  parse_expr_suffix_rest e0 = parser
-  [< '(l, Kwd "->");
-     e = begin parser
-       [< '(_, Ident f); e = parse_expr_suffix_rest (Read (l, e0, f)) >] -> e
-     | [< '(_, Kwd "/*@"); '(_, Kwd "activating"); '(_, Kwd "@*/"); '(_, Ident f); e = parse_expr_suffix_rest (ActivatingRead (l, e0, f)) >] -> e
-     end >] -> e
-| [< '(l, Kwd ".") when language = CLang;
-     e = begin parser
-       [< '(_, Ident f); e = parse_expr_suffix_rest (Select (l, e0, f)) >] -> e
-     | [< '(_, Kwd "/*@"); '(_, Kwd "activating"); '(_, Kwd "@*/"); '(_, Ident f); e = parse_expr_suffix_rest (ActivatingRead (l, AddressOf (l, e0), f)) >] -> e
-     end >] -> e
-| [< '(l, Kwd ".");
-     e = begin parser
-       [< '(_, Ident f); e = parse_expr_suffix_rest (Read (l, e0, f)) >] -> e
-     | [< '(_, Kwd "class"); e = parse_expr_suffix_rest (ClassLit (l, expr_to_class_name e0)) >] -> e
+  parse_expr_suffix_rest e0 = function%parser
+  [ (l, Kwd "->");
+    [%l
+    e = begin function%parser
+    | [ (_, Ident f); 
+        [%l e = parse_expr_suffix_rest (Read (l, e0, f))] 
+      ] -> e
+    | [ (_, Kwd "/*@"); 
+        (_, Kwd "activating"); 
+        (_, Kwd "@*/"); 
+        (_, Ident f); 
+        [%l e = parse_expr_suffix_rest (ActivatingRead (l, e0, f))]
+      ] -> e
+    end 
+    ]
+  ] -> e
+| [ (l, Kwd ".");
+    [%l
+    e = begin function%parser
+    | [ (_, Ident f); 
+        [%l e = parse_expr_suffix_rest (Select (l, e0, f))] 
+      ] -> e
+    | [ (_, Kwd "/*@"); 
+        (_, Kwd "activating"); 
+        (_, Kwd "@*/"); 
+        (_, Ident f); 
+        [%l e = parse_expr_suffix_rest (ActivatingRead (l, AddressOf (l, e0), f))] 
+      ] -> e
+    end 
+    ]
+  ] when language = CLang -> e
+| [ (l, Kwd ".");
+    [%l
+    e = begin function%parser
+    | [ (_, Ident f); 
+        [%l e = parse_expr_suffix_rest (Read (l, e0, f))]
+      ] -> e
+    | [ (_, Kwd "class"); 
+        [%l e = parse_expr_suffix_rest (ClassLit (l, expr_to_class_name e0))]
+      ] -> e
+    end
+    ]
+  ] -> e
+| [ (l, Kwd "["); 
+    [%l
+    e = begin function%parser
+    | [ (_, Kwd "]") ] -> ArrayTypeExpr' (l, e0)
+    | [ [%l p1 = opt parse_pattern];
+        [%l
+        e = begin function%parser
+        | [ (ls, Kwd ".."); 
+            [%l p2 = opt parse_pattern]; 
+            (_, Kwd "]") 
+          ] -> ReadArray (l, e0, SliceExpr (ls, p1, p2))
+        | [ (_, Kwd "]") ] -> begin match p1 with Some (LitPat e1) -> ReadArray (l, e0, e1) | _ -> raise (ParseException (l, "Malformed array access.")) end
+        end
+        ]
+      ] -> e
      end
-  >] -> e
-| [< '(l, Kwd "["); 
-     e = begin parser
-       [< '(_, Kwd "]") >] -> ArrayTypeExpr' (l, e0)
-     | [< p1 = opt parse_pattern;
-          e = begin parser
-            [< '(ls, Kwd ".."); p2 = opt parse_pattern; '(_, Kwd "]") >] -> ReadArray (l, e0, SliceExpr (ls, p1, p2))
-          | [< '(_, Kwd "]") >] -> begin match p1 with Some (LitPat e1) -> ReadArray (l, e0, e1) | _ -> raise (ParseException (l, "Malformed array access.")) end
-          end
-       >] -> e
-     end; e = parse_expr_suffix_rest e >] -> e
-| [< '(l, Kwd "++"); e = parse_expr_suffix_rest (AssignOpExpr (l, e0, Add, IntLit (l, unit_big_int, true, false, NoLSuffix), true)) >] -> e
-| [< '(l, Kwd "--"); e = parse_expr_suffix_rest (AssignOpExpr (l, e0, Sub, IntLit (l, unit_big_int, true, false, NoLSuffix), true)) >] -> e
-| [< '(l, Kwd "("); es = rep_comma parse_expr; '(_, Kwd ")"); e = parse_expr_suffix_rest (match e0 with Read(l', e0', f') -> CallExpr (l', f', [], [], LitPat(e0'):: (List.map (fun e -> LitPat(e)) es), Instance) | _ -> ExprCallExpr (l, e0, es)) >] -> e
-| [< >] -> e0
+    ]; 
+    [%l e = parse_expr_suffix_rest e] 
+  ] -> e
+| [ (l, Kwd "++"); 
+    [%l e = parse_expr_suffix_rest (AssignOpExpr (l, e0, Add, IntLit (l, unit_big_int, true, false, NoLSuffix), true))] ] -> e
+| [ (l, Kwd "--"); 
+    [%l e = parse_expr_suffix_rest (AssignOpExpr (l, e0, Sub, IntLit (l, unit_big_int, true, false, NoLSuffix), true))] ] -> e
+| [ (l, Kwd "("); 
+    [%l es = rep_comma parse_expr]; 
+    (_, Kwd ")"); 
+    [%l e = parse_expr_suffix_rest (match e0 with Read(l', e0', f') -> CallExpr (l', f', [], [], LitPat(e0'):: (List.map (fun e -> LitPat(e)) es), Instance) | _ -> ExprCallExpr (l, e0, es))]
+  ] -> e
+| [ ] -> e0
 and
-  parse_expr_mul_rest e0 = parser
-  [< '(l, Kwd "*"); e1 = parse_expr_suffix; e = parse_expr_mul_rest (Operation (l, Mul, [e0; e1])) >] -> e
-| [< '(l, Kwd "/"); e1 = parse_expr_suffix; e = parse_expr_mul_rest (Operation (l, Div, [e0; e1])) >] -> e
-| [< '(l, Kwd "%"); e1 = parse_expr_suffix; e = parse_expr_mul_rest (Operation (l, Mod, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_expr_mul_rest e0 = function%parser
+| [ (l, Kwd "*"); 
+    parse_expr_suffix as e1; 
+    [%l e = parse_expr_mul_rest (Operation (l, Mul, [e0; e1]))] 
+  ] -> e
+| [ (l, Kwd "/"); 
+    parse_expr_suffix as e1; 
+    [%l e = parse_expr_mul_rest (Operation (l, Div, [e0; e1]))]
+  ] -> e
+| [ (l, Kwd "%"); 
+    parse_expr_suffix as e1; 
+    [%l e = parse_expr_mul_rest (Operation (l, Mod, [e0; e1]))] 
+  ] -> e
+| [ ] -> e0
 and
-  parse_expr_arith_rest e0 = parser
-  [< '(l, Kwd "+"); e1 = parse_expr_mul; e = parse_expr_arith_rest (Operation (l, Add, [e0; e1])) >] -> e
-| [< '(l, Kwd "-"); e1 = parse_expr_mul; e = parse_expr_arith_rest (Operation (l, Sub, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_expr_arith_rest e0 = function%parser
+| [ (l, Kwd "+"); 
+    parse_expr_mul as e1; 
+    [%l e = parse_expr_arith_rest (Operation (l, Add, [e0; e1]))] 
+  ] -> e
+| [ (l, Kwd "-"); 
+    parse_expr_mul as e1; 
+    [%l e = parse_expr_arith_rest (Operation (l, Sub, [e0; e1]))] 
+  ] -> e
+| [ ] -> e0
 and
-  parse_shift_rest e0 = parser
-  [< '(l, Kwd "<<"); e1 = parse_expr_arith; e = parse_shift_rest (Operation (l, ShiftLeft, [e0; e1])) >] -> e
-| [< '(l, Kwd ">>"); e1 = parse_expr_arith; e = parse_shift_rest (Operation (l, ShiftRight, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_shift_rest e0 = function%parser
+| [ (l, Kwd "<<"); parse_expr_arith as e1; [%l e = parse_shift_rest (Operation (l, ShiftLeft, [e0; e1]))] ] -> e
+| [ (l, Kwd ">>"); parse_expr_arith as e1; [%l e = parse_shift_rest (Operation (l, ShiftRight, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_expr_rel_rest e0 = parser
-  [< '(l, Kwd "=="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Eq, [e0; e1])) >] -> e
-| [< '(l, Kwd "!="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Neq, [e0; e1])) >] -> e
-| [< '(l, Kwd "<="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Le, [e0; e1])) >] -> e
-| [< '(l, Kwd ">"); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Gt, [e0; e1])) >] -> e
-| [< '(l, Kwd ">="); e1 = parse_truncating_expr; e = parse_expr_rel_rest (Operation (l, Ge, [e0; e1])) >] -> e
-| [< '(l, Kwd "instanceof"); tp = parse_expr; e = parse_expr_rel_rest (InstanceOfExpr (l, e0, type_expr_of_expr tp)) >] -> e
-| [< e = parse_expr_lt_rest e0 parse_expr_rel_rest >] -> e
+  parse_expr_rel_rest e0 = function%parser
+| [ (l, Kwd "=="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Eq, [e0; e1]))] ] -> e
+| [ (l, Kwd "!="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Neq, [e0; e1]))] ] -> e
+| [ (l, Kwd "<="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Le, [e0; e1]))] ] -> e
+| [ (l, Kwd ">"); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Gt, [e0; e1]))] ] -> e
+| [ (l, Kwd ">="); parse_truncating_expr as e1; [%l e = parse_expr_rel_rest (Operation (l, Ge, [e0; e1]))] ] -> e
+| [ (l, Kwd "instanceof"); parse_expr as tp; [%l e = parse_expr_rel_rest (InstanceOfExpr (l, e0, type_expr_of_expr tp))] ] -> e
+| [ [%l e = parse_expr_lt_rest e0 parse_expr_rel_rest] ] -> e
 and
   apply_type_args e targs args =
   match e with
@@ -1813,76 +2772,98 @@ and
   | Operation (l, op, [e1; e2]) -> Operation (l, op, [e1; apply_type_args e2 targs args])
   | _ -> raise (ParseException (expr_loc e, "Identifier expected before type argument list"))
 and
-  parse_expr_lt_rest e0 cont = parser
-  [< '(l, Kwd "<");
-     e = parser
-       [< e1 = parse_truncating_expr; e1 = parse_expr_lt_rest e1 (let rec iter e0 = parse_expr_lt_rest e0 iter in iter);
-          e = parser
-            [< '(_, Kwd ">"); (* Type argument *)
-               args = (parser [< args = parse_patlist >] -> args | [< >] -> []);
-               e = cont (apply_type_args e0 [type_expr_of_expr e1] args)
-            >] -> e
-          | [< '(_, Kwd ","); ts = rep_comma parse_type; '(_, Kwd ">");
-               args = (parser [< args = parse_patlist >] -> args | [< >] -> []);
-               e = cont (apply_type_args e0 ([type_expr_of_expr e1] @ ts) args)
-            >] -> e
-          | [< e = cont (Operation (l, Lt, [e0; e1])) >] -> e
-       >] -> e
-     | [< ts = rep_comma parse_type; '(_, Kwd ">");
-          args = (parser [< args = parse_patlist >] -> args | [< >] -> []);
-          e = cont (apply_type_args e0 ts args)
-       >] -> e
-  >] -> e
-| [< >] -> e0
+  parse_expr_lt_rest e0 cont = function%parser
+| [ (l, Kwd "<");
+    [%l
+    e = function%parser
+    | [ parse_truncating_expr as e1; 
+        [%l e1 = parse_expr_lt_rest e1 (let rec iter e0 = parse_expr_lt_rest e0 iter in iter)];
+        [%l
+        e = function%parser
+        | [ (_, Kwd ">"); (* Type argument *)
+            [%l args = (function%parser [ parse_patlist as args ] -> args | [ ] -> [])];
+            [%l e = cont (apply_type_args e0 [type_expr_of_expr e1] args)]
+          ] -> e
+        | [ (_, Kwd ","); 
+            [%l ts = rep_comma parse_type]; 
+            (_, Kwd ">");
+            [%l args = (function%parser [ parse_patlist as args ] -> args | [ ] -> [])];
+            [%l e = cont (apply_type_args e0 ([type_expr_of_expr e1] @ ts) args)]
+          ] -> e
+        | [ [%l e = cont (Operation (l, Lt, [e0; e1]))] ] -> e
+        ]
+      ] -> e
+    | [ [%l ts = rep_comma parse_type]; 
+        (_, Kwd ">");
+        [%l args = (function%parser [ parse_patlist as args ] -> args | [ ] -> [])];
+        [%l e = cont (apply_type_args e0 ts args)]
+      ] -> e
+    ]
+  ] -> e
+| [ ] -> e0
 and
-  parse_bitand_expr_rest e0 = parser
-  [< '(l, Kwd "&"); e1 = parse_expr_rel; e = parse_bitand_expr_rest (Operation (l, BitAnd, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_bitand_expr_rest e0 = function%parser
+| [ (l, Kwd "&"); parse_expr_rel as e1; [%l e = parse_bitand_expr_rest (Operation (l, BitAnd, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_bitxor_expr_rest e0 = parser
-  [< '(l, Kwd "^"); e1 = parse_bitand_expr; e = parse_bitxor_expr_rest (Operation (l, BitXor, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_bitxor_expr_rest e0 = function%parser
+| [ (l, Kwd "^"); parse_bitand_expr as e1; [%l e = parse_bitxor_expr_rest (Operation (l, BitXor, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_bitor_expr_rest e0 = parser
-  [< '(l, Kwd "|"); e1 = parse_bitxor_expr; e = parse_bitor_expr_rest (Operation (l, BitOr, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_bitor_expr_rest e0 = function%parser
+| [ (l, Kwd "|"); parse_bitxor_expr as e1; [%l e = parse_bitor_expr_rest (Operation (l, BitOr, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_conj_expr_rest e0 = parser
-  [< '(l, Kwd "&&"); e1 = parse_bitor_expr; e = parse_conj_expr_rest (Operation (l, And, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_conj_expr_rest e0 = function%parser
+| [ (l, Kwd "&&"); parse_bitor_expr as e1; [%l e = parse_conj_expr_rest (Operation (l, And, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_disj_expr_rest e0 = parser
-  [< '(l, Kwd "||"); e1 = parse_conj_expr; e = parse_disj_expr_rest (Operation (l, Or, [e0; e1])) >] -> e
-| [< >] -> e0
+  parse_disj_expr_rest e0 = function%parser
+| [ (l, Kwd "||"); parse_conj_expr as e1; [%l e = parse_disj_expr_rest (Operation (l, Or, [e0; e1]))] ] -> e
+| [ ] -> e0
 and
-  parse_assign_expr_rest e0 = parser
-  [< '(l, Kwd "="); e1 = parse_assign_expr >] -> AssignExpr (l, e0, e1)
-| [< '(l, Kwd "+="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, Add, e1, false)
-| [< '(l, Kwd "-="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, Sub, e1, false)
-| [< '(l, Kwd "*="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, Mul, e1, false)
-| [< '(l, Kwd "/="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, Div, e1, false)
-| [< '(l, Kwd "&="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, BitAnd, e1, false)
-| [< '(l, Kwd "|="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, BitOr, e1, false)
-| [< '(l, Kwd "^="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, BitXor, e1, false)
-| [< '(l, Kwd "%="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, Mod, e1, false)
-| [< '(l, Kwd "<<="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, ShiftLeft, e1, false)
-| [< '(l, Kwd ">>="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, ShiftRight, e1, false)
+  parse_assign_expr_rest e0 = function%parser
+| [ (l, Kwd "="); parse_assign_expr as e1 ] -> AssignExpr (l, e0, e1)
+| [ (l, Kwd "+="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, Add, e1, false)
+| [ (l, Kwd "-="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, Sub, e1, false)
+| [ (l, Kwd "*="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, Mul, e1, false)
+| [ (l, Kwd "/="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, Div, e1, false)
+| [ (l, Kwd "&="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, BitAnd, e1, false)
+| [ (l, Kwd "|="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, BitOr, e1, false)
+| [ (l, Kwd "^="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, BitXor, e1, false)
+| [ (l, Kwd "%="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, Mod, e1, false)
+| [ (l, Kwd "<<="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, ShiftLeft, e1, false)
+| [ (l, Kwd ">>="); parse_assign_expr as e1 ] -> AssignOpExpr (l, e0, ShiftRight, e1, false)
 (*| [< '(l, Kwd ">>>="); e1 = parse_assign_expr >] -> AssignOpExpr (l, e0, ???, e1, false)*)
-| [< >] -> e0
+| [ ] -> e0
 and
-  parse_arglist = parser
-  [< '(l, Kwd "("); es = parser [< '(_, Kwd ")") >] -> [] | [< e0 = parse_expr; es = parse_arglist_rest >] -> e0::es >] -> es
+  parse_arglist = function%parser
+| [ (l, Kwd "("); 
+    [%l
+    es = function%parser 
+    | [ (_, Kwd ")") ] -> [] 
+    | [ parse_expr as e0; 
+        parse_arglist_rest as es 
+      ] -> e0::es 
+    ]
+  ] -> es
 and
-  parse_arglist_rest = parser
-  [< '(_, Kwd ","); e0 = parse_expr; es = parse_arglist_rest >] -> e0::es
-| [< '(_, Kwd ")") >] -> []
+  parse_arglist_rest = function%parser
+| [ (_, Kwd ","); parse_expr as e0; parse_arglist_rest as es ] -> e0::es
+| [ (_, Kwd ")") ] -> []
 and
-  parse_patlist = parser
-  [< '(l, Kwd "("); pats = parser [< '(_, Kwd ")") >] -> [] | [< pat0 = parse_pattern; pats = parse_patlist_rest >] -> pat0::pats >] -> pats
+  parse_patlist = function%parser
+| [ (l, Kwd "("); 
+    [%l
+    pats = function%parser 
+    | [ (_, Kwd ")") ] -> [] 
+    | [ parse_pattern as pat0; parse_patlist_rest as pats ] -> pat0::pats 
+    ]
+  ] -> pats
 and
-  parse_patlist_rest = parser
-  [< '(_, Kwd ","); pat0 = parse_pattern; pats = parse_patlist_rest >] -> pat0::pats
-| [< '(_, Kwd ")") >] -> []
+  parse_patlist_rest = function%parser
+| [ (_, Kwd ","); parse_pattern as pat0; parse_patlist_rest as pats ] -> pat0::pats
+| [ (_, Kwd ")") ] -> []
 
 end
 
@@ -1895,38 +2876,49 @@ let parse_decls lang dataModel enforceAnnotations ?inGhostHeader =
   let module MyParser = Parser(MyParserArgs) in
   MyParser.parse_decls ?inGhostHeader
 
-let rec parse_package_name= parser
-  [<'(_, Ident n);x=parser
-    [<'(_, Kwd ".");rest=parse_package_name>] -> n^"."^rest
-  | [<'(_, Kwd ";")>] -> n
-  >] -> x
+let rec parse_package_name = function%parser
+  [ (_, Ident n); 
+    [%l
+    x = function%parser
+    | [ (_, Kwd ".");
+      parse_package_name as rest
+      ] -> n ^ "." ^ rest
+    | [(_, Kwd ";") ] -> n
+    ]
+  ] -> x
   
-let parse_package= parser
-  [<'(l, Kwd "package");n= parse_package_name>] ->(l,n)
-| [<>] -> (dummy_loc,"")
+let parse_package = function%parser
+  [ (l, Kwd "package"); parse_package_name as n ] ->(l,n)
+| [ ] -> (dummy_loc,"")
   
-let rec parse_import_names= parser
-  [<'(_, Kwd ".");y=parser
-        [<'(_, Kwd "*");'(_, Kwd ";")>] -> ("",None)
-      | [<'(_, Ident el);x=parser
-          [<'(_, Kwd ";")>]-> ("",Some el)
-        | [<rest=parse_import_names>]-> let (n',el')=rest in ("."^el^n',el')
-        >] -> x
-  >] -> y
+let rec parse_import_names = function%parser
+  [ (_, Kwd "."); 
+    [%l
+    y = function%parser
+    | [ (_, Kwd "*"); (_, Kwd ";") ] -> ("", None)
+    | [ (_, Ident el);
+        [%l 
+        x = function%parser
+        | [ (_, Kwd ";") ]-> ("", Some el)
+        | [ parse_import_names as rest ] -> let (n',el') = rest in ("." ^el^n',el')
+        ]
+      ] -> x
+    ]
+  ] -> y
 
-let parse_import_name= parser
-  [<'(_, Ident n);(n',el)=parse_import_names>] -> (n^n',el)
+let parse_import_name = function%parser
+| [ (_, Ident n); [%l (n',el) = parse_import_names] ] -> (n^n',el)
   
-let parse_import0= parser
-  [<'(l, Kwd "import");n= parse_import_name>] -> let (pn,el)=n in Import(l,Real,pn,el)
+let parse_import0 = function%parser
+  [ (l, Kwd "import"); parse_import_name as n ] -> let (pn,el)=n in Import(l,Real,pn,el)
 
-let parse_import = parser
-  [< i = parse_import0 >] -> i
-| [< i = peek_in_ghost_range (parser [< i = parse_import0; '(_, Kwd "@*/") >] -> i) >] ->
-      (match i with Import(l, Real, pn,el) -> Import(l, Ghost, pn,el))
+let parse_import = function%parser
+| [ parse_import0 as i ] -> i
+| [ [%l i = peek_in_ghost_range (function%parser [ parse_import0 as i; (_, Kwd "@*/") ] -> i)] ] ->
+    (match i with Import(l, Real, pn,el) -> Import(l, Ghost, pn,el))
 
-let parse_package_decl enforceAnnotations = parser
-  [< (l,p) = parse_package; is=rep parse_import; ds=parse_decls Java (Some data_model_java) enforceAnnotations;>] -> PackageDecl(l,p,Import(dummy_loc,Real,"java.lang",None)::is, ds)
+let parse_package_decl enforceAnnotations = function%parser
+| [ [%l (l,p) = parse_package]; [%l is=rep parse_import]; [%l ds=parse_decls Java (Some data_model_java) enforceAnnotations]; ] -> PackageDecl(l,p,Import(dummy_loc,Real,"java.lang",None)::is, ds)
 
 let noop_preprocessor stream =
   let next _ =
@@ -1942,7 +2934,7 @@ let noop_preprocessor stream =
 let parse_scala_file (path: string) (reportRange: range_kind -> loc0 -> unit): package =
   let lexer = make_lexer Scala.keywords ghost_keywords in
   let (loc, ignore_eol, token_stream) = lexer path (readFile path) reportRange (fun _ _ -> ()) in
-  let parse_decls_eof = parser [< ds = rep Scala.parse_decl; '(_, Eof) >] -> PackageDecl(dummy_loc,"",[Import(dummy_loc,Real,"java.lang",None)],ds) in
+  let parse_decls_eof = function%parser [ [%l ds = rep Scala.parse_decl]; (_, Eof) ] -> PackageDecl(dummy_loc,"",[Import(dummy_loc,Real,"java.lang",None)],ds) in
   try
     parse_decls_eof (noop_preprocessor token_stream)
   with
@@ -1962,7 +2954,7 @@ let parse_java_file_old (path: string) (reportRange: range_kind -> loc0 -> unit)
   else
   let lexer = make_lexer (common_keywords @ java_keywords) ghost_keywords in
   let (loc, ignore_eol, token_stream) = lexer path (readFile path) reportRange reportShouldFail in
-  let parse_decls_eof = parser [< p = parse_package_decl enforceAnnotations; '(_, Eof) >] -> p in
+  let parse_decls_eof = function%parser [ [%l p = parse_package_decl enforceAnnotations]; (_, Eof) ] -> p in
   try
     parse_decls_eof (noop_preprocessor token_stream)
   with
@@ -1980,13 +2972,17 @@ let rec parse_include_directives_core (verbose: int) (enforceAnnotations: bool) 
     if List.mem totalPath !active_headers then raise (ParseException (l, "Include cycles (even with header guards) are not supported"));
   in
   let rec parse_include_directives_core header_names in_ghost_range =
-    let parse = parser
-      | [< '(_, Kwd "/*@"); (headers, header_name) = parse_include_directive true; (headers', header_names') = parse_include_directives_core (header_name::header_names) true >] 
-              -> (List.append headers headers', header_names')
-      | [< (headers, header_name) = parse_include_directive in_ghost_range; (headers', header_names') = parse_include_directives_core (header_name::header_names) in_ghost_range >] 
-              -> (List.append headers headers', header_names')
-      | [< '(_, Kwd "@*/"); (headers', header_names') = parse_include_directives_core header_names false >]
-              -> headers', header_names'
+    let parse = function%parser
+      | [ (_, Kwd "/*@"); 
+          [%l (headers, header_name) = parse_include_directive true]; 
+          [%l (headers', header_names') = parse_include_directives_core (header_name::header_names) true] 
+        ] -> (List.append headers headers', header_names')
+      | [ [%l (headers, header_name) = parse_include_directive in_ghost_range]; 
+          [%l (headers', header_names') = parse_include_directives_core (header_name::header_names) in_ghost_range] 
+        ] -> (List.append headers headers', header_names')
+      | [ (_, Kwd "@*/"); 
+          [%l (headers', header_names') = parse_include_directives_core header_names false] 
+        ] -> headers', header_names'
     in
     begin fun stream ->
       begin match Stream.npeek 2 stream with
@@ -2008,16 +3004,20 @@ let rec parse_include_directives_core (verbose: int) (enforceAnnotations: bool) 
     end
   and parse_include_directive in_ghost_range = 
     let isGhostHeader header = Filename.check_suffix header ".gh" in
-    parser
-      [< '(l, SecondaryInclude(h, totalPath)) >] -> 
+    function%parser
+    | [ (l, SecondaryInclude(h, totalPath)) ] -> 
         if verbose = -1 then Printf.printf "%10.6fs: >>>> ignored secondary include: %s \n" (Perf.time()) totalPath;
         test_include_cycle l totalPath; ([], totalPath)
-    | [< '(l, BeginInclude(kind, h, totalPath)); (headers, header_names) = (active_headers := totalPath::!active_headers; parse_include_directives_core [] in_ghost_range); 
-                                           ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:(isGhostHeader h); '(_, Eof); '(_, EndInclude) >] ->
-                                                        if verbose = -1 then Printf.printf "%10.6fs: >>>> parsed include: %s \n" (Perf.time()) totalPath;
-                                                        active_headers := List.filter (fun h -> h <> totalPath) !active_headers;
-                                                        let ps = [PackageDecl(dummy_loc,"",[],ds)] in
-                                                        (List.append headers [(l, (kind, h, totalPath), header_names, ps)], totalPath)
+    | [ (l, BeginInclude(kind, h, totalPath)); 
+        [%l (headers, header_names) = (active_headers := totalPath::!active_headers; parse_include_directives_core [] in_ghost_range)]; 
+        [%l ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:(isGhostHeader h)]; 
+        (_, Eof); 
+        (_, EndInclude) 
+      ] ->
+        if verbose = -1 then Printf.printf "%10.6fs: >>>> parsed include: %s \n" (Perf.time()) totalPath;
+        active_headers := List.filter (fun h -> h <> totalPath) !active_headers;
+        let ps = [PackageDecl(dummy_loc,"",[],ds)] in
+        (List.append headers [(l, (kind, h, totalPath), header_names, ps)], totalPath)
   in
   parse_include_directives_core [] false
 
@@ -2037,9 +3037,11 @@ let parse_c_file reportMacroCall (path: string) (reportRange: range_kind -> loc0
     in
     let (loc, token_stream) = make_preprocessor reportMacroCall make_lexer path verbose include_paths dataModel define_macros in
     let parse_c_file =
-      parser
-        [< (headers, _) = parse_include_directives verbose enforceAnnotations dataModel; 
-                            ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:false; '(_, Eof) >] -> (headers, [PackageDecl(dummy_loc,"",[],ds)])
+      function%parser
+      | [ [%l (headers, _d) = parse_include_directives verbose enforceAnnotations dataModel]; 
+          [%l ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:false]; 
+          (_, Eof) 
+        ] -> (headers, [PackageDecl(dummy_loc,"",[],ds)])
     in
     try
       parse_c_file token_stream
@@ -2061,11 +3063,11 @@ let parse_header_file reportMacroCall (path: string) (reportRange: range_kind ->
       make_lexer (common_keywords @ c_keywords) ghost_keywords path text reportRange ~inGhostRange:inGhostRange reportShouldFail
     in
     let (loc, token_stream) = make_preprocessor reportMacroCall make_lexer path verbose include_paths dataModel define_macros in
-    let p = parser
-      [< (headers, _) = parse_include_directives verbose enforceAnnotations dataModel; 
-         ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:isGhostHeader; 
-         '(_, Eof)
-      >] -> (headers, [PackageDecl(dummy_loc,"",[],ds)])
+    let p = function%parser
+    | [ [%l (headers, _d) = parse_include_directives verbose enforceAnnotations dataModel]; 
+        [%l ds = parse_decls CLang dataModel enforceAnnotations ~inGhostHeader:isGhostHeader]; 
+        (_, Eof)
+      ] -> (headers, [PackageDecl(dummy_loc,"",[],ds)])
     in
     try
       p token_stream

--- a/src/smtlib.ml
+++ b/src/smtlib.ml
@@ -183,7 +183,7 @@ module Symbol (S : SORT) : SYMBOL with type sort = S.t = struct
      Symbols may not start with a numeral. *)
   let escape_char = function
     | '@' -> "_@"
-    | ''' -> "_q"
+    | '\'' -> "_q"
     | '#' -> "_h"
     | '0'..'9' as c -> Printf.sprintf "_%c" c
     | c -> String.make 1 c

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -5445,7 +5445,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | _ -> ()
     end
 
-  if fno_strict_aliasing && List.mem_assoc "has_type" purefuncmap then begin
+  let () = if fno_strict_aliasing && List.mem_assoc "has_type" purefuncmap then begin
     ctxt#begin_formal;
     let p = ctxt#mk_bound 0 ctxt#type_inductive in
     let t = ctxt#mk_bound 1 ctxt#type_inductive in
@@ -5454,7 +5454,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     ctxt#assume_forall "all_has_type" [hasType] [ctxt#type_inductive; ctxt#type_inductive] hasType
   end
 
-  if assume_no_subobject_provenance && List.mem_assoc "field_ptr" purefuncmap then begin
+  let () = if assume_no_subobject_provenance && List.mem_assoc "field_ptr" purefuncmap then begin
     begin
     ctxt#begin_formal;
     let pr = ctxt#mk_bound 0 ctxt#type_inductive in

--- a/src/win/caml_stopwatch.c
+++ b/src/win/caml_stopwatch.c
@@ -4,7 +4,7 @@
 #include <caml/alloc.h>
 
 value caml_stopwatch_getpid() {
-    return copy_int32(GetCurrentProcessId());
+    return caml_copy_int32(GetCurrentProcessId());
 }
 
 value caml_lock_process_to_processor_1() {
@@ -14,7 +14,7 @@ value caml_lock_process_to_processor_1() {
 }
 
 value caml_stopwatch_processor_ticks() {
-    return copy_int64(__rdtsc());
+    return caml_copy_int64(__rdtsc());
 }
 
 struct stopwatch {
@@ -50,5 +50,5 @@ value caml_stopwatch_stop(value stopwatch) {
 
 value caml_stopwatch_ticks(value stopwatch) {
     struct stopwatch *s = (void *)stopwatch;
-    return copy_int64(s->counter);
-}
+    return caml_copy_int64(s->counter);
+}


### PR DESCRIPTION
Updated to use new vfdeps and new parser syntax. (`depend` target is a lot faster now because we don't have to preprocess it with `camlp4`)