### PR TITLE
Simplify pointers in redux

### DIFF
--- a/tests/cxx/virtual_methods/multiple_inheritance.cpp
+++ b/tests/cxx/virtual_methods/multiple_inheritance.cpp
@@ -1,5 +1,3 @@
-// verifast_options{prover:z3v4.5}
-
 class Target;
 
 class Source {


### PR DESCRIPTION
Simplify nested `field_ptr_parent(field_ptr(target, _, offset), offset)` to `target` in redux.