### PR TITLE
[Rust] Simplify building capnp struct lists

### DIFF
--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/benchmark/carsales.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/benchmark/carsales.rs
@@ -40,7 +40,7 @@ macro_rules! car_value_impl(
                     {
                         let mut wheels = self.reborrow().get_wheels()?;
                         for ii in 0..wheels.len() {
-                            let mut wheel = wheels.reborrow().get(ii);
+                            let mut wheel = wheels.reborrow().get(ii as usize);
                             result += wheel.reborrow().get_diameter() as u64 * wheel.reborrow().get_diameter() as u64;
                             result += if wheel.reborrow().get_snow_tires() { 100 } else { 0 };
                         }
@@ -96,7 +96,7 @@ pub fn random_car(rng: &mut FastRand, mut car: car::Builder) {
     {
         let mut wheels = car.reborrow().init_wheels(4);
         for ii in 0..wheels.len() {
-            let mut wheel = wheels.reborrow().get(ii);
+            let mut wheel = wheels.reborrow().get(ii as usize);
             wheel.set_diameter(25 + rng.next_less_than(15) as u16);
             wheel.set_air_pressure((30.0 + rng.next_double(20.0)) as f32);
             wheel.set_snow_tires(rng.next_less_than(16) == 0);
@@ -139,9 +139,9 @@ impl crate::TestCase for CarSales {
 
     fn setup_request(&self, rng: &mut FastRand, request: parking_lot::Builder) -> u64 {
         let mut result = 0;
-        let mut cars = request.init_cars(rng.next_less_than(200));
+        let mut cars = request.init_cars(rng.next_less_than(200) as usize);
         for ii in 0..cars.len() {
-            let mut car = cars.reborrow().get(ii);
+            let mut car = cars.reborrow().get(ii as usize);
             random_car(rng, car.reborrow());
             result += car.car_value().unwrap();
         }

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/benchmark/catrank.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/benchmark/catrank.rs
@@ -41,10 +41,10 @@ impl crate::TestCase for CatRank {
         let count = rng.next_less_than(1000);
         let mut good_count: i32 = 0;
 
-        let mut list = request.init_results(count);
+        let mut list = request.init_results(count as usize);
 
         for i in 0..count {
-            let mut result = list.reborrow().get(i);
+            let mut result = list.reborrow().get(i as usize);
             result.set_score(1000.0 - i as f64);
             let url_size = rng.next_less_than(100);
 
@@ -99,7 +99,7 @@ impl crate::TestCase for CatRank {
 
         let results = request.get_results()?;
         for i in 0..results.len() {
-            let result = results.get(i);
+            let result = results.get(i as usize);
             let mut score = result.get_score();
             let snippet = result.get_snippet()?.to_str()?;
             if snippet.contains(" cat ") {
@@ -120,13 +120,13 @@ impl crate::TestCase for CatRank {
             }
         });
 
-        let mut list = response.init_results(scored_results.len() as u32);
+        let mut list = response.init_results(scored_results.len());
         for i in 0..list.len() {
-            let mut item = list.reborrow().get(i);
+            let mut item = list.reborrow().get(i as usize);
             let result = scored_results[i as usize];
             item.set_score(result.score);
-            item.set_url(result.result.get_url()?);
-            item.set_snippet(result.result.get_snippet()?);
+            item.set_url(result.result.get_url()?.to_str()?);
+            item.set_snippet(result.result.get_snippet()?.to_str()?);
         }
 
         Ok(())

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp-rpc/examples/calculator/server.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp-rpc/examples/calculator/server.rs
@@ -65,7 +65,7 @@ fn evaluate_impl(
                 .map(|v| Ok(v?.get()?.get_value())),
         ),
         calculator::expression::Parameter(p) => match params {
-            Some(params) if p < params.len() => Promise::ok(params.get(p)),
+            Some(params) if p < params.len() => Promise::ok(params.get(p as usize)),
             _ => Promise::err(Error::failed(format!("bad parameter: {p}"))),
         },
         calculator::expression::Call(call) => {
@@ -79,9 +79,9 @@ fn evaluate_impl(
                 let param_values = eval_params.await?;
                 let mut request = func.call_request();
                 {
-                    let mut params = request.get().init_params(param_values.len() as u32);
+                    let mut params = request.get().init_params(param_values.len());
                     for (ii, value) in param_values.iter().enumerate() {
-                        params.set(ii as u32, *value);
+                        params.set(ii, *value);
                     }
                 }
                 Ok(request.send().promise.await?.get()?.get_value())

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp-rpc/src/rpc.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp-rpc/src/rpc.rs
@@ -1445,7 +1445,7 @@ impl<VatId> ConnectionState<VatId> {
                     if let Some(export_id) = Self::write_descriptor(
                         state,
                         cap.clone(),
-                        cap_table_builder.reborrow().get(idx as u32),
+                        cap_table_builder.reborrow().get(idx),
                     )
                     .unwrap()
                     {
@@ -1453,7 +1453,7 @@ impl<VatId> ConnectionState<VatId> {
                     }
                 }
                 None => {
-                    cap_table_builder.reborrow().get(idx as u32).set_none(());
+                    cap_table_builder.reborrow().get(idx).set_none(());
                 }
             }
         }
@@ -1582,7 +1582,7 @@ impl<VatId> ConnectionState<VatId> {
     ) -> ::capnp::Result<Vec<Option<Box<dyn ClientHook>>>> {
         let mut result = Vec::new();
         for idx in 0..cap_table.len() {
-            result.push(Self::receive_cap(state, cap_table.get(idx))?);
+            result.push(Self::receive_cap(state, cap_table.get(idx as usize))?);
         }
         Ok(result)
     }
@@ -2927,7 +2927,7 @@ impl<VatId> Client<VatId> {
                     {
                         transform
                             .reborrow()
-                            .get(idx as u32)
+                            .get(idx)
                             .set_get_pointer_field(ordinal);
                     }
                 }
@@ -2962,7 +2962,7 @@ impl<VatId> Client<VatId> {
                     {
                         transform
                             .reborrow()
-                            .get(idx as u32)
+                            .get(idx)
                             .set_get_pointer_field(ordinal);
                     }
                 }

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/list_list.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/list_list.rs
@@ -92,7 +92,7 @@ where
     T: crate::traits::Owned,
 {
     fn index_move(&self, index: u32) -> Result<T::Reader<'a>> {
-        self.get(index)
+        self.get(index as usize)
     }
 }
 
@@ -117,9 +117,10 @@ where
 {
     /// Gets the element at position `index`. Panics if `index` is greater than or
     /// equal to `len()`.
-    pub fn get(self, index: u32) -> Result<T::Reader<'a>> {
-        assert!(index < self.len());
-        FromPointerReader::get_from_pointer(&self.reader.get_pointer_element(index), None)
+    pub fn get(self, index: usize) -> Result<T::Reader<'a>> {
+        let index_u32: u32 = index.try_into().expect("index out of bounds");
+        assert!(index_u32 < self.len());
+        FromPointerReader::get_from_pointer(&self.reader.get_pointer_element(index_u32), None)
     }
 
     /// Gets the element at position `index`. Returns `None` if `index`
@@ -177,8 +178,10 @@ impl<'a, T> Builder<'a, T>
 where
     T: crate::traits::Owned,
 {
-    pub fn init(self, index: u32, size: u32) -> T::Builder<'a> {
-        FromPointerBuilder::init_pointer(self.builder.get_pointer_element(index), size)
+    pub fn init(self, index: usize, size: usize) -> T::Builder<'a> {
+        let index_u32: u32 = index.try_into().expect("index out of bounds");
+        let size_u32: u32 = size.try_into().expect("maximum size exceeded");
+        FromPointerBuilder::init_pointer(self.builder.get_pointer_element(index_u32), size_u32)
     }
 }
 
@@ -221,9 +224,10 @@ where
 {
     /// Gets the element at position `index`. Panics if `index` is greater than or
     /// equal to `len()`.
-    pub fn get(self, index: u32) -> Result<T::Builder<'a>> {
-        assert!(index < self.len());
-        FromPointerBuilder::get_from_pointer(self.builder.get_pointer_element(index), None)
+    pub fn get(self, index: usize) -> Result<T::Builder<'a>> {
+        let index_u32: u32 = index.try_into().expect("index out of bounds");
+        assert!(index_u32 < self.len());
+        FromPointerBuilder::get_from_pointer(self.builder.get_pointer_element(index_u32), None)
     }
 
     /// Gets the element at position `index`. Returns `None` if `index`

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/primitive_list.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/primitive_list.rs
@@ -90,16 +90,17 @@ impl<'a, T: PrimitiveElement> FromPointerReader<'a> for Reader<'a, T> {
 
 impl<'a, T: PrimitiveElement> IndexMove<u32, T> for Reader<'a, T> {
     fn index_move(&self, index: u32) -> T {
-        self.get(index)
+        self.get(index as usize)
     }
 }
 
 impl<'a, T: PrimitiveElement> Reader<'a, T> {
     /// Gets the `T` at position `index`. Panics if `index` is greater than or
     /// equal to `len()`.
-    pub fn get(&self, index: u32) -> T {
-        assert!(index < self.len());
-        PrimitiveElement::get(&self.reader, index)
+    pub fn get(&self, index: usize) -> T {
+        let index_u32: u32 = index.try_into().expect("index out of bounds");
+        assert!(index_u32 < self.len());
+        PrimitiveElement::get(&self.reader, index_u32)
     }
 
     /// Gets the `T` at position `index`. Returns `None` if `index`
@@ -167,9 +168,10 @@ where
         }
     }
 
-    pub fn set(&mut self, index: u32, value: T) {
-        assert!(index < self.len());
-        PrimitiveElement::set(&self.builder, index, value);
+    pub fn set(&mut self, index: usize, value: T) {
+        let index_u32: u32 = index.try_into().expect("Index exceeds length");
+        assert!(index_u32 < self.len());
+        PrimitiveElement::set(&self.builder, index_u32, value);
     }
 
     #[cfg(target_endian = "little")]
@@ -213,9 +215,10 @@ impl<'a, T: PrimitiveElement> FromPointerBuilder<'a> for Builder<'a, T> {
 impl<'a, T: PrimitiveElement> Builder<'a, T> {
     /// Gets the `T` at position `index`. Panics if `index` is greater than or
     /// equal to `len()`.
-    pub fn get(&self, index: u32) -> T {
-        assert!(index < self.len());
-        PrimitiveElement::get_from_builder(&self.builder, index)
+    pub fn get(&self, index: usize) -> T {
+        let index_u32: u32 = index.try_into().expect("index is out of bounds");
+        assert!(index_u32 < self.len());
+        PrimitiveElement::get_from_builder(&self.builder, index_u32)
     }
 
     /// Gets the `T` at position `index`. Returns `None` if `index`

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/schema.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/schema.rs
@@ -163,7 +163,7 @@ impl FieldList {
 
     pub fn get(self, index: u16) -> Field {
         Field {
-            proto: self.fields.get(index as u32),
+            proto: self.fields.get(index as usize),
             index,
             parent: self.parent,
         }
@@ -209,7 +209,7 @@ impl FieldSubset {
     pub fn get(self, index: u16) -> Field {
         let index = self.indices[index as usize];
         Field {
-            proto: self.fields.get(index as u32),
+            proto: self.fields.get(index as usize),
             index,
             parent: self.parent,
         }
@@ -330,7 +330,7 @@ impl EnumerantList {
 
     pub fn get(self, ordinal: u16) -> Enumerant {
         Enumerant {
-            proto: self.enumerants.get(ordinal as u32),
+            proto: self.enumerants.get(ordinal as usize),
             ordinal,
             parent: self.parent,
         }
@@ -398,7 +398,7 @@ impl AnnotationList {
     }
 
     pub fn get(self, index: u32) -> Annotation {
-        let proto = self.annotations.get(index);
+        let proto = self.annotations.get(index as usize);
         let ty = (self.get_annotation_type)(self.child_index, index);
         Annotation { proto, ty }
     }

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/traits.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnp/src/traits.rs
@@ -74,6 +74,9 @@ pub trait Pipelined {
 
 pub trait FromPointerBuilder<'a>: Sized {
     fn init_pointer(builder: PointerBuilder<'a>, length: u32) -> Self;
+    fn init_pointer_with_usize_length(builder: PointerBuilder<'a>, length: usize) -> Self {
+        Self::init_pointer(builder, length.try_into().expect("maximum length exceeded"))
+    }
     fn get_from_pointer(
         builder: PointerBuilder<'a>,
         default: Option<&'a [crate::Word]>,

--- a/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnpc/src/codegen_types.rs
+++ b/src/rust_frontend/vf_mir_exporter/capnproto-rust/capnpc/src/codegen_types.rs
@@ -258,7 +258,7 @@ impl<'a> RustTypeInfo for type_::Reader<'a> {
                 type_::any_pointer::Parameter(def) => {
                     let the_struct = &ctx.node_map[&def.get_scope_id()];
                     let parameters = the_struct.get_parameters()?;
-                    let parameter = parameters.get(u32::from(def.get_parameter_index()));
+                    let parameter = parameters.get(usize::from(def.get_parameter_index()));
                     let parameter_name = parameter.get_name()?.to_str()?;
                     match module {
                         Leaf::Owned => Ok(parameter_name.to_string()),


### PR DESCRIPTION
- Take usize lengths and indices instead of u32
- Add `fill` method
