### PR TITLE
[Rust] Support implementing the Drop trait

### DIFF
--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -581,6 +581,7 @@ struct Body {
     unsafety @10: Unsafety;
     hirGenerics @11: Hir.Generics;
     isTraitFn @12: Bool;
+    isDropFn @13: Bool; # Implements std::ops::Drop::drop
     # Todo @Nima: Add Visibility data
 }
 
@@ -601,6 +602,7 @@ struct Trait {
 }
 
 struct TraitImpl {
+    span @3: SpanData;
     ofTrait @0: Text;
     selfTy @1: Text;
     items @2: List(Text);

--- a/tests/rust/safe_abstraction/cell_u32.rs
+++ b/tests/rust/safe_abstraction/cell_u32.rs
@@ -19,7 +19,7 @@ i.e. in VeriFast the `[[u32]].OWN` is implicitly persistent.
 */
 
 pred_ctor CellU32_nonatomic_borrow_content(l: *CellU32, t: thread_id_t)() =
-  CellU32_v(l, ?v) &*& CellU32_own(t, v);
+  CellU32_v(l, ?v) &*& struct_CellU32_padding(l) &*& CellU32_own(t, v);
 
 // `SHR` for Cell<u32>
 pred CellU32_share(k: lifetime_t, t: thread_id_t, l: *CellU32) =

--- a/tests/rust/safe_abstraction/drop_test.rs
+++ b/tests/rust/safe_abstraction/drop_test.rs
@@ -1,0 +1,83 @@
+pub struct Foo {
+    field1: i32,
+    field2: u8
+}
+
+/*@
+
+pred Foo_own(t: thread_id_t, fields1: i32, field2: u8) = true;
+
+pred Foo_share(k: lifetime_t, t: thread_id_t, l: *Foo) = true;
+
+lem Foo_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Foo)
+    req lifetime_inclusion(k1, k) == true &*& [_]Foo_share(k, t, l);
+    ens [_]Foo_share(k1, t, l);
+{
+    close Foo_share(k1, t, l);
+    leak Foo_share(k1, t, l);
+}
+
+lem Foo_share_full(k: lifetime_t, t: thread_id_t, l: *Foo)
+    req full_borrow(k, Foo_full_borrow_content(t, l)) &*& [?q]lifetime_token(k);
+    ens [_]Foo_share(k, t, l) &*& [q]lifetime_token(k);
+{
+    close Foo_share(k, t, l);
+    leak Foo_share(k, t, l);
+    leak full_borrow(_, _);
+}
+
+@*/
+
+impl Drop for Foo {
+    fn drop<'a>(&'a mut self) {
+        //@ open Foo_full_borrow_content(_t, self)();
+        //@ close i32_full_borrow_content(_t, &(*self).field1)();
+        //@ close u8_full_borrow_content(_t, &(*self).field2)();
+    }
+}
+
+pub struct Bar {
+    fd: *mut u8
+}
+
+/*@
+
+pred Bar_own(t: thread_id_t, fd: *mut u8) = true;
+
+pred Bar_share(k: lifetime_t, t: thread_id_t, l: *Bar) = true;
+
+lem Bar_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Bar)
+    req lifetime_inclusion(k1, k) == true &*& [_]Bar_share(k, t, l);
+    ens [_]Bar_share(k1, t, l);
+{
+    close Bar_share(k1, t, l);
+    leak Bar_share(k1, t, l);
+}
+
+lem Bar_share_full(k: lifetime_t, t: thread_id_t, l: *Bar)
+    req full_borrow(k, Bar_full_borrow_content(t, l)) &*& [?q]lifetime_token(k);
+    ens [_]Bar_share(k, t, l) &*& [q]lifetime_token(k);
+{
+    close Bar_share(k, t, l);
+    leak Bar_share(k, t, l);
+    leak full_borrow(_, _);
+}
+
+@*/
+
+impl Bar {
+    pub fn new() -> Bar {
+        Bar { fd: std::ptr::null_mut() }
+    }
+}
+
+impl Drop for Bar {
+    fn drop<'a>(&'a mut self)
+    //@ req false; //~ should_fail
+    //@ ens true;
+    {
+        unsafe {
+            *self.fd = 42;
+        }
+    }
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -18,4 +18,5 @@ cd safe_abstraction
   verifast -c deque.rs
   verifast -c cell_u32.rs
   verifast -c tree.rs
+  verifast -c -allow_should_fail -allow_dead_code drop_test.rs
 cd ..


### PR DESCRIPTION
TODO: Support implementing Drop for Tree in tree.rs. This requires
drop elaboration for verifying function new_nonempty.
