### PR TITLE
[Rust] Support locals that impl Drop; ManuallyDrop

### DIFF
--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -543,6 +543,7 @@ struct Body {
                     resume @2: Void;
                     return @3: Void;
                     call @4: FnCallData;
+                    drop @5: Void;
                 }
             }
 


### PR DESCRIPTION
Does not actually support implicit drops yet; for now,
only code where implicit drops do not actually happen
is supported.

VeriFast now consumes drop-elaborated MIR, so that
drop terminators are run only on locals whose
content has not been moved out.
