### PR TITLE
[C++] Exporter: do not use concepts if unsupported

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,6 @@ jobs:
   build_ubuntu:
     runs-on: ubuntu-20.04
     permissions: {}
-    env:
-      CC: gcc-10
-      CXX: g++-10
 
     steps:
       - uses: actions/checkout@v3

--- a/src/cxx_frontend/ast_exporter/AstSerializer.h
+++ b/src/cxx_frontend/ast_exporter/AstSerializer.h
@@ -1,10 +1,10 @@
 #pragma once
 #include "Annotation.h"
+#include "Concept.h"
 #include "Inclusion.h"
 #include "NodeSerializer.h"
 #include "capnp/orphan.h"
 #include "llvm/ADT/SmallVector.h"
-#include <concepts>
 #include <kj/common.h>
 #include <string.h>
 #include <unordered_map>

--- a/src/cxx_frontend/ast_exporter/Concept.h
+++ b/src/cxx_frontend/ast_exporter/Concept.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#if __cpp_concepts >= 201907
+#include "stubs_ast.capnp.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/TypeLoc.h"
+#include <concepts>
+
+template <typename T, typename... U>
+concept IsAnyOf = (std::same_as<T, U> || ...);
+
+template <typename T>
+concept IsStubsNode =
+    IsAnyOf<T, stubs::Decl, stubs::Stmt, stubs::Expr, stubs::Type>;
+
+template <typename T>
+concept IsAstNode = IsAnyOf<T, clang::Decl, clang::Stmt, clang::Expr,
+                            clang::Type, clang::TypeLoc>;
+
+template <typename T>
+concept IsWhileAstNode = IsAnyOf<T, clang::WhileStmt, clang::DoStmt>;
+
+#else
+#define IsAnyOf typename
+#define IsStubsNode typename
+#define IsAstNode typename
+#define IsWhileAstNode typename
+#endif

--- a/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
@@ -329,13 +329,15 @@ bool ExprSerializer::VisitCXXDefaultInitExpr(
   return true;
 }
 
-bool ExprSerializer::VisitExprWithCleanups(const clang::ExprWithCleanups *expr) {
+bool ExprSerializer::VisitExprWithCleanups(
+    const clang::ExprWithCleanups *expr) {
   auto cleanups = m_builder.initCleanups();
   m_serializer.serializeExpr(cleanups, expr->getSubExpr());
   return true;
 }
 
-bool ExprSerializer::VisitCXXBindTemporaryExpr(const clang::CXXBindTemporaryExpr *expr) {
+bool ExprSerializer::VisitCXXBindTemporaryExpr(
+    const clang::CXXBindTemporaryExpr *expr) {
   auto temp = m_builder.initBindTemporary();
   m_serializer.serializeExpr(temp, expr->getSubExpr());
   return true;

--- a/src/cxx_frontend/ast_exporter/NodeSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeSerializer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Annotation.h"
+#include "Concept.h"
 #include "Util.h"
 #include "clang/AST/DeclVisitor.h"
 #include "clang/AST/Stmt.h"
@@ -8,23 +9,8 @@
 #include "clang/AST/TypeVisitor.h"
 #include "clang/Lex/Preprocessor.h"
 #include <cassert>
-#include <concepts>
 
 namespace vf {
-
-template <typename T, typename... U>
-concept IsAnyOf = (std::same_as<T, U> || ...);
-
-template <typename T>
-concept IsStubsNode =
-    IsAnyOf<T, stubs::Decl, stubs::Stmt, stubs::Expr, stubs::Type>;
-
-template <typename T>
-concept IsAstNode = IsAnyOf<T, clang::Decl, clang::Stmt, clang::Expr,
-                            clang::Type, clang::TypeLoc>;
-
-template <typename T>
-concept isWhileAstNode = IsAnyOf<T, clang::WhileStmt, clang::DoStmt>;
 
 class AstSerializer;
 
@@ -152,7 +138,7 @@ struct StmtSerializer : public NodeSerializer<stubs::Stmt, clang::Stmt>,
   bool VisitDefaultStmt(const clang::DefaultStmt *stmt);
 
 private:
-  template <isWhileAstNode While>
+  template <IsWhileAstNode While>
   bool serializeWhileStmt(stubs::Stmt::While::Builder builder,
                           const While *stmt);
 };

--- a/src/cxx_frontend/ast_exporter/StmtSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/StmtSerializer.cpp
@@ -83,7 +83,7 @@ bool StmtSerializer::VisitNullStmt(const clang::NullStmt *stmt) {
   return true;
 }
 
-template <isWhileAstNode While>
+template <IsWhileAstNode While>
 bool StmtSerializer::serializeWhileStmt(stubs::Stmt::While::Builder builder,
                                         const While *stmt) {
 


### PR DESCRIPTION
Concepts require g++ >= 10, which is not available by default on Ubuntu 20.04