### PR TITLE
T_own takes a T value, even if T is a struct

### DIFF
--- a/src/rust_frontend/vf_mir_translator/rustbelt.ml
+++ b/src/rust_frontend/vf_mir_translator/rustbelt.ml
@@ -8,7 +8,7 @@ type vid = string (* value id *)
 
 type ty_interp = {
   size : expr;
-  own : tid -> v list -> (asn, string) result;
+  own : tid -> v -> (asn, string) result;
   shr : lft -> tid -> l -> (asn, string) result;
   full_bor_content : (string, string) result;
   points_to : tid -> l -> vid option -> (asn, string) result;

--- a/tests/rust/safe_abstraction/cell_u32.rs
+++ b/tests/rust/safe_abstraction/cell_u32.rs
@@ -7,7 +7,7 @@ pub struct CellU32 {
 // Interpretation
 // `OWN` for Cell<u32>
 // [[cell(tau)]].OWN(t, vs) = [[tau]].OWN(t, vs)
-pred CellU32_own(t: thread_id_t, v: u32;) = true; // The `v` parameter type carries the info
+pred CellU32_own(t: thread_id_t, v: CellU32;) = true; // The `v` parameter type carries the info
 
 /* A note on `|= cell(tau) copy` judgement:
 In RustBelt `|= tau copy => |= cell(tau) copy` but it is not the case in Rust as it is prohibited
@@ -19,7 +19,7 @@ i.e. in VeriFast the `[[u32]].OWN` is implicitly persistent.
 */
 
 pred_ctor CellU32_nonatomic_borrow_content(l: *CellU32, t: thread_id_t)(;) =
-  CellU32_v(l, ?v) &*& struct_CellU32_padding(l) &*& CellU32_own(t, v);
+  CellU32_v(l, ?v) &*& struct_CellU32_padding(l) &*& CellU32_own(t, CellU32 { v });
 
 // `SHR` for Cell<u32>
 pred CellU32_share(k: lifetime_t, t: thread_id_t, l: *CellU32) =
@@ -63,7 +63,7 @@ impl CellU32 {
         let c = CellU32 {
             v: std::cell::UnsafeCell::new(u),
         };
-        //@ close CellU32_own(_t, u);
+        //@ close CellU32_own(_t, CellU32 { v: u });
         c
     }
 

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -76,14 +76,14 @@ pred Deque_(sentinel: *Node; elems: list<i32> ) =
     (*sentinel).next |-> ?first &*&
     Nodes(first, sentinel, last, sentinel, elems);
 
-pred Deque_own(t: thread_id_t, sentinel: *Node; size: i32) =
-    Deque_(sentinel, ?elems) &*& size == length(elems);
+pred Deque_own(t: thread_id_t, deque: Deque;) =
+    Deque_(deque.sentinel, ?elems) &*& deque.size == length(elems);
 
 pred Deque(deque: *Deque; elems: list<i32>) =
     (*deque).sentinel |-> ?sentinel &*& (*deque).size |-> ?size &*& Deque_(sentinel, elems) &*& size == length(elems);
 
 pred_ctor Deque_frac_borrow_content(t: thread_id_t, l: *Deque)(;) =
-    (*l).sentinel |-> ?sentinel &*& (*l).size |-> ?size &*& Deque_own(t, sentinel, size) &*& struct_Deque_padding(l);
+    (*l).sentinel |-> ?sentinel &*& (*l).size |-> ?size &*& Deque_own(t, Deque { sentinel, size }) &*& struct_Deque_padding(l);
 pred Deque_share(k: lifetime_t, t: thread_id_t, l: *Deque) = [_]frac_borrow(k, Deque_frac_borrow_content(t, l));
 
 // Proof obligations
@@ -126,7 +126,7 @@ impl Deque {
             //@ close_struct(sentinel);
             (*sentinel).prev = sentinel;
             (*sentinel).next = sentinel;
-            //@ close Deque_own(_t, sentinel, 0);
+            //@ close Deque_own(_t, Deque { sentinel, size: 0 });
             Deque { sentinel, size: 0 }
         }
     }

--- a/tests/rust/safe_abstraction/drop_test.rs
+++ b/tests/rust/safe_abstraction/drop_test.rs
@@ -5,7 +5,7 @@ pub struct Foo {
 
 /*@
 
-pred Foo_own(t: thread_id_t, fields1: i32, field2: u8) = true;
+pred Foo_own(t: thread_id_t, v: Foo) = true;
 
 pred Foo_share(k: lifetime_t, t: thread_id_t, l: *Foo) = true;
 
@@ -42,7 +42,7 @@ pub struct Bar {
 
 /*@
 
-pred Bar_own(t: thread_id_t, fd: *mut u8) = true;
+pred Bar_own(t: thread_id_t, v: Bar) = true;
 
 pred Bar_share(k: lifetime_t, t: thread_id_t, l: *Bar) = true;
 

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -156,7 +156,7 @@ pub struct Tree {
 
 /*@
 
-pred Tree_own(t: thread_id_t, root: *mut Node;) = Tree(root, 0, ?shape);
+pred Tree_own(t: thread_id_t, v: Tree;) = Tree(v.root, 0, ?shape);
 
 pred Tree_share(k: lifetime_t, t: thread_id_t, l: *Tree) = true;
 
@@ -226,9 +226,9 @@ impl Tree {
         unsafe {
             //@ open_full_borrow(_q_a/2, a, Tree_full_borrow_content(_t, self));
             //@ open Tree_full_borrow_content(_t, self)();
-            //@ open Tree_own(_t, (*self).root);
+            //@ open Tree_own(_t, Tree { root: (*self).root });
             Self::accept0::<V>(self.root, true, visitor);
-            //@ close Tree_own(_t, (*self).root);
+            //@ close Tree_own(_t, Tree { root: (*self).root });
             //@ close Tree_full_borrow_content(_t, self)();
             //@ close_full_borrow(Tree_full_borrow_content(_t, self));
             //@ leak full_borrow(_, _) &*& full_borrow(_, _);


### PR DESCRIPTION
Also implemented struct expressions in the Rust annotation parser.
Horrible hack: if an identifier I is followed by a left brace,
this is parsed as a struct expression if and only if I starts with
an uppercase letter. (I don't know how the official Rust parser
parses this; I suspect it first resolves I to see whether it refers
to a struct!)

To have I be parsed as a variable name, enclose it in parentheses: (I).
