### PR TITLE
vf-mir-exporter: Export struct generics info

### DIFF
--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -231,6 +231,7 @@ struct Ty {
         span @3: SpanData;
         vis @4: Visibility;
         isLocal @5: Bool;
+        hirGenerics @6: Hir.Generics;
     }
 
     struct AdtTy {

--- a/tests/rust/purely_unsafe/generic_structs.rs
+++ b/tests/rust/purely_unsafe/generic_structs.rs
@@ -1,0 +1,16 @@
+struct Pair<A, B> {
+    fst: A,
+    snd: B
+}
+
+unsafe fn swap_Pair_i32_bool(p1: *mut Pair<i32, bool>, p2: *mut Pair<i32, bool>)
+//@ req (*p1).fst |-> ?fst1 &*& (*p1).snd |-> ?snd1 &*& (*p2).fst |-> ?fst2 &*& (*p2).snd |-> ?snd2;
+//@ ens (*p1).fst |-> fst2 &*& (*p1).snd |-> snd2 &*& (*p2).fst |-> fst1 &*& (*p2).snd |-> snd1;
+{
+    let tmp1 = (*p1).fst;
+    let tmp2 = (*p1).snd;
+    (*p1).fst = (*p2).fst;
+    (*p1).snd = (*p2).snd;
+    (*p2).fst = tmp1;
+    (*p2).snd = tmp2;
+}


### PR DESCRIPTION
TODO: Add support for generic structs in the MIR translator.
But I plan to first implement generic predicate constructors.
