### PR TITLE
Refactoring: Eliminate redundant PureCtor scope

### DIFF
--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -188,7 +188,6 @@ let sexpr_of_func_kind kind =
 let sexpr_of_ident_scope (scope : ident_scope) : sexpression =
   match scope with
     | LocalVar           -> Symbol "local"
-    | PureCtor           -> Symbol "pure-constructor"
     | FuncName           -> Symbol "function"
     | PredFamName        -> Symbol "predicate-family"
     | EnumElemName n     -> Symbol "enumeration-member"

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -1338,7 +1338,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               flatmap 
                 (fun (WSwitchAsnClause (l, casename, args, boxinginfo, asn)) ->
                   if (List.length args) = 0 then
-                    let cond = WOperation (l, Eq, [e; WVar (l, casename, PureCtor)], AnyType) in
+                    let cond = WOperation (l, Eq, [e; WVar (l, casename, PureFuncName)], AnyType) in
                     iter (cond :: conds) asn cont
                   else 
                    []

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -239,7 +239,6 @@ class predref (name: string) (domain: type_ list) (inputParamCount: int option) 
 type
   ident_scope = (* ?ident_scope *)
     LocalVar
-  | PureCtor
   | FuncName
   | PredFamName
   | EnumElemName of big_int

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -78,7 +78,6 @@ let of_predref p =
 
 let of_ident_scope = function
   LocalVar -> c "LocalVar"
-| PureCtor -> c "PureCtor"
 | FuncName -> c "FuncName"
 | PredFamName -> c "PredFamName"
 | EnumElemName n -> C ("EnumElemName", [BigInt n])

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -3974,11 +3974,11 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         begin
           let targs = List.map (fun _ -> InferredType (object end, ref Unconstrained)) tparams in
           let Some tpenv = zip tparams targs in
-          (WVar (l, x, PureCtor), instantiate_type tpenv t, None)
+          (WVar (l, x, PureFuncName), instantiate_type tpenv t, None)
         end
         else
         begin
-          (WVar (l, x, PureCtor), t, None)
+          (WVar (l, x, PureFuncName), t, None)
         end
       | _ ->
       match try_assoc x all_funcnameterms with
@@ -7328,7 +7328,6 @@ let check_if_list_is_defined () =
       begin
         match scope with
           LocalVar -> (try List.assoc x env with Not_found -> assert_false [] env l (Printf.sprintf "Unbound variable '%s'" x) None)
-        | PureCtor -> let Some (lg, tparams, t, [], s) = try_assoc x purefuncmap in mk_app s []
         | FuncName -> List.assoc x all_funcnameterms
         | PredFamName -> let Some (_, _, _, _, symb, _, _) = try_assoc x predfammap in symb
         | EnumElemName n -> ctxt#mk_intlit_of_string (string_of_big_int n)


### PR DESCRIPTION
It is subsumed by PureFuncName (which was added later).
