### PR TITLE
[Rust] Generic purely unsafe deque.rs

### DIFF
--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -180,8 +180,8 @@ lemma_auto(has_type((void *)ptr_add_(p, offset, elemTypeid), elemTypeid)) void h
     requires true;
     ensures has_type((void *)ptr_add_(p, offset, elemTypeid), elemTypeid) == has_type((void *)p, elemTypeid);
 
-predicate generic_points_to<t>(t *p; t v);
 predicate generic_points_to_<t>(t *p; option<t> v);
+predicate generic_points_to<t>(t *p; t v) = generic_points_to_(p, some(v));
 
 predicate integer__(void *p, int size, bool signed_; option<int> v);
 predicate integer_(void *p, int size, bool signed_; int v) = integer__(p, size, signed_, some(v));

--- a/bin/prelude_rust_core.gh
+++ b/bin/prelude_rust_core.gh
@@ -171,7 +171,8 @@ lemma_auto(has_type((void *)ptr_add_(p, offset, elemTypeid), elemTypeid)) void h
     requires true;
     ensures has_type((void *)ptr_add_(p, offset, elemTypeid), elemTypeid) == has_type((void *)p, elemTypeid);
 
-predicate generic_points_to<t>(t *p; t v);
+predicate generic_points_to_<t>(t *p; option<t> v);
+predicate generic_points_to<t>(t *p; t v) = generic_points_to_<t>(p, some(v));
 
 predicate integer__(void *p, int size, bool signed_; option<int> v);
 predicate integer_(void *p, int size, bool signed_; int v) = integer__(p, size, signed_, some(v));

--- a/src/frontend/verifast0.ml
+++ b/src/frontend/verifast0.ml
@@ -55,6 +55,9 @@ let get_callers (ctxts: 'termnode context list): loc option list =
 
 let get_root_caller ctxts = match List.rev (get_callers ctxts) with Some l::_ -> Some l | _ -> None
 
+let tparam_is_uppercase tparam =
+  String.length tparam > 0 && match tparam.[0] with 'A'..'Z' -> true | _ -> false
+
 let rec string_of_type t =
   match t with
     Bool -> "bool"

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -581,6 +581,7 @@ struct Body {
     varDebugInfo @8: List(VarDebugInfo);
     ghostStmts @9: List(Annotation);
     unsafety @10: Unsafety;
+    implBlockHirGenerics @14: Option(Hir.Generics);
     hirGenerics @11: Hir.Generics;
     isTraitFn @12: Bool;
     isDropFn @13: Bool; # Implements std::ops::Drop::drop

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -641,7 +641,10 @@ mod vf_mir_builder {
                 let it = req_adt_defs.into_iter();
                 req_adt_defs = Vec::new();
                 for adt_def in it {
-                    if adt_def.is_unsafe_cell() || adt_def.is_manually_drop() || !adt_def.did().is_local(){
+                    if adt_def.is_unsafe_cell()
+                        || adt_def.is_manually_drop()
+                        || !adt_def.did().is_local()
+                    {
                         continue;
                     }
                     match encoded_adt_defs
@@ -800,6 +803,13 @@ mod vf_mir_builder {
                 tcx.fn_sig(def_id).skip_binder().unsafety(),
                 body_cpn.reborrow().init_unsafety(),
             );
+
+            if let Some(impl_did) = tcx.impl_of_method(def_id) {
+                let impl_hir_gens = tcx.hir().get_generics(impl_did.expect_local()).unwrap();
+                let impl_generics_cpn = body_cpn.reborrow().init_impl_block_hir_generics();
+                let impl_generics_some_cpn = impl_generics_cpn.init_something();
+                Self::encode_hir_generics(enc_ctx, impl_hir_gens, impl_generics_some_cpn);
+            }
 
             let hir_gens_cpn = body_cpn.reborrow().init_hir_generics();
             let hir_gens = tcx

--- a/tests/rust/purely_unsafe/deque_i32.rs
+++ b/tests/rust/purely_unsafe/deque_i32.rs
@@ -4,19 +4,19 @@ unsafe fn assert(b: bool)
 {
 }
 
-struct Node<T> {
-    prev: *mut Node<T>,
-    value: T,
-    next: *mut Node<T>,
+struct Node {
+    prev: *mut Node,
+    value: i32,
+    next: *mut Node,
 }
 
 /*@
 
-pred Nodes<T>(n: *Node<T>, prev: *Node<T>, last: *Node<T>, next: *Node<T>; elems: list<T>) =
+pred Nodes(n: *Node, prev: *Node, last: *Node, next: *Node; elems: list<i32>) =
     if n == next {
         elems == [] &*& last == prev
     } else {
-        alloc_block(n, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(n) &*&
+        alloc_block(n, std::mem::size_of::<Node>()) &*& struct_Node_padding(n) &*&
         (*n).prev |-> prev &*&
         (*n).value |-> ?value &*&
         (*n).next |-> ?next0 &*&
@@ -24,11 +24,11 @@ pred Nodes<T>(n: *Node<T>, prev: *Node<T>, last: *Node<T>, next: *Node<T>; elems
         elems == cons(value, elems0)
     };
 
-lem Nodes_split_last<T>(n: *Node<T>)
+lem Nodes_split_last(n: *Node)
     req Nodes(n, ?prev, ?last, ?next, ?elems) &*& 1 <= length(elems);
     ens
         Nodes(n, prev, ?last1, last, take(length(elems) - 1, elems)) &*&
-        alloc_block(last, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(last) &*&
+        alloc_block(last, std::mem::size_of::<Node>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> nth(length(elems) - 1, elems) &*&
         (*last).next |-> next;
@@ -45,10 +45,10 @@ lem Nodes_split_last<T>(n: *Node<T>)
     }
 }
 
-lem Nodes_join_last<T>(n: *Node<T>)
+lem Nodes_join_last(n: *Node)
     req
         Nodes(n, ?prev, ?last1, ?last, ?elems1) &*&
-        alloc_block(last, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(last) &*&
+        alloc_block(last, std::mem::size_of::<Node>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> ?value &*&
         (*last).next |-> ?next &*& (*next).next |-> ?nextNext;
@@ -64,17 +64,17 @@ lem Nodes_join_last<T>(n: *Node<T>)
 
 @*/
 
-struct Deque<T> {
-    sentinel: *mut Node<T>,
+struct Deque {
+    sentinel: *mut Node,
     size: i32,
 }
 
 /*@
 
-pred Deque<T>(deque: *Deque<T>; elems: list<T>) =
-    alloc_block(deque, std::mem::size_of::<Deque<T>>()) &*& struct_Deque_padding(deque) &*&
+pred Deque(deque: *Deque; elems: list<i32>) =
+    alloc_block(deque, std::mem::size_of::<Deque>()) &*& struct_Deque_padding(deque) &*&
     (*deque).sentinel |-> ?sentinel &*&
-    alloc_block(sentinel, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(sentinel) &*&
+    alloc_block(sentinel, std::mem::size_of::<Node>()) &*& struct_Node_padding(sentinel) &*&
     (*sentinel).prev |-> ?last &*&
     (*sentinel).value |-> _ &*&
     (*sentinel).next |-> ?first &*&
@@ -83,19 +83,19 @@ pred Deque<T>(deque: *Deque<T>; elems: list<T>) =
 
 @*/
 
-impl<T> Deque<T> {
-    unsafe fn new() -> *mut Deque<T>
+impl Deque {
+    unsafe fn new() -> *mut Deque
     //@ req true;
     //@ ens Deque(result, []);
     {
-        let deque = std::alloc::alloc(std::alloc::Layout::new::<Deque<T>>()) as *mut Deque<T>;
+        let deque = std::alloc::alloc(std::alloc::Layout::new::<Deque>()) as *mut Deque;
         if deque.is_null() {
-            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Deque<T>>());
+            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Deque>());
         }
         //@ close_struct(deque);
-        let sentinel = std::alloc::alloc(std::alloc::Layout::new::<Node<T>>()) as *mut Node<T>;
+        let sentinel = std::alloc::alloc(std::alloc::Layout::new::<Node>()) as *mut Node;
         if sentinel.is_null() {
-            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Node<T>>());
+            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Node>());
         }
         //@ close_struct(sentinel);
         (*sentinel).prev = sentinel;
@@ -105,25 +105,24 @@ impl<T> Deque<T> {
         return deque;
     }
 
-    unsafe fn get_size(deque: *mut Deque<T>) -> i32
+    unsafe fn get_size(deque: *mut Deque) -> i32
     //@ req Deque(deque, ?elems);
     //@ ens Deque(deque, elems) &*& result == length(elems);
     {
         return (*deque).size;
     }
 
-    unsafe fn push_front(deque: *mut Deque<T>, value: T)
+    unsafe fn push_front(deque: *mut Deque, value: i32)
     //@ req Deque(deque, ?elems) &*& length(elems) < 0x7fffffff;
     //@ ens Deque(deque, cons(value, elems));
     {
-        let new_node = std::alloc::alloc(std::alloc::Layout::new::<Node<T>>()) as *mut Node<T>;
+        let new_node = std::alloc::alloc(std::alloc::Layout::new::<Node>()) as *mut Node;
         if new_node.is_null() {
-            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Node<T>>());
+            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Node>());
         }
         //@ close_struct(new_node);
         (*new_node).prev = (*deque).sentinel;
-        std::ptr::write(std::ptr::addr_of_mut!((*new_node).value), value);
-        //@ close Node_value(new_node, _);
+        (*new_node).value = value;
         //@ let sentinel = (*deque).sentinel;
         //@ let first = (*sentinel).next;
         (*new_node).next = (*(*deque).sentinel).next;
@@ -133,19 +132,18 @@ impl<T> Deque<T> {
         (*deque).size += 1;
     }
 
-    unsafe fn push_back(deque: *mut Deque<T>, value: T)
+    unsafe fn push_back(deque: *mut Deque, value: i32)
     //@ req Deque(deque, ?elems) &*& length(elems) < 0x7fffffff;
     //@ ens Deque(deque, append(elems, [value]));
     {
-        let new_node = std::alloc::alloc(std::alloc::Layout::new::<Node<T>>()) as *mut Node<T>;
+        let new_node = std::alloc::alloc(std::alloc::Layout::new::<Node>()) as *mut Node;
         if new_node.is_null() {
-            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Node<T>>());
+            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Node>());
         }
         //@ close_struct(new_node);
         //@ let sentinel = (*deque).sentinel;
         (*new_node).prev = (*(*deque).sentinel).prev;
-        std::ptr::write(std::ptr::addr_of_mut!((*new_node).value), value);
-        //@ close Node_value(new_node, _);
+        (*new_node).value = value;
         (*new_node).next = (*deque).sentinel;
         /*@
         if length(elems) > 0 {
@@ -169,25 +167,23 @@ impl<T> Deque<T> {
         //@ Nodes_join_last((*sentinel).next);
     }
 
-    unsafe fn pop_front(deque: *mut Deque<T>) -> T
+    unsafe fn pop_front(deque: *mut Deque) -> i32
     //@ req Deque(deque, cons(?elem, ?elems));
     //@ ens Deque(deque, elems) &*& result == elem;
     {
         let node = (*(*deque).sentinel).next;
         //@ open Nodes(_, _, _, _, _);
-        //@ open Node_value(node, _);
-        let result = std::ptr::read(std::ptr::addr_of!((*node).value));
-        //@ close Node_value(node, _);
+        let result = (*node).value;
         (*(*node).prev).next = (*node).next;
         //@ open Nodes(_, _, _, _, _);
         (*(*node).next).prev = (*node).prev;
         //@ open_struct(node);
-        std::alloc::dealloc(node as *mut u8, std::alloc::Layout::new::<Node<T>>());
+        std::alloc::dealloc(node as *mut u8, std::alloc::Layout::new::<Node>());
         (*deque).size -= 1;
         return result;
     }
 
-    unsafe fn pop_back(deque: *mut Deque<T>) -> T
+    unsafe fn pop_back(deque: *mut Deque) -> i32
     //@ req Deque(deque, ?elems) &*& 1 <= length(elems);
     //@ ens Deque(deque, take(length(elems) - 1, elems)) &*& result == nth(length(elems) - 1, elems);
     {
@@ -195,9 +191,7 @@ impl<T> Deque<T> {
         //@ let first = (*sentinel).next;
         //@ Nodes_split_last(first);
         let node = (*(*deque).sentinel).prev;
-        //@ open Node_value(node, _);
-        let result = std::ptr::read(std::ptr::addr_of!((*node).value));
-        //@ close Node_value(node, _);
+        let result = (*node).value;
         /*@
         if 2 <= length(elems) {
             Nodes_split_last(first);
@@ -210,7 +204,7 @@ impl<T> Deque<T> {
         (*(*node).prev).next = (*node).next;
         (*(*node).next).prev = (*node).prev;
         //@ open_struct(node);
-        std::alloc::dealloc(node as *mut u8, std::alloc::Layout::new::<Node<T>>());
+        std::alloc::dealloc(node as *mut u8, std::alloc::Layout::new::<Node>());
         (*deque).size -= 1;
         /*@
         if 2 <= length(elems) {
@@ -220,21 +214,21 @@ impl<T> Deque<T> {
         return result;
     }
 
-    unsafe fn dispose(deque: *mut Deque<T>)
+    unsafe fn dispose(deque: *mut Deque)
     //@ req Deque(deque, []);
     //@ ens true;
     {
-        //@ open_struct((*deque).sentinel);
+        //@ open_struct((*deque ) . sentinel);
         std::alloc::dealloc(
             (*deque).sentinel as *mut u8,
-            std::alloc::Layout::new::<Node<T>>(),
+            std::alloc::Layout::new::<Node>(),
         );
         //@ open_struct(deque);
-        std::alloc::dealloc(deque as *mut u8, std::alloc::Layout::new::<Deque<T>>());
+        std::alloc::dealloc(deque as *mut u8, std::alloc::Layout::new::<Deque>());
         //@ open Nodes(_, _, _, _, _);
     }
 
-    unsafe fn swap(d: *mut Deque<T>, d1: *mut Deque<T>)
+    unsafe fn swap(d: *mut Deque, d1: *mut Deque)
     //@ req Deque(d, ?elems) &*& Deque(d1, ?elems1);
     //@ ens Deque(d, elems1) &*& Deque(d1, elems);
     {
@@ -249,16 +243,16 @@ impl<T> Deque<T> {
 
 fn main() {
     unsafe {
-        let deque = Deque::<i32>::new();
-        Deque::<i32>::push_back(deque, 10);
-        Deque::<i32>::push_front(deque, -10);
-        Deque::<i32>::push_back(deque, 20);
-        Deque::<i32>::push_front(deque, -20);
-        assert(Deque::<i32>::get_size(deque) == 4);
-        assert(Deque::<i32>::pop_back(deque) == 20);
-        assert(Deque::<i32>::pop_back(deque) == 10);
-        assert(Deque::<i32>::pop_front(deque) == -20);
-        assert(Deque::<i32>::pop_front(deque) == -10);
-        Deque::<i32>::dispose(deque);
+        let deque = Deque::new();
+        Deque::push_back(deque, 10);
+        Deque::push_front(deque, -10);
+        Deque::push_back(deque, 20);
+        Deque::push_front(deque, -20);
+        assert(Deque::get_size(deque) == 4);
+        assert(Deque::pop_back(deque) == 20);
+        assert(Deque::pop_back(deque) == 10);
+        assert(Deque::pop_front(deque) == -20);
+        assert(Deque::pop_front(deque) == -10);
+        Deque::dispose(deque);
     }
 }

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -6,6 +6,7 @@ cd purely_unsafe
   verifast -c alloc.rs
   verifast -c reverse.rs
   verifast -c account.rs
+  verifast -c deque_i32.rs
   verifast -c deque.rs
   verifast -c strlen.rs
   verifast -c tree.rs


### PR DESCRIPTION
Includes the following minor improvements:
- Uninitialized generic points-to chunks
- Chunk consumption is logged at -verbose N with N >= 4
- [Rust] Generic impls
- [Rust] Parser parses `Foo<Bar<T>>` as `Foo< Bar<T> >`
- [Rust] Generic pred/lem declarations
- [Rust] ptr::read/write()
- [Rust] Real type parameters must be uppercase and carry a typeid
- Inference of type parameters under pointers and in struct type args
- Typeid env is available in more consumption contexts
