### PR TITLE
[Rust] T_own for tparams; open/close_fbc::<T>

### DIFF
--- a/bin/rust/rust_belt/general.h
+++ b/bin/rust/rust_belt/general.h
@@ -4,6 +4,25 @@
 #include "stdint.h"
 //@ #include "lifetime_logic.gh"
 /*@
+
+predicate bool_own(thread_id_t t, bool v;) = true;
+predicate char_own(thread_id_t t, uint32_t v;) = 0 <= v && v <= 0xD7FF || 0xE000 <= v && v <= 0x10FFFF;
+predicate raw_ptr_own(thread_id_t t, void *v;) = true;
+
+predicate i8_own(thread_id_t t, int8_t v;) = true;
+predicate i16_own(thread_id_t t, int16_t v;) = true;
+predicate i32_own(thread_id_t t, int32_t v;) = true;
+predicate i64_own(thread_id_t t, int64_t v;) = true;
+predicate i128_own(thread_id_t t, int128_t v;) = true;
+predicate isize_own(thread_id_t t, intptr_t v;) = true;
+
+predicate u8_own(thread_id_t t, uint8_t v;) = true;
+predicate u16_own(thread_id_t t, uint16_t v;) = true;
+predicate u32_own(thread_id_t t, uint32_t v;) = true;
+predicate u64_own(thread_id_t t, uint64_t v;) = true;
+predicate u128_own(thread_id_t t, uint128_t v;) = true;
+predicate usize_own(thread_id_t t, uintptr_t v;) = true;
+
 predicate_ctor bool_full_borrow_content(thread_id_t t, bool *l)() = *l |-> ?_;
 predicate_ctor char_full_borrow_content(thread_id_t t, uint32_t *l)() = *l |-> ?c &*& ((c >= 0 && c <= 0xD7FF) || (c >= 0xE000 && c <= 0x10FFFF));
 predicate_ctor raw_ptr_full_borrow_content(thread_id_t t, void **l)() = *l |-> ?_;

--- a/src/rust_frontend/vf_mir_translator/rustbelt.ml
+++ b/src/rust_frontend/vf_mir_translator/rustbelt.ml
@@ -9,6 +9,7 @@ type vid = string (* value id *)
 type ty_interp = {
   size : expr;
   own : tid -> v list -> (asn, string) result;
+  own_predname : (string, string) result;
   shr : lft -> tid -> l -> (asn, string) result;
   full_bor_content : (string, string) result;
   points_to : tid -> l -> vid option -> (asn, string) result;
@@ -18,6 +19,7 @@ let emp_ty_interp loc =
   {
     size = True loc;
     own = (fun _ _ -> Ok (True loc));
+    own_predname = Error "Not yet supported";
     shr = (fun _ _ _ -> Ok (True loc));
     full_bor_content = Error "Not yet supported";
     points_to = (fun _ _ _ -> Ok (True loc));

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -652,6 +652,34 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           Chunk ((chars__pred_symb (), true), [], real_unit, [pointerTerm; size; cs], None)
       in
       cont (chunk::h) env
+    | ExprStmt (CallExpr (l, ("open_full_borrow_content"|"close_full_borrow_content" as g), targs, indices, args, Static)) when dialect = Some Rust ->
+      let x, thread_id, ptr =
+        match targs, indices, args with
+          [IdentTypeExpr (_, None, x)], [], [LitPat thread_id; LitPat ptr] when List.mem x tparams && tparam_carries_typeid x ->
+          x, thread_id, ptr
+        | _ ->
+          static_error l (Printf.sprintf "Syntax error: %s<T>(t, l) expected" g) None
+      in
+      let thread_id = check_expr_t (pn,ilist) tparams tenv thread_id (AbstractType "thread_id_t") in
+      let ptr = check_expr_t (pn,ilist) tparams tenv ptr voidPtrType in
+      let thread_id = ev thread_id in
+      let ptr = ev ptr in
+      let x_full_borrow_content = List.assoc (x ^ "_full_borrow_content") env in
+      let x_own = List.assoc (x ^ "_own") env in
+      let fbc_term = ctxt#mk_app apply_symbol [ctxt#mk_app apply_symbol [x_full_borrow_content; thread_id]; ptr] in
+      begin match g with
+        "open_full_borrow_content" ->
+        consume_chunk rules h [] [] [] l (fbc_term, false) [] real_unit real_unit_pat None [] $. fun _ h _ _ _ _ _ _ ->
+        let value = get_unique_var_symb_non_ghost (x ^ "_value") (GhostTypeParam x) in
+        let points_to_chunk = Chunk ((generic_points_to_symb (), true), [GhostTypeParam x], real_unit, [ptr; value], None) in
+        let own_chunk = Chunk ((x_own, false), [], real_unit, [thread_id; value], None) in
+        cont (points_to_chunk::own_chunk::h) env
+      | "close_full_borrow_content" ->
+        consume_chunk rules h [] [] [] l (generic_points_to_symb (), true) [GhostTypeParam x] real_unit real_unit_pat (Some 1) [TermPat ptr; SrcPat DummyPat] $. fun _ h _ [_; value] _ _ _ _ ->
+        consume_chunk rules h [] [] [] l (x_own, false) [] real_unit real_unit_pat None [TermPat thread_id; TermPat value] $. fun _ h _ _ _ _ _ _ ->
+        let fbc_chunk = Chunk ((fbc_term, false), [], real_unit, [], None) in
+        cont (fbc_chunk::h) env
+      end
     | ExprStmt (CallExpr (l, "free", [], [], args,Static) as e) ->
       let args = List.map (function LitPat e -> e | _ -> static_error l "No patterns allowed here" None ) args in
       begin

--- a/tests/rust/safe_abstraction/tparam_own.rs
+++ b/tests/rust/safe_abstraction/tparam_own.rs
@@ -1,0 +1,30 @@
+fn replace<'a, T>(r: &'a mut T, v: T) -> T {
+    unsafe {
+        //@ open_full_borrow(_q_a, a, T_full_borrow_content(_t, r));
+        //@ open_full_borrow_content::<T>(_t, r);
+        let result = std::ptr::read(r);
+        std::ptr::write(r, v);
+        //@ close_full_borrow_content::<T>(_t, r);
+        //@ close_full_borrow(T_full_borrow_content(_t, r));
+        //@ leak full_borrow(_, _);
+        result
+    }
+}
+
+fn swap<'a, T>(r1: &'a mut T, r2: &'a mut T) {
+    unsafe {
+        //@ open_full_borrow(_q_a/2, a, T_full_borrow_content(_t, r1));
+        //@ open_full_borrow_content::<T>(_t, r1);
+        //@ open_full_borrow(_q_a/2, a, T_full_borrow_content(_t, r2));
+        //@ open_full_borrow_content::<T>(_t, r2);
+        let tmp = std::ptr::read(r1);
+        std::ptr::write(r1, std::ptr::read(r2));
+        std::ptr::write(r2, tmp);
+        //@ close_full_borrow_content::<T>(_t, r2);
+        //@ close_full_borrow(T_full_borrow_content(_t, r2));
+        //@ close_full_borrow_content::<T>(_t, r1);
+        //@ close_full_borrow(T_full_borrow_content(_t, r1));
+        //@ leak full_borrow(_, _);
+        //@ leak full_borrow(_, _);
+    }
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -24,4 +24,5 @@ cd safe_abstraction
   verifast -c cell_u32.rs
   verifast -c tree.rs
   verifast -c -allow_should_fail -allow_dead_code drop_test.rs
+  verifast -c tparam_own.rs
 cd ..


### PR DESCRIPTION
This commit enables expressing ownership of values of type T where
T is a type parameter. This is accomplished by adding a T_own
parameter to each function with a type parameter T. When calling
such a function, the `own` predicate for the type argument is
passed in. Since struct own predicates take each field as a
separate argument, an S_own_ predicate that takes a struct value
is generated automatically for each struct S, expressed in terms
of the user-defined S_own predicate. S_own_ is passed when calling
functions with struct S as a type argument.

This commit also builds ghost commands

    open_full_borrow_content::<T>(t, l)

and

    close_full_borrow_content::<T>(t, l)

into the VeriFast engine. These consume/produce

    T_full_borrow_content(t, l)()

and produce/consume

    generic_points_to<T>(l, ?v) &*& T_own(l, v)

.
