### PR TITLE
[Rust] Pass T_share arg for each generic param T

### DIFF
--- a/bin/rust/rust_belt/general.h
+++ b/bin/rust/rust_belt/general.h
@@ -22,6 +22,10 @@ lemma void close_atomic_space(mask_t spaceMask);
     requires atomic_mask(?currentMask) &*& close_atomic_space_token(spaceMask, ?inv) &*& inv();
     ensures atomic_mask(mask_union(currentMask, spaceMask));
 
+predicate_ctor simple_share(fixpoint(thread_id_t, void *, predicate(;)) frac_borrow_content)(lifetime_t k, thread_id_t t, void *l) =
+    frac_borrow(k, frac_borrow_content(t, l));
+predicate_ctor shared_ref_own(predicate(lifetime_t, thread_id_t, void *) pointee_shr, lifetime_t k)(thread_id_t t, void *l) = [_]pointee_shr(k, t, l);
+
 predicate bool_own(thread_id_t t, bool v;) = true;
 predicate char_own(thread_id_t t, uint32_t v;) = 0 <= v && v <= 0xD7FF || 0xE000 <= v && v <= 0x10FFFF;
 predicate raw_ptr_own(thread_id_t t, void *v;) = true;

--- a/bin/rust/rust_belt/general.h
+++ b/bin/rust/rust_belt/general.h
@@ -61,6 +61,12 @@ predicate_ctor u32_full_borrow_content(thread_id_t t, uint32_t *l)(;) = *l |-> ?
 predicate_ctor u64_full_borrow_content(thread_id_t t, uint64_t *l)(;) = *l |-> ?_;
 predicate_ctor u128_full_borrow_content(thread_id_t t, uint128_t *l)(;) = *l |-> ?_;
 predicate_ctor usize_full_borrow_content(thread_id_t t, uintptr_t *l)(;) = *l |-> ?_;
+
+predicate type_interp<T>(; predicate(thread_id_t, T) T_own, fixpoint(thread_id_t, void *, predicate()) T_full_borrow_content, predicate(lifetime_t, thread_id_t, void *) T_share);
+
+lemma void share_full_borrow<T>(lifetime_t k, thread_id_t t, void *l);
+    requires type_interp<T>(?T_own, ?T_full_borrow_content, ?T_share) &*& full_borrow(k, T_full_borrow_content(t, l)) &*& [?q]lifetime_token(k);
+    ensures type_interp<T>(T_own, T_full_borrow_content, T_share) &*& [_]T_share(k, t, l) &*& [q]lifetime_token(k);
 @*/
 
 #endif

--- a/src/rust_frontend/vf_mir_translator/rustbelt.ml
+++ b/src/rust_frontend/vf_mir_translator/rustbelt.ml
@@ -10,7 +10,8 @@ type ty_interp = {
   size : expr;
   own : tid -> v list -> (asn, string) result;
   own_pred : (Ast.expr, string) result;
-  shr : lft -> tid -> l -> (asn, string) result;
+  shr : lft -> tid -> l -> (asn, string) result; (* Should be duplicable, e.g. a dummy pattern. The caller will not wrap this in a dummy coef asn. *)
+  shr_pred : (Ast.expr, string) result; (* Need not be duplicable; the caller will wrap this in a dummy pattern. *)
   full_bor_content : (Ast.expr, string) result;
   points_to : tid -> l -> vid option -> (asn, string) result;
 }
@@ -20,7 +21,8 @@ let emp_ty_interp loc =
     size = True loc;
     own = (fun _ _ -> Ok (True loc));
     own_pred = Error "Not yet supported";
-    shr = (fun _ _ _ -> Ok (True loc));
+    shr = (fun _ _ _ -> Error "Not yet supported");
+    shr_pred = Error "Not yet supported";
     full_bor_content = Error "Not yet supported";
     points_to = (fun _ _ _ -> Ok (True loc));
   }

--- a/src/rust_frontend/vf_mir_translator/rustbelt.ml
+++ b/src/rust_frontend/vf_mir_translator/rustbelt.ml
@@ -9,9 +9,9 @@ type vid = string (* value id *)
 type ty_interp = {
   size : expr;
   own : tid -> v list -> (asn, string) result;
-  own_predname : (string, string) result;
+  own_pred : (Ast.expr, string) result;
   shr : lft -> tid -> l -> (asn, string) result;
-  full_bor_content : (string, string) result;
+  full_bor_content : (Ast.expr, string) result;
   points_to : tid -> l -> vid option -> (asn, string) result;
 }
 
@@ -19,7 +19,7 @@ let emp_ty_interp loc =
   {
     size = True loc;
     own = (fun _ _ -> Ok (True loc));
-    own_predname = Error "Not yet supported";
+    own_pred = Error "Not yet supported";
     shr = (fun _ _ _ -> Ok (True loc));
     full_bor_content = Error "Not yet supported";
     points_to = (fun _ _ _ -> Ok (True loc));

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -3818,10 +3818,11 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
          they need to be inside appropriate `ModuleDecl`s. `modularize_decl` does this. TODO: Generate the declarations inside the right
          module declarations from the start. This will become necessary once we want to take real `use` items into account inside annotations.*)
       let decls =
-        List.map modularize_decl (traits_decls @ trait_impl_prototypes @ adt_decls @ aux_decls
-        @ adts_full_bor_content_preds @ adts_proof_obligs) @
-        ghost_decls @
-        List.map modularize_decl (body_sigs @ body_decls)
+        List.map modularize_decl
+          (traits_decls @ trait_impl_prototypes @ adt_decls @ aux_decls
+         @ adts_full_bor_content_preds @ adts_proof_obligs)
+        @ ghost_decls
+        @ List.map modularize_decl (body_sigs @ body_decls)
       in
       (* Todo @Nima: we should add necessary inclusions during translation *)
       let extern_header_names =

--- a/tests/rust/safe_abstraction/cell_u32.rs
+++ b/tests/rust/safe_abstraction/cell_u32.rs
@@ -84,7 +84,7 @@ impl CellU32 {
     /* User can also write the contract of safe functions to have it explicit.
     Verifast would check the compatibility of the contract with the function semantic type. */
     fn set<'a>(&'a self, u: u32)
-    //@ req thread_token(?t) &*& [?q]lifetime_token(?a) &*& CellU32_share(a, t, self);
+    //@ req thread_token(?t) &*& [?q]lifetime_token(?a) &*& [_]CellU32_share(a, t, self);
     //@ ens thread_token(t) &*& [q]lifetime_token(a);
     {
         let p = self.v.get();

--- a/tests/rust/safe_abstraction/shared_primitive_types.rs
+++ b/tests/rust/safe_abstraction/shared_primitive_types.rs
@@ -1,0 +1,132 @@
+fn bool_get<'a>(x: &'a bool) -> bool
+{
+    //@ open_frac_borrow(a, bool_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]bool_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]bool_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, bool_full_borrow_content(_t, x));
+    result
+}
+
+fn char_get<'a>(x: &'a char) -> char
+{
+    //@ open_frac_borrow(a, char_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]char_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ open char_own(_t, result);
+    //@ close char_own(_t, result);
+    //@ close char_own(_t, result);
+    //@ close [qc]char_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, char_full_borrow_content(_t, x));
+    result
+}
+
+fn raw_ptr_get<'a>(x: &'a *mut u8) -> *mut u8
+{
+    //@ open_frac_borrow(a, raw_ptr_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]raw_ptr_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]raw_ptr_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, raw_ptr_full_borrow_content(_t, x));
+    result
+}
+
+fn i8_get<'a>(x: &'a i8) -> i8
+{
+    //@ open_frac_borrow(a, i8_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]i8_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]i8_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, i8_full_borrow_content(_t, x));
+    result
+}
+
+fn i16_get<'a>(x: &'a i16) -> i16
+{
+    //@ open_frac_borrow(a, i16_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]i16_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]i16_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, i16_full_borrow_content(_t, x));
+    result
+}
+
+fn i32_get<'a>(x: &'a i32) -> i32
+{
+    //@ open_frac_borrow(a, i32_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]i32_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]i32_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, i32_full_borrow_content(_t, x));
+    result
+}
+
+fn i64_get<'a>(x: &'a i64) -> i64
+{
+    //@ open_frac_borrow(a, i64_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]i64_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]i64_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, i64_full_borrow_content(_t, x));
+    result
+}
+
+fn i128_get<'a>(x: &'a i128) -> i128
+{
+    //@ open_frac_borrow(a, i128_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]i128_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]i128_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, i128_full_borrow_content(_t, x));
+    result
+}
+
+fn u8_get<'a>(x: &'a u8) -> u8
+{
+    //@ open_frac_borrow(a, u8_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]u8_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]u8_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, u8_full_borrow_content(_t, x));
+    result
+}
+
+fn u16_get<'a>(x: &'a u16) -> u16
+{
+    //@ open_frac_borrow(a, u16_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]u16_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]u16_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, u16_full_borrow_content(_t, x));
+    result
+}
+
+fn u32_get<'a>(x: &'a u32) -> u32
+{
+    //@ open_frac_borrow(a, u32_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]u32_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]u32_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, u32_full_borrow_content(_t, x));
+    result
+}
+
+fn u64_get<'a>(x: &'a u64) -> u64
+{
+    //@ open_frac_borrow(a, u64_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]u64_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]u64_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, u64_full_borrow_content(_t, x));
+    result
+}
+
+fn u128_get<'a>(x: &'a u128) -> u128
+{
+    //@ open_frac_borrow(a, u128_full_borrow_content(_t, x), _q_a);
+    //@ open [?qc]u128_full_borrow_content(_t, x)();
+    let result = *x;
+    //@ close [qc]u128_full_borrow_content(_t, x)();
+    //@ close_frac_borrow(qc, u128_full_borrow_content(_t, x));
+    result
+}

--- a/tests/rust/safe_abstraction/tparam_own.rs
+++ b/tests/rust/safe_abstraction/tparam_own.rs
@@ -28,3 +28,10 @@ fn swap<'a, T>(r1: &'a mut T, r2: &'a mut T) {
         //@ leak full_borrow(_, _);
     }
 }
+
+fn share<'a, T>(r: &'a mut T) -> &'a T {
+    //@ produce_type_interp::<T>();
+    //@ share_full_borrow::<T>(a, _t, r);
+    //@ leak type_interp(_, _, _);
+    r
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -30,6 +30,7 @@ cd purely_unsafe
 cd ..
 cd safe_abstraction
   verifast -c full_bor_primitive_types.rs
+  verifast -c shared_primitive_types.rs
   verifast -c deque.rs
   verifast -c cell_u32.rs
   verifast -c tree.rs


### PR DESCRIPTION
- **Reformat vf_mir_translator.ml (addendum to 906236de86ec1ad26da8efa7318bc694d3d5e1f3)**
- **Refactoring: make own_pred and fbc into exprs**
- **[Rust] shr_pred and other shared refs work**
- **[Rust] Pass T_share arg for each generic param T**
