### PR TITLE
Predicate expression assertions

### DIFF
--- a/examples/generic_pred_ctors.c
+++ b/examples/generic_pred_ctors.c
@@ -24,7 +24,7 @@ predicate MutexCell_held<T>(struct MutexCell<T> *mutexCell, predicate(T) T_own, 
 @*/
 
 struct MutexCell<T> *create_MutexCell<T>(T value)
-//@ requires exists<predicate(T)>(?T_own) &*& T_own(value);
+//@ requires exists<predicate(T)>(?T_own) &*& (T_own)(value);
 //@ ensures MutexCell<T>(result, T_own);
 {
     //@ open exists(_);

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -470,6 +470,16 @@ and
       type_ list *
       pat list *
       pat list
+  | PredExprAsn of
+      loc *
+      expr *
+      pat list
+  | WPredExprAsn of
+      loc *
+      expr *
+      type_ list * (* parameter types *)
+      int option * (* inputParamCount *)
+      pat list
   | InstPredAsn of
       loc *
       expr *
@@ -1018,6 +1028,8 @@ let rec expr_loc e =
   | WPointsTo (l, e, tp, rhs) -> l
   | PredAsn (l, g, targs, ies, es) -> l
   | WPredAsn (l, g, _, targs, ies, es) -> l
+  | PredExprAsn (l, e, pats) -> l
+  | WPredExprAsn (l, e, pts, inputParamCount, pats) -> l
   | InstPredAsn (l, e, g, index, pats) -> l
   | WInstPredAsn (l, e_opt, tns, cfin, tn, g, index, pats) -> l
   | ExprAsn (l, e) -> l

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -547,6 +547,20 @@ and of_expr = function
     of_list of_pat indices;
     of_list of_pat args
   ])
+| PredExprAsn (l, e, args) ->
+  C ("PredExprAsn", [
+    of_loc l;
+    of_expr e;
+    of_list of_pat args
+  ])
+| WPredExprAsn (l, e, pts, inputParamCount, pats) ->
+  C ("WPredExprAsn", [
+    of_loc l;
+    of_expr e;
+    of_list of_type pts;
+    of_option i inputParamCount;
+    of_list of_pat pats
+  ])
 | InstPredAsn (l, e, p, index, args) ->
   C ("InstPredAsn", [
     of_loc l;

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1364,6 +1364,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | MatchAsn (l, e, pat) -> expr_mark_addr_taken e locals; pat_expr_mark_addr_taken pat locals
     | LetTypeAsn (l, x, tp, a) -> ass_mark_addr_taken a locals
     | WMatchAsn (l, e, pat, tp) -> expr_mark_addr_taken e locals; pat_expr_mark_addr_taken pat locals
+    | WPredExprAsn (_, e, _, _, pats) -> expr_mark_addr_taken e locals; List.iter (fun p -> pat_expr_mark_addr_taken p locals) pats
     | e -> expr_mark_addr_taken e locals
   
   let rec stmt_mark_addr_taken s locals pure cont =


### PR DESCRIPTION
Expressions of the form (E)(args) in assertion position are now
interpreted as assertions. E must be of predicate type.