### PR TITLE
[Rust] Hang own, fbc, share off the typeid

### DIFF
--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -1202,7 +1202,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     let pred_expr_asn l coefpat e pts inputParamCount pats =
       let g_symb = (ev e, false) in
       let pts' = instantiate_types tpenv pts in
-      consume_chunk_core rules h ghostenv env env' l g_symb [] coef real_unit_pat inputParamCount (srcpats pats) pts pts' @@ fun chunk h coef ts size ghostenv env env' ->
+      consume_chunk_core rules h ghostenv env env' l g_symb [] coef coefpat inputParamCount (srcpats pats) pts pts' @@ fun chunk h coef ts size ghostenv env env' ->
       check_dummy_coefpat l coefpat coef;
       cont [chunk] h ghostenv env env' size
     in

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -531,6 +531,8 @@ and
   | MatchAsn of loc * expr * pat
   | WMatchAsn of loc * expr * pat * type_
   | LetTypeAsn of loc * string * type_ * asn (* `let_type U = T in A` means A with type T substituted for type parameter U *)
+  | TypePredExpr of loc * type_expr * string
+  | WTypePredExpr of loc * type_ * string
 and
   asn = expr
 and
@@ -898,6 +900,8 @@ and
   | ImportModuleDecl of loc * string
   | RequireModuleDecl of loc * string
   | ModuleDecl of loc * string * import list * decl list (* A Rust module. Is flattened into a list of PackageDecl after parsing. *)
+  | TypePredDecl of loc * type_expr * string * string
+  | TypePredDef of loc * string list * type_expr * string * loc * string
 and (* shared box is deeltje ghost state, waarde kan enkel via actions gewijzigd worden, handle predicates geven info over de ghost state, zelfs als er geen eigendom over de box is*)
   action_decl = (* ?action_decl *)
   | ActionDecl of loc * string * bool (* does performing this action require a corresponding action permission? *) * (type_expr * string) list * expr * expr
@@ -1036,6 +1040,8 @@ let rec expr_loc e =
   | MatchAsn (l, e, pat) -> l
   | WMatchAsn (l, e, pat, tp) -> l
   | LetTypeAsn (l, x, t, p) -> l
+  | TypePredExpr (l, t, x) -> l
+  | WTypePredExpr (l, t, x) -> l
   | Sep (l, p1, p2) -> l
   | IfAsn (l, e, p1, p2) -> l
   | SwitchAsn (l, e, sacs) -> l

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -448,6 +448,8 @@ and of_expr = function
 | TypedExpr (e, t) -> C ("TypedExpr", [of_expr e; of_type t])
 | WidenedParameterArgument e -> C ("WidenedParameterArgument", [of_expr e])
 | SizeofExpr (l, e) -> C ("SizeofExpr", [of_loc l; of_expr e])
+| TypePredExpr (l, te, x) -> C ("TypePredExpr", [of_loc l; of_type_expr te; S x])
+| WTypePredExpr (l, t, x) -> C ("WTypePredExpr", [of_loc l; of_type t; S x])
 | TypeExpr t -> C ("TypeExpr", [of_type_expr t])
 | GenericExpr (l, e, cs, def) ->
   C ("GenericExpr", [
@@ -1022,6 +1024,29 @@ and of_decl = function
     of_type_expr tp_expr;
     S name;
     of_option of_expr expr_opt
+  ])
+| ModuleDecl (l, mn, ilist, ds) ->
+  C ("ModuleDecl", [
+    of_loc l;
+    S mn;
+    of_list of_import ilist;
+    of_list of_decl ds
+  ])
+| TypePredDecl (l, te, selfTypeName, predName) ->
+  C ("TypePredDecl", [
+    of_loc l;
+    of_type_expr te;
+    S selfTypeName;
+    S predName
+  ])
+| TypePredDef (l, tparams, te, predName, lrhs, rhs) ->
+  C ("TypePredDef", [
+    of_loc l;
+    of_list s tparams;
+    of_type_expr te;
+    S predName;
+    of_loc lrhs;
+    S rhs
   ])
 and of_params params = 
   params |> of_list @@ fun (t, x) -> T [of_type_expr t; S x]

--- a/src/frontend/parser.ml
+++ b/src/frontend/parser.ml
@@ -146,7 +146,8 @@ let ghost_keywords = [
   "produce_lemma_function_pointer_chunk"; "duplicate_lemma_function_pointer_chunk"; "produce_function_pointer_chunk";
   "producing_box_predicate"; "producing_handle_predicate"; "producing_fresh_handle_predicate"; "box"; "handle"; "any"; "split_fraction"; "by"; "merge_fractions";
   "unloadable_module"; "decreases"; "forall_"; "import_module"; "require_module"; ".."; "extends"; "permbased";
-  "terminates"; "abstract_type"; "fixpoint_auto"; "typeid"; "activating"; "truncating"; "typedef"
+  "terminates"; "abstract_type"; "fixpoint_auto"; "typeid"; "activating"; "truncating"; "typedef";
+  "type_pred_decl"; "type_pred_def"
 ]
 
 exception CompilationError of string
@@ -1105,6 +1106,18 @@ and
       if kwd = "fixpoint_auto" then raise (ParseException (l, "Keyword 'fixpoint_auto' does not make sense here because this type of fixpoint definition is always unfolded automatically"));
       [Func (l, Fixpoint, tparams, rt, g, ps, false, None, None, false, body, false, [])]
     end
+| [ (l, Kwd "type_pred_decl"); parse_type as te; (_, Kwd "<"); (_, Ident selfTypeName); (_, Kwd ">"); (_, Kwd "."); (_, Ident predName); (_, Kwd ";") ] ->
+  [TypePredDecl (l, te, selfTypeName, predName)]
+| [ (l, Kwd "type_pred_def"); [%let tparams = parse_type_params l];
+    (_, Kwd "<"); parse_type as tp; (_, Kwd ">"); (_, Kwd "."); (_, Ident predName); (_, Kwd "=");
+    (lrhs, Ident rhs); [%let targs = parse_type_args lrhs]; (_, Kwd ";")
+  ] ->
+  let targ_names = targs |> List.map @@ function
+    IdentTypeExpr (_, None, targ_name) -> targ_name
+  | te -> raise (ParseException (type_expr_loc te, "Type parameter name expected"))
+  in
+  if targ_names <> tparams then raise (ParseException (lrhs, "Right-hand side type arguments must match definition type parameters"));
+  [TypePredDef (l, tparams, tp, predName, lrhs, rhs)]
 and
   parse_action_decls = function%parser
 | [ parse_action_decl as ad; 
@@ -2252,6 +2265,8 @@ and
   parse_expr stream = parse_assign_expr stream
 and
   parse_assign_expr = function%parser
+  [ (_, Kwd "<"); parse_type as tp; (_, Kwd ">"); (_, Kwd "."); (l, Ident x) ] ->
+  TypePredExpr (l, tp, x)
 | [ parse_sep_expr as e0; [%l e = parse_assign_expr_rest e0] ] -> e
 and
   parse_sep_expr = function%parser

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1336,6 +1336,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | Sep (_, e1, e2) -> expr_mark_addr_taken e1 locals; expr_mark_addr_taken e2 locals
     | TypeExpr _ -> ()
     | Typeid (_, e) -> expr_mark_addr_taken e locals
+    | TypePredExpr (_, _, _) | WTypePredExpr (_, _, _) -> ()
   and pat_expr_mark_addr_taken pat locals = 
     match pat with
     | LitPat(e) -> expr_mark_addr_taken e locals

--- a/tests/rust/safe_abstraction/tparam_own.rs
+++ b/tests/rust/safe_abstraction/tparam_own.rs
@@ -1,11 +1,11 @@
 fn replace<'a, T>(r: &'a mut T, v: T) -> T {
     unsafe {
-        //@ open_full_borrow(_q_a, a, T_full_borrow_content(_t, r));
+        //@ open_full_borrow(_q_a, a, (<T>.full_borrow_content)(_t, r));
         //@ open_full_borrow_content::<T>(_t, r);
         let result = std::ptr::read(r);
         std::ptr::write(r, v);
         //@ close_full_borrow_content::<T>(_t, r);
-        //@ close_full_borrow(T_full_borrow_content(_t, r));
+        //@ close_full_borrow(<T>.full_borrow_content(_t, r));
         //@ leak full_borrow(_, _);
         result
     }
@@ -13,17 +13,17 @@ fn replace<'a, T>(r: &'a mut T, v: T) -> T {
 
 fn swap<'a, T>(r1: &'a mut T, r2: &'a mut T) {
     unsafe {
-        //@ open_full_borrow(_q_a/2, a, T_full_borrow_content(_t, r1));
+        //@ open_full_borrow(_q_a/2, a, <T>.full_borrow_content(_t, r1));
         //@ open_full_borrow_content::<T>(_t, r1);
-        //@ open_full_borrow(_q_a/2, a, T_full_borrow_content(_t, r2));
+        //@ open_full_borrow(_q_a/2, a, <T>.full_borrow_content(_t, r2));
         //@ open_full_borrow_content::<T>(_t, r2);
         let tmp = std::ptr::read(r1);
         std::ptr::write(r1, std::ptr::read(r2));
         std::ptr::write(r2, tmp);
         //@ close_full_borrow_content::<T>(_t, r2);
-        //@ close_full_borrow(T_full_borrow_content(_t, r2));
+        //@ close_full_borrow(<T>.full_borrow_content(_t, r2));
         //@ close_full_borrow_content::<T>(_t, r1);
-        //@ close_full_borrow(T_full_borrow_content(_t, r1));
+        //@ close_full_borrow(<T>.full_borrow_content(_t, r1));
         //@ leak full_borrow(_, _);
         //@ leak full_borrow(_, _);
     }
@@ -32,6 +32,6 @@ fn swap<'a, T>(r1: &'a mut T, r2: &'a mut T) {
 fn share<'a, T>(r: &'a mut T) -> &'a T {
     //@ produce_type_interp::<T>();
     //@ share_full_borrow::<T>(a, _t, r);
-    //@ leak type_interp(_, _, _);
+    //@ leak type_interp();
     r
 }

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -236,14 +236,14 @@ impl Tree {
     }
 
     unsafe fn accept0<'a, V: TreeVisitor>(mut x: *mut Node, mut x_is_new: bool, visitor: &'a mut V)
-    //@ req Tree(?root, 0, ?rootShape) &*& x == root &*& x_is_new &*& thread_token(?t) &*& [?q]lifetime_token(?k) &*& full_borrow(k, V_full_borrow_content(t, visitor));
-    //@ ens Tree(root, 0, rootShape) &*& thread_token(t) &*& [q]lifetime_token(k) &*& full_borrow(k, V_full_borrow_content(t, visitor));
+    //@ req Tree(?root, 0, ?rootShape) &*& x == root &*& x_is_new &*& thread_token(?t) &*& [?q]lifetime_token(?k) &*& full_borrow(k, <V>.full_borrow_content(t, visitor));
+    //@ ens Tree(root, 0, rootShape) &*& thread_token(t) &*& [q]lifetime_token(k) &*& full_borrow(k, <V>.full_borrow_content(t, visitor));
     {
         //@ Tree_inv();
         //@ close stack(0, root, rootShape, root, rootShape, 0, []);
         //@ close inv_(true, x, root, rootShape, _, _);
         loop {
-            //@ inv inv_(x_is_new, x, root, rootShape, ?stepsLeft, ?elems_todo) &*& x != 0 &*& thread_token(t) &*& [q]lifetime_token(k) &*& full_borrow(k, V_full_borrow_content(t, visitor));
+            //@ inv inv_(x_is_new, x, root, rootShape, ?stepsLeft, ?elems_todo) &*& x != 0 &*& thread_token(t) &*& [q]lifetime_token(k) &*& full_borrow(k, <V>.full_borrow_content(t, visitor));
             //@ open inv_(_, _, _, _, _, _);
             //@ if x_is_new == false { open stack(x, _, _, _, _, _, _); }
             if (*x).left.is_null() {
@@ -254,7 +254,7 @@ impl Tree {
                 if x_is_new {
                     //@ let k1 = begin_lifetime();
                     //@ let kk1 = lifetime_intersection(k, k1);
-                    //@ reborrow(kk1, k, V_full_borrow_content(t, visitor));
+                    //@ reborrow(kk1, k, <V>.full_borrow_content(t, visitor));
                     //@ lifetime_token_inv(k);
                     //@ if q < 1 { close [1 - q]hidden_lifetime_token(k1); }
                     //@ close_lifetime_intersection_token(q, k, k1);
@@ -264,7 +264,7 @@ impl Tree {
                     //@ end_lifetime(k1);
                     //@ lifetime_intersection_symm(k, k1);
                     //@ close_lifetime_intersection_dead_token(k1, k);
-                    //@ end_reborrow(kk1, k, V_full_borrow_content(t, visitor));
+                    //@ end_reborrow(kk1, k, <V>.full_borrow_content(t, visitor));
                     
                     //@ set_lsb((*x).parent as *mut u8);
                     (*x).parent = ((*x).parent as *mut u8).offset(1) as *mut Node;


### PR DESCRIPTION
 fbc, share off the typeid,Specifically, this commit introduces a "type predicates" construct into the VeriFast engine. This enables associating predicates with types, such that they can be retrieved using `<T>.own`/`<T>.share` syntax.

Note: this approach means distinct Rust types (with distinct RustBelt
type interpretations) must be mapped to distinct VF types.

TODO: Introduce a separate VF type for Rust type `char`.