### PR TITLE
[C++] Fix multiple inheritance test

### DIFF
--- a/tests/cxx/virtual_methods/multiple_inheritance.cpp
+++ b/tests/cxx/virtual_methods/multiple_inheritance.cpp
@@ -83,6 +83,9 @@ public:
     //@ requires true;
     //@ ensures SourceDyn(&typeid(Node)) &*& SourceOk();
     {
+      setTarget(this);
+      //@ close TargetOk();
+      setSource(this);
       //@ open Node_vtype(this, &typeid(Node));
     }
 
@@ -90,10 +93,7 @@ public:
     //@ requires SourceDyn(thisType) &*& SourceOk();
     //@ ensures true;
     {
-      //@ open this->TargetDyn(&typeid(struct Target))(thisType);
-      setTarget(this);
-      //@ close TargetOk();
-      setSource(this);
+      //@ close Node_vtype(this, &typeid(Node));
     }
 
     virtual void setTarget(Target *target)


### PR DESCRIPTION
Moves virtual method calls from destructor to constructor.