### PR TITLE
[Rust] Writing to stdout

### DIFF
--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -12,6 +12,14 @@ mod intrinsics {
 
 }
 
+mod mem {
+
+    fn drop<T>(value: T);
+    //@ req thread_token(?t) &*& <T>.own(t, value);
+    //@ ens thread_token(t);
+    
+}
+
 mod ptr {
 
     unsafe fn drop_in_place<T>(to_drop: *mut T);
@@ -77,3 +85,48 @@ mod process {
     //@ terminates;
 }
 //Todo @Nima: Edit Rust parser so it substitutes `!` type with std_empty_ union
+
+mod result {
+
+    enum Result<T, E> {
+        Ok(T),
+        Err(E),
+    }
+    
+    //@ pred Result_own<T, E>(t: thread_id_t, v: Result<T, E>);
+    
+    impl<T, E> Result<T, E> {
+    
+        fn unwrap(self: Result<T, E>) -> T;
+        //@ req thread_token(?t) &*& Result_own::<T, E>(t, self);
+        //@ ens thread_token(t);
+    
+    }
+
+}
+
+mod io {
+
+    struct Error;
+    
+    type Result<T> = std::result::Result<T, Error>;
+    
+    trait Write {
+    
+        fn write(self: *Self, buf: &[u8]) -> Result<usize>;
+        //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0) &*& [?f]integers_(buf.ptr, 1, false, buf.len, ?bs);
+        //@ ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1) &*& [f]integers_(buf.ptr, 1, false, buf.len, bs) &*& std::result::Result_own::<usize, Error>(t, result);
+        
+        fn flush(self: *Self) -> Result<()>;
+        //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0);
+        //@ ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1);
+        
+    }
+
+    struct Stdout;
+    
+    fn stdout() -> Stdout;
+    //@ req thread_token(?t);
+    //@ ens thread_token(t) &*& <Stdout>.own(t, result);
+
+}

--- a/tests/rust/purely_unsafe/httpd.rs
+++ b/tests/rust/purely_unsafe/httpd.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 struct Buffer {
     buffer: *mut u8,
     size: usize,
@@ -159,10 +161,20 @@ unsafe fn handle_connection(buffer: *mut Buffer, socket: platform::sockets::Sock
     socket.close();
 }
 
+unsafe fn print<'a>(text: &'a str)
+//@ req thread_token(?t) &*& [?f]integers_(text.ptr, 1, false, text.len, ?cs);
+//@ ens thread_token(t) &*& [f]integers_(text.ptr, 1, false, text.len, cs);
+{
+    let mut stdout = std::io::stdout();
+    stdout.write(text.as_bytes()).unwrap();
+    std::mem::drop(stdout);
+}
+
 fn main() {
     unsafe {
         let port: u16 = 10000;
         let server_socket = platform::sockets::Socket::listen(port);
+        print("Listening on port 10000...\n");
         let mut buffer = Buffer::new(1000);
         //@ assert Buffer_own(?buf, 1000, 0);
         //@ assert buffer.buffer |-> buf.buffer &*& buffer.size |-> 1000 &*& buffer.length |-> 0;

--- a/tests/rust/purely_unsafe/httpd_mt.rs
+++ b/tests/rust/purely_unsafe/httpd_mt.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 #[path = "simple_mutex.rs"]
 mod simple_mutex;
 
@@ -234,10 +236,20 @@ unsafe fn handle_connection(data: *mut u8)
     Buffer::drop(&mut buffer_copy as *mut Buffer);
 }
 
+unsafe fn print<'a>(text: &'a str)
+//@ req thread_token(?t) &*& [?f]integers_(text.ptr, 1, false, text.len, ?cs);
+//@ ens thread_token(t) &*& [f]integers_(text.ptr, 1, false, text.len, cs);
+{
+    let mut stdout = std::io::stdout();
+    stdout.write(text.as_bytes()).unwrap();
+    std::mem::drop(stdout);
+}
+
 fn main() {
     unsafe {
         let port: u16 = 10000;
         let server_socket = platform::sockets::Socket::listen(port);
+        print("Listening on port 10000...");
         let mut buffer = Buffer::new(1000);
         //@ assert Buffer_own(?buf, 1000, 0);
         //@ assert buffer.buffer |-> buf.buffer &*& buffer.size |-> 1000 &*& buffer.length |-> 0;


### PR DESCRIPTION
Extends the .rsspec file parser with support for
- Enums
- Generic impl blocks
- Type alias declarations
- Trait declarations
- Ref types
- Tuple types

Adds specs for the following std items:
- fn std::mem::Drop
- enum std::result::Result
- fn std::result::Result::unwrap
- struct std::io::Error
- type std::io::Result
- trait std::io::Write with required fns write and flush
- struct std::io::Stdout
- fn std::io::stdout