### PR TITLE
[Rust] Generate POs for S iff S_own or S_share declared

### DIFF
--- a/tests/rust/parser_test.rs
+++ b/tests/rust/parser_test.rs
@@ -5,11 +5,11 @@ mod foo {
     }
 }
 
-//@ pred foo::Foo_own(t: thread_id_t, v: i32) = true;
+//@ pred foo::Foo_own__(t: thread_id_t, v: i32) = true;
 
 /*@
 lem foo::Foo_dummy(p: *foo::Foo)
-req [?q](*p).v |-> ?v &*& foo::Foo_own(?t, v);
-ens [q](*p).v |-> v &*& foo::Foo_own(t, v);
+req [?q](*p).v |-> ?v &*& foo::Foo_own__(?t, v);
+ens [q](*p).v |-> v &*& foo::Foo_own__(t, v);
 {}
 @*/

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -12,20 +12,6 @@ About the definitions:
 */
 
 /*@
-// dummy
-pred sys::locks::Mutex_own(t: thread_id_t, m: *u32);
-pred sys::locks::Mutex_share(k: lifetime_t, t: thread_id_t, l: *sys::locks::Mutex;) = true;
-lem sys::locks::Mutex_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *sys::locks::Mutex)
-    req lifetime_inclusion(k1, k) == true &*& [_]sys::locks::Mutex_share(k, t, l);
-    ens [_]sys::locks::Mutex_share(k1, t, l);
-{}
-lem sys::locks::Mutex_share_full(k: lifetime_t, t: thread_id_t, l: *sys::locks::Mutex)
-    req full_borrow(k, sys::locks::Mutex_full_borrow_content(t, l)) &*& [?q]lifetime_token(k);
-    ens [_]sys::locks::Mutex_share(k, t, l) &*& [q]lifetime_token(k);
-{
-    leak full_borrow(_, _);
-}
-// ymmud
 
 pred SysMutex(m: sys::locks::Mutex; P: pred());
 pred SysMutex_share(l: *sys::locks::Mutex; P: pred());


### PR DESCRIPTION
If the user declares neither S_own nor S_share, one can imagine S_own
and S_share as being defined as `false`; for those definitions, the
proof obligations hold trivially.
