### PR TITLE
[C++] Support for 'for' loops and 'continue' statements

### DIFF
--- a/src/cxx_frontend/ast_exporter/Concept.h
+++ b/src/cxx_frontend/ast_exporter/Concept.h
@@ -20,11 +20,11 @@ concept IsAstNode = IsAnyOf<T, clang::Decl, clang::Stmt, clang::Expr,
                             clang::Type, clang::TypeLoc>;
 
 template <typename T>
-concept IsWhileAstNode = IsAnyOf<T, clang::WhileStmt, clang::DoStmt>;
+concept IsLoopAstNode = IsAnyOf<T, clang::WhileStmt, clang::DoStmt, clang::ForStmt>;
 
 #else
 #define IsAnyOf typename
 #define IsStubsNode typename
 #define IsAstNode typename
-#define IsWhileAstNode typename
+#define IsLoopAstNode typename
 #endif

--- a/src/cxx_frontend/ast_exporter/NodeSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeSerializer.h
@@ -128,6 +128,8 @@ struct StmtSerializer : public NodeSerializer<stubs::Stmt, clang::Stmt>,
 
   bool VisitDoStmt(const clang::DoStmt *stmt);
 
+  bool VisitForStmt(const clang::ForStmt *stmt);
+
   bool VisitBreakStmt(const clang::BreakStmt *stmt);
 
   bool VisitContinueStmt(const clang::ContinueStmt *stmt);
@@ -139,7 +141,7 @@ struct StmtSerializer : public NodeSerializer<stubs::Stmt, clang::Stmt>,
   bool VisitDefaultStmt(const clang::DefaultStmt *stmt);
 
 private:
-  template <IsWhileAstNode While>
+  template <IsLoopAstNode While>
   bool serializeWhileStmt(stubs::Stmt::While::Builder builder,
                           const While *stmt);
 };

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -138,6 +138,12 @@ struct Stmt {
     whileLoc @3 :Loc;
   }
 
+  struct For {
+    init @0 :StmtNode;
+    insideWhile @1 :While;
+    iteration @2 :ExprNode;
+  }
+
   struct Case {
     lhs @0 :ExprNode;
     stmt @1 :StmtNode; # optional
@@ -168,6 +174,7 @@ struct Stmt {
     switch @12 :Switch;
     case @13 :Case;
     defCase @14 :DefCase;
+    for @15 :For;
   }
 }
 

--- a/tests/cxx/loops.cpp
+++ b/tests/cxx/loops.cpp
@@ -1,0 +1,34 @@
+void f()
+//@ requires true;
+//@ ensures true;
+{
+  int i;
+  const int n = 2;
+
+  for(i = 0; i < n; ++i)
+  //@ invariant 0 <= i &*& i <= n;
+  //@ decreases n - i;
+  {
+    continue;
+    //@ assert false;
+  }
+  //@ assert i == 2;
+}
+
+void g()
+//@ requires true;
+//@ ensures true;
+{
+  int i;
+  const int n = 2;
+
+  for(i = 0; i < n; ++i)
+  //@ requires 0 <= i &*& i <= n;
+  //@ ensures i == n;
+  //@ decreases n - i;
+  {
+    continue;
+    //@ assert false;
+  }
+  //@ assert i == 2;
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -688,6 +688,7 @@ cd tests
     verifast -c ghost_field.cpp
     verifast -c -disable_overflow_check non_compound_stmts.cpp
     verifast -c -target Linux64 literals.cpp
+    verifast -c loops.cpp
   cd ..
   cd rust
     call testsuite.mysh


### PR DESCRIPTION
Adds support for 'for' loops and 'continue' statements for C++ and solves issue #475 for C++ (instead of C).