### PR TITLE
[C++] Support Pointer to Integer casts

### DIFF
--- a/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
@@ -207,6 +207,10 @@ bool ExprSerializer::serializeCast(const clang::CastExpr *expr, bool expl) {
     auto ce = m_builder.initBaseToDerived();
     return serializeStructToStructCast(ce, expr);
   }
+  case clang::CastKind::CK_PointerToIntegral: {
+    auto ce = m_builder.initIntegralCast();
+    return serializeStructToStructCast(ce, expr);
+  }
   default:
     if (expl)
       return false;

--- a/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
@@ -181,8 +181,8 @@ bool ExprSerializer::VisitExplicitCastExpr(
   return serializeCast(expr, true);
 }
 
-bool ExprSerializer::serializeStructToStructCast(
-    stubs::Expr::Expr::StructToStruct::Builder &builder,
+bool ExprSerializer::serializeCast(
+    stubs::Expr::Expr::Cast::Builder &builder,
     const clang::CastExpr *expr) {
   auto e = builder.initExpr();
   auto type = builder.initType();
@@ -201,15 +201,15 @@ bool ExprSerializer::serializeCast(const clang::CastExpr *expr, bool expl) {
   case clang::CastKind::CK_UncheckedDerivedToBase:
   case clang::CastKind::CK_DerivedToBase: {
     auto ce = m_builder.initDerivedToBase();
-    return serializeStructToStructCast(ce, expr);
+    return serializeCast(ce, expr);
   }
   case clang::CastKind::CK_BaseToDerived: {
     auto ce = m_builder.initBaseToDerived();
-    return serializeStructToStructCast(ce, expr);
+    return serializeCast(ce, expr);
   }
   case clang::CastKind::CK_PointerToIntegral: {
     auto ce = m_builder.initIntegralCast();
-    return serializeStructToStructCast(ce, expr);
+    return serializeCast(ce, expr);
   }
   default:
     if (expl)

--- a/src/cxx_frontend/ast_exporter/NodeSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeSerializer.h
@@ -297,8 +297,8 @@ private:
 
   bool serializeCast(const clang::CastExpr *expr, bool expl);
 
-  bool serializeStructToStructCast(
-      stubs::Expr::Expr::StructToStruct::Builder &builder,
+  bool serializeCast(
+      stubs::Expr::Expr::Cast::Builder &builder,
       const clang::CastExpr *expr);
 };
 

--- a/src/cxx_frontend/expr_translator.ml
+++ b/src/cxx_frontend/expr_translator.ml
@@ -232,15 +232,15 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     let e = translate e in
     Ast.CxxLValueToRValue (loc, e)
 
-  and transl_derived_to_base_expr (loc : Ast.loc) (e : E.StructToStruct.t) :
+  and transl_derived_to_base_expr (loc : Ast.loc) (e : E.Cast.t) :
       Ast.expr =
-    let open E.StructToStruct in
+    let open E.Cast in
     let sub_expr = expr_get e |> translate in
     let ty = type_get e |> Type_translator.translate_decomposed loc in
     Ast.CxxDerivedToBase (loc, sub_expr, ty)
 
-  and transl_integral_cast (loc : Ast.loc) (c : E.StructToStruct.t) : Ast.expr =
-    let open E.StructToStruct in
+  and transl_integral_cast (loc : Ast.loc) (c : E.Cast.t) : Ast.expr =
+    let open E.Cast in
     let sub_expr = expr_get c |> translate in
     let ty = type_get c |> Type_translator.translate_decomposed loc in
     Ast.CastExpr (loc, ty, sub_expr)

--- a/src/cxx_frontend/expr_translator.ml
+++ b/src/cxx_frontend/expr_translator.ml
@@ -35,6 +35,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     | OperatorCall o -> transl_operator_call_expr loc o
     | Cleanups c -> transl_cleanups_expr c
     | BindTemporary t -> transl_bind_temporary_expr t
+    | IntegralCast c -> transl_integral_cast loc c
     | Undefined _ -> failwith "Undefined expression"
     | _ -> Error.error loc "Unsupported expression."
 
@@ -237,6 +238,12 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     let sub_expr = expr_get e |> translate in
     let ty = type_get e |> Type_translator.translate_decomposed loc in
     Ast.CxxDerivedToBase (loc, sub_expr, ty)
+
+  and transl_integral_cast (loc : Ast.loc) (c : E.StructToStruct.t) : Ast.expr =
+    let open E.StructToStruct in
+    let sub_expr = expr_get c |> translate in
+    let ty = type_get c |> Type_translator.translate_decomposed loc in
+    Ast.CastExpr (loc, ty, sub_expr)
 
   and transl_cleanups_expr (e : R.Node.t) : Ast.expr = translate e
   and transl_bind_temporary_expr (e : R.Node.t) = translate e

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -446,6 +446,7 @@ struct Expr {
     operatorCall @19 :Call;
     cleanups @20 :ExprNode;
     bindTemporary @21 :ExprNode;
+    integralCast @22 :StructToStruct;
   }
 }
 

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -418,7 +418,7 @@ struct Expr {
     type @2 :Type;
   }
 
-  struct StructToStruct {
+  struct Cast {
     expr @0 :ExprNode;
     type @1 :Type;
   }
@@ -441,12 +441,12 @@ struct Expr {
     delete @14 :ExprNode;
     truncating @15 :ExprNode;
     lValueToRValue @16 :ExprNode;
-    derivedToBase @17 :StructToStruct;
-    baseToDerived @18 :StructToStruct;
+    derivedToBase @17 :Cast;
+    baseToDerived @18 :Cast;
     operatorCall @19 :Call;
     cleanups @20 :ExprNode;
     bindTemporary @21 :ExprNode;
-    integralCast @22 :StructToStruct;
+    integralCast @22 :Cast;
   }
 }
 

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -4953,6 +4953,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | (PtrType _, PtrType _) when isCast -> Upcast (w, t, t0)
         | (Int (_, _)), (Int (_, _)) when isCast -> if definitely_is_upcast (int_rank_and_signedness t) (int_rank_and_signedness t0) then Upcast (w, t, t0) else w
         | (PtrType _), (Int (Unsigned, PtrRank)) when isCast -> WReadInductiveField (expr_loc w, w, "pointer", "pointer_ctor", "address", [], PtrType Void, PtrType Void)
+        | (PtrType _), (Int (Unsigned, m)) when isCast && definitely_is_upcast (int_rank_and_signedness t) (int_rank_and_signedness t0) -> WReadInductiveField (expr_loc w, w, "pointer", "pointer_ctor", "address", [], PtrType Void, PtrType Void)
         | (Int (_, _)), (PtrType _) when isCast && (inAnnotation = Some true || definitely_is_upcast (int_rank_and_signedness t) (int_rank_and_signedness t0)) -> WPureFunCall (expr_loc w, "pointer_ctor", [], [WPureFunCall (expr_loc w, "null_pointer_provenance", [], []); w])
         | (Int (signedness, _), (Float|Double|LongDouble)) -> floating_point_fun_call_expr funcmap (expr_loc w) t0 ("of_" ^ identifier_string_of_type (Int (signedness, FixedWidthRank max_width))) [TypedExpr (w, t)]
         | ((Float|Double|LongDouble), (Float|Double|LongDouble)) -> floating_point_fun_call_expr funcmap (expr_loc w) t0 ("of_" ^ identifier_string_of_type t) [TypedExpr (w, t)]

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -141,7 +141,6 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
 
   let data_model = match language with Java -> Some data_model_java | CLang -> data_model
   let int_width, long_width, ptr_width = decompose_data_model data_model
-  let llong_width = LitWidth 3
   let intType = Int (Signed, IntRank)
   let sizeType = Int (Unsigned, PtrRank)
   let ptrdiff_t = Int (Signed, PtrRank)

--- a/tests/cxx/casts.cpp
+++ b/tests/cxx/casts.cpp
@@ -1,0 +1,9 @@
+unsigned long alignmentRest(void const * const pointer, unsigned int const byte_count)
+//@ requires byte_count > 0;
+//@ ensures result <= byte_count;
+{
+	unsigned long const p = (unsigned long) pointer;
+	//@ div_rem_nonneg(p, byte_count);
+
+	return byte_count - (p % byte_count);
+}

--- a/tests/cxx/casts.cpp
+++ b/tests/cxx/casts.cpp
@@ -1,8 +1,8 @@
-unsigned long alignmentRest(void const * const pointer, unsigned int const byte_count)
+unsigned long long alignmentRest(void const * const pointer, unsigned int const byte_count)
 //@ requires byte_count > 0;
 //@ ensures result <= byte_count;
 {
-	unsigned long const p = (unsigned long) pointer;
+	unsigned long long const p = (unsigned long long) pointer;
 	//@ div_rem_nonneg(p, byte_count);
 
 	return byte_count - (p % byte_count);

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -689,6 +689,7 @@ cd tests
     verifast -c -disable_overflow_check non_compound_stmts.cpp
     verifast -c -target Linux64 literals.cpp
     verifast -c loops.cpp
+    verifast -c -target Linux64 casts.cpp
   cd ..
   cd rust
     call testsuite.mysh


### PR DESCRIPTION
For clang, uintptr_t is just a typedef that may be defined by the programmer itself. To support calculations with pointer values anyway I added support for casts from pointers to integer types. The Verifast core supported this for integers with PtrRank only so far. So I had to add support for those casts more generally.

Please have a closer look at my added line in verifast1.ml to be sure that my changes are sound.
The removed line in verifast1.ml had an exact duplicate some lines below.