### PR TITLE
[C++] Collection of small changes

### DIFF
--- a/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
@@ -207,6 +207,17 @@ bool ExprSerializer::serializeCast(const clang::CastExpr *expr, bool expl) {
     auto ce = m_builder.initBaseToDerived();
     return serializeCast(ce, expr);
   }
+  case clang::CastKind::CK_NoOp: // Required for down-casts of integral types
+  case clang::CastKind::CK_IntegralCast: {
+    if (expl) {
+      auto ce = m_builder.initIntegralCast();
+      return serializeCast(ce, expr);
+    }
+    else {
+      serialize(expr->getSubExpr());
+      return true;
+    }
+  }
   case clang::CastKind::CK_PointerToIntegral: {
     auto ce = m_builder.initIntegralCast();
     return serializeCast(ce, expr);

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -66,12 +66,14 @@ let static_error l msg url = raise (StaticError (l, msg, url))
 let rec root_caller_token l =
   match l with
     Lexed l -> l
+  | DummyLoc -> dummy_loc0
   | MacroExpansion (lcall, _) -> root_caller_token lcall
   | MacroParamExpansion (lparam, _) -> root_caller_token lparam
 
 let rec lexed_loc l =
   match l with
     Lexed l -> l
+  | DummyLoc -> dummy_loc0
   | MacroExpansion (lcall, lbodyTok) -> lexed_loc lbodyTok
   | MacroParamExpansion (lparam, largTok) -> lexed_loc largTok
 

--- a/src/frontend/parser.ml
+++ b/src/frontend/parser.ml
@@ -163,6 +163,7 @@ let file_specs path =
     else if Filename.check_suffix (Filename.basename path) ".javaspec" then Java, None
     else if Filename.check_suffix (Filename.basename path) ".scala" then Java, None
     else if Filename.check_suffix (Filename.basename path) ".h" then CLang, None
+    else if Filename.check_suffix (Filename.basename path) ".hpp" then CLang, Some (Cxx)
     else if Filename.check_suffix (Filename.basename path) ".rs" then CLang, Some(Rust)
     else raise (CompilationError ("unknown extension: " ^ (Filename.basename path)))
   end

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -1316,7 +1316,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let (headers', maps) =
               match try_assoc path !headermap with
                 None ->
-                let header_is_import_spec = Filename.chop_extension (Filename.basename header_path) <> Filename.chop_extension (Filename.basename program_path) in
+                let header_is_import_spec = Filename.remove_extension (Filename.basename header_path) <> Filename.chop_extension (Filename.basename program_path) in
                 let (headers', ds) =
                   match language with
                     CLang ->

--- a/src/vfconsole/vfconsole.ml
+++ b/src/vfconsole/vfconsole.ml
@@ -489,7 +489,7 @@ let _ =
             ]
   in
   let process_file filename =
-    if List.exists (Filename.check_suffix filename) [ ".c"; ".cpp"; ".java"; ".scala"; ".jarsrc"; ".javaspec"; ".rs" ]
+    if List.exists (Filename.check_suffix filename) [ ".c"; ".h"; ".cpp"; ".hpp"; ".java"; ".scala"; ".jarsrc"; ".javaspec"; ".rs" ]
     then
       begin
         let vfbindings = !vfbindings in

--- a/src/vfide/vfide.ml
+++ b/src/vfide/vfide.ml
@@ -615,7 +615,7 @@ let show_ide initialPath prover codeFont traceFont vfbindings layout javaFronten
     | Some (path, mtime) ->
       if Filename.check_suffix path ".c" || Filename.check_suffix path ".h" then highlight c_keywords ghost_keywords
       else if Filename.check_suffix path ".java" || Filename.check_suffix path ".javaspec" then highlight java_keywords ghost_keywords
-      else if Filename.check_suffix path ".cpp" then highlight cxx_keywords ghost_keywords
+      else if Filename.check_suffix path ".cpp" || Filename.check_suffix path ".hpp" then highlight cxx_keywords ghost_keywords
       else if Filename.check_suffix path ".rs" then highlight rust_keywords rust_ghost_keywords
       else ()
   in
@@ -1503,7 +1503,7 @@ let show_ide initialPath prover codeFont traceFont vfbindings layout javaFronten
                 else
                   (fun forest -> postProcess := (fun () -> reportExecutionForest !forest))
               in
-              if options.option_use_java_frontend || Filename.check_suffix path ".cpp" || Filename.check_suffix path ".rs" then begin
+              if options.option_use_java_frontend || Filename.check_suffix path ".cpp" || Filename.check_suffix path ".hpp" || Filename.check_suffix path ".rs" then begin
                 !buffers |> List.iter begin fun tab ->
                   perform_syntax_highlighting tab tab#buffer#start_iter tab#buffer#end_iter
                 end

--- a/tests/cxx/casts.cpp
+++ b/tests/cxx/casts.cpp
@@ -1,9 +1,9 @@
-unsigned long long alignmentRest(void const * const pointer, unsigned int const byte_count)
+unsigned int alignmentRest(void const * const pointer, unsigned int const byte_count)
 //@ requires byte_count > 0;
 //@ ensures result <= byte_count;
 {
 	unsigned long long const p = (unsigned long long) pointer;
 	//@ div_rem_nonneg(p, byte_count);
 
-	return byte_count - (p % byte_count);
+	return (unsigned int) (byte_count - (p % byte_count));
 }

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -689,7 +689,7 @@ cd tests
     verifast -c -disable_overflow_check non_compound_stmts.cpp
     verifast -c -target Linux64 literals.cpp
     verifast -c loops.cpp
-    verifast -c -target Linux64 casts.cpp
+    verifast -c casts.cpp
   cd ..
   cd rust
     call testsuite.mysh


### PR DESCRIPTION
This pull request contains the following changes:

- Support for integer down-cast in C++ (using C-Style-Casts)
- Enables verification of .hpp files
- Fixes error when including C++ standard library headers (e.g. "#include &lt;cstdint&gt;") caused by requirement for file extension
- Fixed error of dummy locations in clang error messages.
- Removed deprecated target specification for casts.cpp test case.