### PR TITLE
[C++] Add support for conditional operator

### DIFF
--- a/src/cxx_frontend/ast_exporter/Error.h
+++ b/src/cxx_frontend/ast_exporter/Error.h
@@ -13,12 +13,11 @@ class ErrorRange {
 
 public:
   ErrorRange(const clang::FullSourceLoc &fullLoc) {
-    const clang::FileEntry *fileEntry = fullLoc.getFileEntry();
-    m_valid = fullLoc.isValid() && fileEntry;
+    m_valid = fullLoc.isValid() && fullLoc.getFileEntry();
     if (m_valid) {
       m_loc.l = fullLoc.getLineNumber();
       m_loc.c = fullLoc.getColumnNumber();
-      m_loc.f = fileEntry->getUID();
+      m_loc.f = fullLoc.getFileEntry()->getUID();
     }
   }
 

--- a/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
@@ -86,6 +86,26 @@ bool ExprSerializer::VisitBinaryOperator(const clang::BinaryOperator *bo) {
   return true;
 }
 
+bool ExprSerializer::VisitConditionalOperator(
+    clang::ConditionalOperator const * const co) {
+  using CondOpBuilder = stubs::Expr::ConditionalOp::Builder;
+  using ExprBuilder = stubs::Node<stubs::Expr>::Builder;
+
+  // Initialize Cap'n Proto elements
+  CondOpBuilder condOpBuilder = m_builder.initConditionalOp();
+
+  ExprBuilder condExpr = condOpBuilder.initCond();
+  ExprBuilder thenExpr = condOpBuilder.initThen();
+  ExprBuilder elseExpr = condOpBuilder.initElse();
+
+  // Serialize subexpressions
+  m_serializer.serializeExpr(condExpr, co->getCond());
+  m_serializer.serializeExpr(thenExpr, co->getTrueExpr());
+  m_serializer.serializeExpr(elseExpr, co->getFalseExpr());
+
+  return true;
+}
+
 bool ExprSerializer::VisitCXXBoolLiteralExpr(
     const clang::CXXBoolLiteralExpr *expr) {
   m_builder.setBoolLit(expr->getValue());

--- a/src/cxx_frontend/ast_exporter/NodeSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeSerializer.h
@@ -239,6 +239,8 @@ struct ExprSerializer : public NodeSerializer<stubs::Expr, clang::Expr>,
 
   bool VisitBinaryOperator(const clang::BinaryOperator *bo);
 
+  bool VisitConditionalOperator(const clang::ConditionalOperator *co);
+
   bool VisitCXXBoolLiteralExpr(const clang::CXXBoolLiteralExpr *expr);
 
   bool VisitCharacterLiteral(const clang::CharacterLiteral *lit);

--- a/src/cxx_frontend/expr_translator.ml
+++ b/src/cxx_frontend/expr_translator.ml
@@ -36,6 +36,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     | Cleanups c -> transl_cleanups_expr c
     | BindTemporary t -> transl_bind_temporary_expr t
     | IntegralCast c -> transl_integral_cast loc c
+    | ConditionalOp op -> transl_conditional_op loc op
     | Undefined _ -> failwith "Undefined expression"
     | _ -> Error.error loc "Unsupported expression."
 
@@ -244,6 +245,13 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     let sub_expr = expr_get c |> translate in
     let ty = type_get c |> Type_translator.translate_decomposed loc in
     Ast.CastExpr (loc, ty, sub_expr)
+
+  and transl_conditional_op (loc : Ast.loc) (op : E.ConditionalOp.t) : Ast.expr =
+    let open E.ConditionalOp in
+    let cond = translate @@ cond_get op in
+    let th = translate @@ then_get op in
+    let el = translate @@ else_get op in
+    Ast.IfExpr(loc, cond, th, el)
 
   and transl_cleanups_expr (e : R.Node.t) : Ast.expr = translate e
   and transl_bind_temporary_expr (e : R.Node.t) = translate e

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -380,6 +380,12 @@ struct Expr {
     kind @2 :BinaryOpKind;
   }
 
+  struct ConditionalOp {
+    cond @0 :ExprNode;
+    then @1 :ExprNode;
+    else @2 :ExprNode;
+  }
+
   struct IntLit {
     uSuffix @0 :Bool;
     lSuffix @1 :SufKind;
@@ -447,6 +453,7 @@ struct Expr {
     cleanups @20 :ExprNode;
     bindTemporary @21 :ExprNode;
     integralCast @22 :Cast;
+    conditionalOp @23 :ConditionalOp;
   }
 }
 

--- a/tests/cxx/operators.cpp
+++ b/tests/cxx/operators.cpp
@@ -49,4 +49,10 @@ int main()
   bool gt = (*iw) > 4; // operator overload >
   //@ assert gt;
   delete iw;
+
+  // Test conditional operator
+  int co1 = lt ? 3 : 9;
+  int co2 = ten != 10 ? 3 : 9;
+  //@ assert co1 == 3;
+  //@ assert co2 == 9;
 }


### PR DESCRIPTION
This pull request adds support for the conditional operator ('?'-operator) in C++.
It also fixes a bug in Error.h that caused a segmentation violations in case of an invalid location while calling fullLoc.getFileEntry().