### PR TITLE
Fix #501

### DIFF
--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -53,6 +53,8 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | AssignExpr (l, e1, e2) -> expr_assigned_variables e1 @ expr_assigned_variables e2
     | AssignOpExpr (l, (Var (_, x) | WVar (_, x, _)), op, e, _) -> [x] @ expr_assigned_variables e
     | AssignOpExpr (l, e1, op, e2, _) -> expr_assigned_variables e1 @ expr_assigned_variables e2
+    | WAssignOpExpr (l, (Var (_, x) | WVar (_, x, _)), _, e, _) -> [x] @ expr_assigned_variables e
+    | WAssignOpExpr (l, e1, _, e2, _) -> expr_assigned_variables e1 @ expr_assigned_variables e2
     | InstanceOfExpr(_, e, _) -> expr_assigned_variables e
     | SliceExpr (l, p1, p2) -> flatmap (function Some (LitPat e) -> expr_assigned_variables e | _ -> []) [p1; p2]
     | SuperMethodCall(_, _, args) -> flatmap expr_assigned_variables args

--- a/tests/loop_cond_assigned_vars.java
+++ b/tests/loop_cond_assigned_vars.java
@@ -1,0 +1,30 @@
+class Test {
+
+  static void test_inv_loop()
+  //@ requires true;
+  //@ ensures false; //~should_fail
+  {
+    int i = 0;
+    int j = 0;
+    while (i++ != 100)
+    //@ invariant i == j &*& i <= 100;
+    {
+      j++;
+    }
+  }
+
+  static void test_spec_loop()
+  //@ requires true;
+  //@ ensures false; //~should_fail
+  {
+    int i = 0;
+    int j = 0;
+    while (i++ != 100)
+    //@ requires i == j &*& i <= 100;
+    //@ ensures true;
+    {
+      j++;
+    }
+  }
+  
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -470,6 +470,7 @@ cd tests
   verifast -c continue.c
   verifast -c generic_points_to.c
   verifast -c struct_points_to.c
+  verifast -c -allow_should_fail loop_cond_assigned_vars.java
   verifast -c -prover z3v4.5 generic_points_to.c
   verifast -c -uppercase_type_params_carry_typeid generic_structs.c
   verifast -c -uppercase_type_params_carry_typeid -prover z3v4.5 generic_structs.c


### PR DESCRIPTION
Also continues verification of the rest of the program when verification
of a method or constructor fails on a line marked as //~should_fail.
