### PR TITLE
[C++] Refine source locations

### DIFF
--- a/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
@@ -58,6 +58,7 @@ struct DeclSerializerImpl
         functionBuilder.initParams(decl->param_size());
 
     functionBuilder.setName(name.data());
+    functionBuilder.setIsMain(decl->isMain());
 
     if (!returnTypeLoc.isNull()) {
       m_ASTSerializer->serialize(resultBuilder, returnTypeLoc.getReturnLoc());
@@ -141,12 +142,9 @@ struct DeclSerializerImpl
     }
 
     if (!isStatic) {
-      stubs::Type::Builder thisTypeBuilder = builder.initThis();
-      m_ASTSerializer->serialize(thisTypeBuilder, decl->getThisObjectType());
+      m_ASTSerializer->serialize(builder.initThis(), decl->getThisObjectType());
     }
-
-    stubs::Decl::Function::Builder funcBuilder = builder.initFunc();
-    serializeFunctionDecl(funcBuilder, decl, true);
+    serializeFunctionDecl(builder.initFunc(), decl, true);
   }
 
   bool VisitFunctionDecl(const clang::FunctionDecl *decl) {

--- a/src/cxx_frontend/ast_exporter/StmtSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/StmtSerializer.cpp
@@ -77,9 +77,7 @@ struct StmtSerializerImpl
     stubs::Stmt::If::Builder ifStmtBuilder = m_builder.initIf();
 
     m_ASTSerializer->serialize(ifStmtBuilder.initCond(), stmt->getCond());
-
-    StmtNodeBuilder then = ifStmtBuilder.initThen();
-    m_ASTSerializer->serialize(then, stmt->getThen());
+    m_ASTSerializer->serialize(ifStmtBuilder.initThen(), stmt->getThen());
 
     if (stmt->hasElseStorage()) {
       m_ASTSerializer->serialize(ifStmtBuilder.initElse(), stmt->getElse());

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -201,6 +201,7 @@ struct Decl {
     result @2 :TypeNode;
     params @3 :List(Param);
     contract @4 :List(Clause); # optional
+    isMain @5 :Bool;
   }
 
   struct Field {

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2988,6 +2988,9 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           match (rt, retval) with
             (None, None) -> do_return h env
           | (Some tp, Some t) -> do_return h (("result", t)::env)
+          | (Some tp, None) when dialect = Some Cxx && g = "main" -> 
+            (* implicit 'return 0' for main function in C++ *)
+            do_return h (("result", int_zero_term) :: env)
           | (None, Some _) -> assert_false h env l "Void function returns a value." None
           | (Some _, None) -> assert_false h env l "Non-void function does not return a value." None
         in


### PR DESCRIPTION
Also removed insertion of implicit `return 0` in `main` for C++ programs. VeriFast now instead uses a zero term as return value when the dialect is C++, the name of the function is main and the function does not return a value.