### PR TITLE
[C++] Deleted and Defaulted functions

### DIFF
--- a/src/cxx_frontend/ast_exporter/AnnotationManager.cpp
+++ b/src/cxx_frontend/ast_exporter/AnnotationManager.cpp
@@ -132,7 +132,7 @@ AnnotationManager::getContract(const clang::FunctionDecl *decl) const {
   if (decl->isImplicit()) {
     return {};
   }
-  if (decl->isThisDeclarationADefinition()) {
+  if (decl->doesThisDeclarationHaveABody()) {
     return getInRange(decl->getTypeSpecEndLoc(),
                       decl->getBody()->getBeginLoc());
   }

--- a/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
@@ -156,6 +156,8 @@ struct DeclSerializerImpl
       // have a deleted definition." and vice versa. Thus a deleted function that
       // is virtual behaves the same as if it was not virtual.
 
+      m_builder.setDeleted();
+
       return true;
     }
     else if(decl->isDefaulted()) {

--- a/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/DeclSerializer.cpp
@@ -85,6 +85,8 @@ struct DeclSerializerImpl
     }
 
     if (isDef) {
+      assert(decl->doesThisDeclarationHaveABody());
+
       StmtNodeBuilder bodyBuilder = functionBuilder.initBody();
       m_ASTSerializer->serialize(bodyBuilder, decl->getBody());
     }
@@ -145,6 +147,29 @@ struct DeclSerializerImpl
       m_ASTSerializer->serialize(builder.initThis(), decl->getThisObjectType());
     }
     serializeFunctionDecl(builder.initFunc(), decl, true);
+  }
+
+  bool checkDefaultedOrDeleted(clang::CXXMethodDecl const * const decl) {
+    if(decl->isDeleted()) {
+      // Regarding deleted virtual functions the C++17 standard says "A function
+      // with a deleted definition shall not override a function that does not
+      // have a deleted definition." and vice versa. Thus a deleted function that
+      // is virtual behaves the same as if it was not virtual.
+
+      return true;
+    }
+    else if(decl->isDefaulted()) {
+      clang::DiagnosticsEngine &diagsEngine =
+        m_ASTSerializer->getASTContext().getDiagnostics();
+      unsigned id = diagsEngine.getCustomDiagID(
+        clang::DiagnosticsEngine::Error,
+        "Declaration of defaulted method function is not supported.");
+      diagsEngine.Report(decl->getBeginLoc(), id);
+
+      return true;
+    }
+
+    return false;
   }
 
   bool VisitFunctionDecl(const clang::FunctionDecl *decl) {
@@ -286,12 +311,20 @@ struct DeclSerializerImpl
   }
 
   bool VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
+    // Serialize method only if it is not defaulted or deleted
+    // and create error when necessary
+    if(checkDefaultedOrDeleted(decl)) return true;
+
     stubs::Decl::Method::Builder methodBuilder = m_builder.initMethod();
     serializeMethodDecl(methodBuilder, decl);
     return true;
   }
 
   bool VisitCXXConstructorDecl(const clang::CXXConstructorDecl *decl) {
+    // Serialize constructor only if it is not defaulted or deleted
+    // and create error when necessary
+    if(checkDefaultedOrDeleted(decl)) return true;
+
     stubs::Decl::Ctor::Builder ctorBuilder = m_builder.initCtor();
     // nb inits will be 1 if it delegates to another ctor
     ListBuilder<stubs::Decl::Ctor::CtorInit> initBuilders =
@@ -321,6 +354,10 @@ struct DeclSerializerImpl
   }
 
   bool VisitCXXDestructorDecl(const clang::CXXDestructorDecl *decl) {
+    // Serialize destructor only if it is not defaulted or deleted
+    // and create error when necessary
+    if(checkDefaultedOrDeleted(decl)) return true;
+
     stubs::Decl::Dtor::Builder dtorBuilder = m_builder.initDtor();
 
     stubs::Decl::Method::Builder methodBuilder = dtorBuilder.initMethod();

--- a/src/cxx_frontend/ast_exporter/NodeListSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeListSerializer.h
@@ -33,12 +33,6 @@ public:
         m_orphanage.newOrphan<stubs::Loc>(), m_orphanage.newOrphan<Stub>());
     m_serializer.serialize(item, nodeOrphan.locOrphan.get(),
                            nodeOrphan.descOrphan.get());
-
-    //if(std::is_convertible<T, clang::Decl const *>::value
-    if constexpr(std::is_same<stubs::Decl, Stub>::value) if(nodeOrphan.descOrphan.get().isUnionNotInitialized())
-    {
-      m_orphans.pop_back();
-    }
   }
 
   template <typename T> void serialize(llvm::ArrayRef<T> container) {

--- a/src/cxx_frontend/ast_exporter/NodeListSerializer.h
+++ b/src/cxx_frontend/ast_exporter/NodeListSerializer.h
@@ -33,6 +33,12 @@ public:
         m_orphanage.newOrphan<stubs::Loc>(), m_orphanage.newOrphan<Stub>());
     m_serializer.serialize(item, nodeOrphan.locOrphan.get(),
                            nodeOrphan.descOrphan.get());
+
+    //if(std::is_convertible<T, clang::Decl const *>::value
+    if constexpr(std::is_same<stubs::Decl, Stub>::value) if(nodeOrphan.descOrphan.get().isUnionNotInitialized())
+    {
+      m_orphans.pop_back();
+    }
   }
 
   template <typename T> void serialize(llvm::ArrayRef<T> container) {

--- a/src/cxx_frontend/decl_translator.ml
+++ b/src/cxx_frontend/decl_translator.ml
@@ -23,7 +23,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     else
       match D.get decl_desc with
       | UnionNotInitialized -> Error.union_no_init_err "declaration"
-      | Empty -> []
+      | Empty | Deleted -> []
       | Function f -> [ transl_func_decl loc f ]
       | Ann a -> transl_ann_decls loc a
       | Record r -> transl_record_decl loc r

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -308,6 +308,7 @@ struct Decl {
     enumDecl @13 :Enum;
     namespace @14 :Namespace;
     functionTemplate @15 :FunctionTemplate;
+    deleted @16 :Void;
   }
 }
 

--- a/tests/cxx/new_class.cpp
+++ b/tests/cxx/new_class.cpp
@@ -10,6 +10,9 @@ public:
     {
         //@ close EmptyPred(this);
     }
+
+    Empty(Empty const &) = delete;
+    Empty const & operator=(Empty const &) = delete;
     
     ~Empty()
     //@ requires EmptyPred(this);

--- a/tests/cxx/virtual_methods/virtual_methods.cpp
+++ b/tests/cxx/virtual_methods/virtual_methods.cpp
@@ -21,6 +21,8 @@ public:
   {
     //@ open valid(_);
   }
+
+  virtual A & operator=(A const &) = delete;
   
   int getI() const
   //@ requires this->m_i |-> ?i;


### PR DESCRIPTION
Till now deleted and defaulted functions caused segmentation violations during serialization because they are definitions but don't have a body. This pull request should make the serializer ignore deleted functions and create error messages for defaulted functions.

Deleted functions must not be used by the programmer and clang should already check that this is ensured. This should imply that we don't need to pass them to verifast and thus don't need to serialize them at all.

Defaulted functions are more complicated. I added an error message for them to replace the segmentation violations by hopefully expressive output.

@NielsMommen I think the most important part to look at is the change in NodeSerializer.h. Maybe you have an idea how to do better.