### PR TITLE
Allow unnamed function parameters

### DIFF
--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -297,7 +297,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         match xs with
           [] -> List.rev xm
         | (te, x)::xs ->
-          if List.mem_assoc x xm then static_error l "Duplicate parameter name." None;
+          if String.empty <> x && List.mem_assoc x xm then static_error l ("Duplicate parameter name '" ^ x ^ "'") None;
           if List.mem_assoc x tenv0 then static_error l ("Parameter '" ^ x ^ "' hides existing variable '" ^ x ^ "'.") None;
           let t = check_pure_type (pn,ilist) tparams1 Ghost te in
           let t =

--- a/tests/cxx/declarations.cpp
+++ b/tests/cxx/declarations.cpp
@@ -1,0 +1,3 @@
+void multiple_unnamed_arguments(int, int, long);
+//@ requires true;
+//@ ensures true;

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -697,6 +697,7 @@ cd tests
     verifast -c loops.cpp
     verifast -c casts.cpp
     verifast -c switch.cpp
+    verifast -c declarations.cpp
   cd ..
   cd rust
     call testsuite.mysh


### PR DESCRIPTION
I need to write header files to get support for some UNIX standard functions and there inside I used function declarations that have parameters without a name. This caused the error message "Duplicate parameter name" for those with multiple unnamed parameters. To avoid others to run into the same problem, I wrote this change request. I hope my change in _verify_expr.ml_ is the right way to solve the problem.