### PR TITLE
Update `is_permutation_reflexive` for general types

### DIFF
--- a/bin/permutations.c
+++ b/bin/permutations.c
@@ -3,7 +3,7 @@
 //@ #include "nat.gh"
 
 /*@
-lemma_auto void is_permutation_reflexive(list<int> xs) 
+lemma_auto void is_permutation_reflexive<t>(list<t> xs) 
   requires true;
   ensures is_permutation(xs, xs) == true;
 {

--- a/bin/permutations.gh
+++ b/bin/permutations.gh
@@ -13,7 +13,7 @@ fixpoint bool is_permutation<t>(list<t> xs, list<t> ys)
   }
 }
 
-lemma_auto void is_permutation_reflexive(list<int> xs);
+lemma_auto void is_permutation_reflexive<t>(list<t> xs);
   requires true;
   ensures is_permutation(xs, xs) == true;
 


### PR DESCRIPTION
Hi,

I wanted to use `is_permutation_reflexive` in `bin` but realized that it's not for general types so I got errors. Hence, I made changes to use `is_permutation_reflexive` for all types.