### PR TITLE
[Rust] atomics_example.rs

### DIFF
--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -14,6 +14,10 @@ mod intrinsics {
 
 mod mem {
 
+    fn size_of<T>() -> usize;
+    //@ req true;
+    //@ ens result == std::mem::size_of::<T>();
+
     fn drop<T>(value: T);
     //@ req thread_token(?t) &*& <T>.own(t, value);
     //@ ens thread_token(t);
@@ -226,5 +230,55 @@ mod io {
     fn stdout() -> Stdout;
     //@ req thread_token(?t);
     //@ ens thread_token(t) &*& <Stdout>.own(t, result);
+
+}
+
+mod sync {
+
+    mod atomic {
+    
+        enum Ordering {
+            SeqCst
+        }
+    
+        struct AtomicUsize;
+        
+        /*@
+        
+        lem_type AtomicUsize_fetch_add_op(self: *AtomicUsize, val: usize, P: pred(), Q: pred(usize)) = lem();
+            req *(self as *usize) |-> ?value0 &*& P();
+            ens *(self as *usize) |-> (value0 + val) % (usize::MAX + 1) &*& Q(value0);
+        
+        lem_type AtomicUsize_fetch_add_ghop(self: *AtomicUsize, val: usize, pre: pred(), post: pred(usize)) = lem();
+            req atomic_mask(MaskTop) &*& is_AtomicUsize_fetch_add_op(?op, self, val, ?P, ?Q) &*& P() &*& pre();
+            ens atomic_mask(MaskTop) &*& is_AtomicUsize_fetch_add_op(op, self, val, P, Q) &*& Q(?result) &*& post(result);
+        
+        lem_type AtomicUsize_load_op(self: *AtomicUsize, P: pred(), Q: pred(usize)) = lem();
+            req [?f](*(self as *usize) |-> ?value) &*& P();
+            ens [f](*(self as *usize) |-> value) &*& Q(value);
+        
+        lem_type AtomicUsize_load_ghop(self: *AtomicUsize, pre: pred(), post: pred(usize)) = lem();
+            req atomic_mask(MaskTop) &*& is_AtomicUsize_load_op(?op, self, ?P, ?Q) &*& P() &*& pre();
+            ens atomic_mask(MaskTop) &*& is_AtomicUsize_load_op(op, self, P, Q) &*& Q(?result) &*& post(result);
+        
+        @*/
+        
+        impl AtomicUsize {
+        
+            fn from_ptr(ptr: *mut usize) -> &AtomicUsize;
+            //@ req true;
+            //@ ens result as *mut usize == ptr;
+            
+            fn fetch_add(self: &AtomicUsize, val: usize, order: Ordering) -> usize;
+            //@ req order == std::sync::atomic::Ordering::SeqCst &*& is_AtomicUsize_fetch_add_ghop(?ghop, self, val, ?pre, ?post) &*& pre();
+            //@ ens post(result);
+        
+            fn load(self: &AtomicUsize, order: Ordering) -> usize;
+            //@ req order == std::sync::atomic::Ordering::SeqCst &*& is_AtomicUsize_load_ghop(?ghop, self, ?pre, ?post) &*& pre();
+            //@ ens post(result);
+            
+        }
+    
+    }
 
 }

--- a/src/frontend/util.ml
+++ b/src/frontend/util.ml
@@ -416,6 +416,8 @@ let cwd = Sys.getcwd()
 
 let compose base path = if Filename.is_relative path then base ^ "/" ^ path else path
 
+let smart_compose base path = if Filename.is_relative path && base <> "." then base ^ "/" ^ path else path
+
 (** Reduces './foo' to 'foo', 'foo/.' to 'foo', 'foo//' to 'foo/', and 'foo/../bar' to 'bar'. *)
 let reduce_path path =
   let path = split (fun c -> c = '/' || c = '\\') path in

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -490,6 +490,8 @@ struct Body {
                         substs @2: List(Ty.GenArg);
                         userTypeAnnotationIndex @3: Void;
                         unionActiveField @4: Void;
+                        fieldNames @6: List(Text);
+                        adtKind @7: Ty.AdtKind;
                     }
                     union {
                         array @0: Ty; #Elements type

--- a/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
@@ -267,7 +267,7 @@ pub fn preprocess(
                                         if is_block_decls {
                                             open_blocks.push(OpenBlock {
                                                 start_ghost_range_index: ghost_ranges.len(),
-                                                brace_depth: brace_depth - 1,
+                                                brace_depth: brace_depth,
                                             });
                                         }
                                         ghost_ranges.push(Box::new(GhostRange {
@@ -475,7 +475,7 @@ pub fn preprocess(
                                     if ghost_range.is_block_decls {
                                         open_blocks.push(OpenBlock {
                                             start_ghost_range_index: ghost_ranges.len(),
-                                            brace_depth: brace_depth - 1,
+                                            brace_depth: brace_depth,
                                         });
                                     }
                                     ghost_ranges.push(ghost_range);

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -3843,7 +3843,6 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | RustFe.RustFrontend msg -> raise (CompilationErrorWithDetails ("Rust frontend failed", msg))
       end
     in
-    emitter_callback ds;
     check_should_fail ([], [], [], [], [], []) $. fun () ->
     let (linker_info, _) = check_file path false true programDir headers ds dbg_info in
     linker_info
@@ -4004,7 +4003,7 @@ end
     This function is generic in the types of SMT solver types, symbols, and terms.
     *)
 let verify_program_core (* ?verify_program_core *)
-    ?(emitter_callback : package list -> unit = fun _ -> ())
+    ?(emitter_callback : string -> string -> package list -> unit = fun _ _ _ -> ())
     (type typenode') (type symbol') (type termnode')  (* Explicit type parameters; new in OCaml 3.12 *)
     (ctxt: (typenode', symbol', termnode') Proverapi.context)
     (options : options)
@@ -4083,7 +4082,7 @@ let lookup_prover prover =
   | Some (banner, f) -> f
 
 let verify_program (* ?verify_program *)
-    ?(emitter_callback : package list -> unit = fun _ -> ())
+    ?(emitter_callback : string -> string -> package list -> unit = fun _ _ _ -> ())
     (prover : string)
     (options : options)
     (path : string)

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -37,7 +37,7 @@ type callbacks = {
 let noop_callbacks = {reportRange = (fun _ _ -> ()); reportUseSite = (fun _ _ _ -> ()); reportExecutionForest = (fun _ -> ()); reportStmt = (fun _ -> ()); reportStmtExec = (fun _ -> ()); reportDirective = (fun _ _ -> false)}
 
 module type VERIFY_PROGRAM_ARGS = sig
-  val emitter_callback: package list -> unit
+  val emitter_callback: string -> string -> package list -> unit
   type typenode
   type symbol
   type termnode
@@ -74,7 +74,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
 
   let disable_overflow_check = Vfbindings.get Vfparam_disable_overflow_check vfbindings
   let fwrapv = Vfbindings.get Vfparam_fwrapv vfbindings
-  let fno_strict_aliasing = Vfbindings.get Vfparam_fno_strict_aliasing vfbindings
+  let fno_strict_aliasing = Vfbindings.get Vfparam_fno_strict_aliasing vfbindings || dialect = Some Rust
   let assume_left_to_right_evaluation = Vfbindings.get Vfparam_assume_left_to_right_evaluation vfbindings
   let assume_no_provenance = Vfbindings.get Vfparam_assume_no_provenance vfbindings
   let assume_no_subobject_provenance = Vfbindings.get Vfparam_assume_no_subobject_provenance vfbindings
@@ -1135,6 +1135,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   module CheckFile1(CheckFileArgs: CHECK_FILE_ARGS) = struct
   
   include CheckFileArgs
+
+  let () = emitter_callback filepath dir ps
 
   let assert_false h env l msg url =
     Util.push (Node (ErrorNode, ref [])) !currentForest;

--- a/tests/rust/purely_unsafe/atomics_example.rs
+++ b/tests/rust/purely_unsafe/atomics_example.rs
@@ -1,0 +1,99 @@
+use std::{ptr::null_mut, sync::atomic::{AtomicUsize, Ordering::SeqCst}};
+
+unsafe fn assert(b: bool)
+//@ req b;
+//@ ens true;
+{
+    if !b { //~allow_dead_code
+        *null_mut() = 42; //~allow_dead_code
+    }
+}
+
+/*@
+
+pred_ctor space_inv(x: *mut usize)() = [1/2](*x |-> ?value) &*& value == 0 || value == 1;
+
+pred incrementor_pre(x: *mut u8) = [_]atomic_space(MaskTop, space_inv(x as *usize)) &*& [1/2](*(x as *usize) |-> 0);
+
+@*/
+
+unsafe fn incrementor(x_: *mut u8)
+//@ req incrementor_pre(x_);
+//@ ens true;
+{
+    let x = x_ as *mut usize;
+    //@ open incrementor_pre(x_);
+    {
+        /*@
+        pred pre() = [_]atomic_space(MaskTop, space_inv(x)) &*& [1/2](*x |-> 0);
+        pred post(result: usize) = true;
+        @*/
+        /*@
+        produce_lem_ptr_chunk std::sync::atomic::AtomicUsize_fetch_add_ghop(x as *std::sync::atomic::AtomicUsize, 1, pre, post)() {
+            open pre();
+            open_atomic_space(MaskTop, space_inv(x));
+            open space_inv(x)();
+            assert std::sync::atomic::is_AtomicUsize_fetch_add_op(?op, _, _, _, _);
+            assert *x |-> ?value &*& value == 0;
+            div_rem_nonneg(value + 1, usize::MAX + 1);
+            if (value + 1) / (usize::MAX + 1) > 0 {
+            } else {
+                if (value + 1) / (usize::MAX + 1) < 0 {
+                } else {
+                }
+            }
+            op();
+            close space_inv(x)();
+            close_atomic_space(MaskTop);
+            close post(0);
+            leak [_](*x |-> _);
+        };
+        @*/
+        //@ close pre();
+        AtomicUsize::from_ptr(x as *mut usize).fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        //@ open post(_);
+    }
+}
+
+fn main() {
+    unsafe {
+        let layout = std::alloc::Layout::from_size_align_unchecked(std::mem::size_of::<usize>(), std::mem::size_of::<usize>());
+        let x = std::alloc::alloc(layout) as *mut usize;
+        if x.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+        //@ u8s__to_integer__(x, std::mem::size_of::<usize>(), false);
+        std::ptr::write(x, 0);
+        //@ produce_fn_ptr_chunk platform::threading::thread_run(incrementor)(incrementor_pre)(data) { call(); }
+        //@ close space_inv(x)();
+        //@ create_atomic_space(MaskTop, space_inv(x));
+        //@ leak atomic_space(MaskTop, space_inv(x));
+        //@ close incrementor_pre(x as *u8);
+        platform::threading::fork(incrementor as unsafe fn(*mut u8), x as *mut u8);
+        let mut x1 = 0;
+        {
+            /*@
+            pred pre() = [_]atomic_space(MaskTop, space_inv(x));
+            pred post(result: usize) = result == 0 || result == 1;
+            @*/
+            /*@
+            produce_lem_ptr_chunk std::sync::atomic::AtomicUsize_load_ghop(x as *std::sync::atomic::AtomicUsize, pre, post)() {
+                open pre();
+                open_atomic_space(MaskTop, space_inv(x));
+                open space_inv(x)();
+                assert [_](*x |-> ?value);
+                assert std::sync::atomic::is_AtomicUsize_load_op(?op, _, _, _);
+                op();
+                close space_inv(x)();
+                close_atomic_space(MaskTop);
+                close post(value);
+            };
+            @*/
+            //@ close pre();
+            x1 = AtomicUsize::from_ptr(x).load(SeqCst);
+            //@ open post(_);
+        }
+        assert(x1 == 0 || x1 == 1);
+        std::process::exit(0);
+    }
+}

--- a/tests/rust/purely_unsafe/my_option.rs
+++ b/tests/rust/purely_unsafe/my_option.rs
@@ -14,7 +14,7 @@ enum MyOptionI32 {
 
 unsafe fn eval_i32(o: MyOptionI32) -> i32
 //@ req true;
-//@ ens result == match o { MyNoneI32 => 0, MySomeI32(v) => v };
+//@ ens result == match o { MyOptionI32::MyNoneI32 => 0, MyOptionI32::MySomeI32(v) => v };
 {
     match o {
         MyOptionI32::MyNoneI32 => 0,
@@ -29,7 +29,7 @@ enum MyOption<T> {
 
 unsafe fn eval(o: MyOption<i32>) -> i32
 //@ req true;
-//@ ens result == match o { MyNone => 0, MySome(v) => v };
+//@ ens result == match o { MyOption::MyNone => 0, MyOption::MySome(v) => v };
 {
     match o {
         MyOption::MyNone => 0,

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -32,6 +32,7 @@ cd purely_unsafe
   verifast -prover z3v4.5 -target LP64 -c -extern ../unverified/platform httpd_mt.rs
   verifast -c my_option.rs
   verifast -c vec_test.rs
+  verifast -target LP64 -c -extern ../unverified/platform atomics_example.rs
 cd ..
 cd safe_abstraction
   verifast -c full_bor_primitive_types.rs


### PR DESCRIPTION
This commit:
- Starts spec'ing out AtomicUsize
- Adds an example that uses AtomicUsize
- Adds support for verifying programs that refer to variants of
  enums declared in extern crates (including std).
  This involved updates to how the exporter exports aggregates
  and changes in how enum variants are translated.
- Fixes a bug in the treatment of blocks with ghost declarations
  in the Rust preprocessor.
- Disables the strict aliasing checks when verifying Rust programs.
- Adds options -dump_asts and -dump_asts_with_locs to the
  'verifast' command-line tool
