### PR TITLE
Produce shift left fact only outside fixpoint

### DIFF
--- a/src/redux.ml
+++ b/src/redux.ml
@@ -1122,6 +1122,7 @@ and context () =
         assumes_with_more_pending_splits <- assumes_with_more_pending_splits + 1;
     
     method assert_term t =
+      if formal_depth = 0 then
       let time0 = if verbosity > 0 then begin trace_entering "Redux.assert_term(%s)" (self#pprint t); Perf.time() end else 0.0 in
       Stopwatch.start stopwatch;
       self#register_pending_splits_count;

--- a/tests/issue536.c
+++ b/tests/issue536.c
@@ -1,0 +1,5 @@
+/*@
+fixpoint int shl(int a) {
+  return a << 8;
+}
+@*/

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -467,6 +467,7 @@ cd tutorial_solutions
   verifast_both -target 32bit students.c
 cd ..
 cd tests
+  verifast -c issue536.c
   verifast -c continue.c
   verifast -c generic_points_to.c
   verifast -c struct_points_to.c


### PR DESCRIPTION
When evaluating x << N where N is a literal between 0 and 64,
VeriFast produces the fact that x << N == x * 2^N. It now does
so only when the expression occurs outside the body of a fixpoint
function.

Fixes #536
