### PR TITLE
Enforce effective types for (u)intN_t accesses

### DIFF
--- a/bin/crt.vfmanifest
+++ b/bin/crt.vfmanifest
@@ -154,6 +154,7 @@
 .provides ./prelude.h#bools_to_chars
 .provides ./prelude.h#chars_to_integers_
 .provides ./prelude.h#integers__to_chars
+.provides ./prelude.h#integers___to_chars_
 .provides ./prelude.h#uchars_to_integers_
 .provides ./prelude.h#integers__to_uchars
 .provides ./prelude.h#integers__to_integers__

--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -472,7 +472,7 @@ lemma_auto void chars_to_boolean(void *p);
     ensures [f]boolean(p, _);
 
 lemma_auto void chars_to_integer_(void *p, int size, bool signed_);
-    requires [?f]chars(p, size, ?cs) &*& has_type(p, &typeid(int)) == true;
+    requires [?f]chars(p, size, ?cs);
     ensures [f]integer_(p, size, signed_, _);
 
 // ... to chars
@@ -863,6 +863,10 @@ lemma_auto void integers__to_chars(void *p);
     ensures
         [f]chars(p, n * size, chars_of_integers(size, signed_, vs)) &*&
         integers_of_chars(size, signed_, chars_of_integers(size, signed_, vs)) == vs;
+
+lemma_auto void integers___to_chars_(void *p);
+    requires [?f]integers__(p, ?size, ?signed_, ?n, _);
+    ensures [f]chars_(p, n * size, _);
 
 lemma_auto void uchars_to_integers_(void *p, int size, bool signed_, int n);
     requires [?f]uchars(p, n * size, _);

--- a/examples/mcas/bitops_ex.vfmanifest
+++ b/examples/mcas/bitops_ex.vfmanifest
@@ -95,6 +95,7 @@
 .requires CRT/prelude.h#int_of_chars_size
 .requires CRT/prelude.h#integer__to_chars
 .requires CRT/prelude.h#integer_to_chars
+.requires CRT/prelude.h#integers___to_chars_
 .requires CRT/prelude.h#integers__inv
 .requires CRT/prelude.h#integers__to_chars
 .requires CRT/prelude.h#integers__to_integers__

--- a/tests/effective_types.c
+++ b/tests/effective_types.c
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 struct point {
   int x;
   int y;
@@ -7,6 +9,13 @@ union u {
   short x;
   int y;
 };
+
+uint32_t read_and_inc_uint32(uint32_t *p)
+//@ requires *p |-> ?value &*& value < 2000000000;
+//@ ensures *p |-> value + 1 &*& result == value;
+{
+    return (*p)++;
+}
 
 /*@
 

--- a/tests/integer__pointee_pred.c
+++ b/tests/integer__pointee_pred.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdint.h>
 
 #if UINT_MAX != UINT16_MAX || UINTPTR_MAX != UINT16_MAX
@@ -50,6 +51,10 @@ void quux()
 {
     uint32_t xs[3] = {444, 333, 222};
     //@ assert xs[..3] |-> {444, 333, 222};
+    uint32_t *ys = malloc(3 * sizeof(uint32_t));
+    if (ys == 0) abort();
+    //@ assert ys[..3] |-> _;
+    free((void *)ys);
 }
 
 void foo3(int32_t *p1, int128_t *p2)

--- a/tests/issue504.c
+++ b/tests/issue504.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include <stdint.h>
+
+void test(uint32_t *p)
+//@ requires integer_(p, 4, false, _);
+//@ ensures *p |-> _; //~should_fail
+{}
+
+int main()
+//@ requires true;
+//@ ensures false;
+{
+  int i = 0;
+  int *p = &i;
+  int16_t *q = (void *)p;
+  *p = 42;
+  //@ open integer(p, 42);
+  //@ open int_(p, some(42));
+  //@ integer__to_chars(p, 4, true);
+  //@ chars_to_integer_(q, 2, true);
+  *q = 0; //~should_fail This is Undefined Behavior. It can lead to miscompilation: https://godbolt.org/z/Yz6z1G6f5
+  //@ assert false;
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -478,6 +478,7 @@ cd tests
   verifast -c inductive_field_access.c
   verifast -c -prover z3v4.5 inductive_field_access.c
   verifast -c -target lp64 issue516.c
+  verifast -c -target lp64 -allow_should_fail issue504.c
   verifast -c issue513.c
   verifast -c issue511.c
   verifast -c issue507.c


### PR DESCRIPTION
Also, *p |-> PAT and p[PAT1..PAT2] |-> PAT3 assertions where
p is of type (u)intN_t* now assert has_type(p, &typeid((u)intN_t)) == true.

This breaking change fixes #504, an unsoundness. You can disable
effective types checks by specifying the -fno-strict-aliasing
command-line flag.
