### PR TITLE
close_struct: Check effective type

### DIFF
--- a/examples/close_struct_zero.c
+++ b/examples/close_struct_zero.c
@@ -13,6 +13,7 @@ int main(void)
     //@ assume(sizeof(Point) < UINT_MAX);
     Point *p = malloc(sizeof(Point) + 0);
     if (p == 0) abort();
+    //@ assume(has_type(p, &typeid(struct Point)));
 
     memset(p, 0, sizeof(Point));
     //@ close_struct_zero(p);

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -611,6 +611,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let (w, tp) = check_expr (pn,ilist) tparams tenv e in
       let sn, targs = match tp with PtrType (StructType (sn, targs)) -> sn, targs | _ -> static_error l "The argument of close_struct must be of type pointer-to-struct." None in
       eval_h h env w $. fun h env pointerTerm ->
+      assert_has_type env pointerTerm (StructType (sn, targs)) h env l "Cannot prove consistency with C's effective types rules" None;
       begin fun cont ->
       match dialect with
         Some Rust ->
@@ -641,6 +642,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let sn, targs = match tp with PtrType (StructType (sn, targs)) -> sn, targs | _ -> static_error l "The argument of open_struct must be of type pointer-to-struct." None in
       eval_h h env w $. fun h env pointerTerm ->
       consume_c_object_core_core l real_unit_pat pointerTerm (StructType (sn, targs)) h env true true $. fun _ h _ ->
+      assume_has_type l env pointerTerm (StructType (sn, targs)) $. fun () ->
       let cs = get_unique_var_symb "cs" (list_type (option_type charType)) in
       let Some (_, _, _, _, length_symb) = try_assoc' Ghost (pn,ilist) "length" purefuncmap in
       let size = struct_size l env sn targs in

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -2589,7 +2589,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               Some (r, s) ->
               n, (if g = "calloc" then intType else option_type intType), (if g = "calloc" then integers__symb () else integers___symb ()), malloc_block_integers__symb (), [rank_size_term r; if s = Signed then true_term else false_term], true
             | _ ->
-              arraySize, (if g = "calloc" then charType else option_type charType), (if g = "calloc" then chars_pred_symb () else chars__pred_symb ()), malloc_block_chars_pred_symb(), [], false
+              arraySize, (if g = "calloc" then charType else option_type charType), (if g = "calloc" then chars_pred_symb () else chars__pred_symb ()), malloc_block_chars_pred_symb(), [], true
           in
           assume (mk_object_pointer_within_limits result arraySize) $. fun () ->
           let values = get_unique_var_symb "values" (list_type elemTp) in

--- a/tests/effective_types.c
+++ b/tests/effective_types.c
@@ -37,3 +37,17 @@ lemma int *effective_types(void *p)
 }
 
 @*/
+
+struct foo {
+  short x;
+  short y;
+};
+
+void close_struct_test()
+//@ requires sizeof(struct foo) == sizeof(int);
+//@ ensures false;
+{
+    int i;
+    //@ int__to_chars_(&i);
+    //@ close_struct((struct foo *)&i); //~should_fail // See https://github.com/verifast/verifast/issues/540
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -277,8 +277,8 @@ cd examples
   cd ..
   cd usbkbd
     cd src
-      verifast_both -target 32bit -I . -c usbmouse.c
-      verifast -target 32bit -I . -c -prover redux usbkbd_verified.c
+      verifast_both -fno-strict-aliasing -target 32bit -I . -c usbmouse.c
+      verifast -fno-strict-aliasing -target 32bit -I . -c -prover redux usbkbd_verified.c
     cd ..
   cd ..
   cd verifythis2016
@@ -473,8 +473,8 @@ cd tests
   verifast -c struct_points_to.c
   verifast -c -allow_should_fail loop_cond_assigned_vars.java
   verifast -c -prover z3v4.5 generic_points_to.c
-  verifast -c -uppercase_type_params_carry_typeid generic_structs.c
-  verifast -c -uppercase_type_params_carry_typeid -prover z3v4.5 generic_structs.c
+  verifast -c -fno-strict-aliasing -uppercase_type_params_carry_typeid generic_structs.c
+  verifast -c -fno-strict-aliasing -uppercase_type_params_carry_typeid -prover z3v4.5 generic_structs.c
   verifast -c inductive_field_access.c
   verifast -c -prover z3v4.5 inductive_field_access.c
   verifast -c -target lp64 issue516.c


### PR DESCRIPTION
This breaking change fixes #540, an unsoundness. You can disable
this check by specifying the -fno-strict-aliasing flag.
