### PR TITLE
[Rust] Fix unsound treatment of alloc/dealloc

### DIFF
--- a/bin/prelude_rust_core.gh
+++ b/bin/prelude_rust_core.gh
@@ -1035,26 +1035,24 @@ lemma_auto void divrem_elim();
     requires [?f]divrem(?D, ?d, ?q, ?r);
     ensures [f]divrem(D, d, q, r) &*& 0 <= r &*& r < d &*& D == q * d + r;
 
-predicate alloc_block(void *p; int size);
-predicate malloc_block_integers_(void *p, int size, bool signed_; int count) = alloc_block(p, ?size_) &*& [_]divrem(size_, size, count, 0);
-predicate malloc_block_chars(char *p; int count) = alloc_block(p, count);
-predicate malloc_block_uchars(unsigned char *p; int count) = alloc_block(p, count);
-predicate malloc_block_ints(int *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(int), count, 0);
-predicate malloc_block_uints(unsigned int *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(unsigned int), count, 0);
-predicate malloc_block_shorts(short *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(short), count, 0);
-predicate malloc_block_ushorts(unsigned short *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(unsigned short), count, 0);
-predicate malloc_block_pointers(void **p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(void *), count, 0);
-predicate malloc_block_intptrs(intptr_t *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(intptr_t), count, 0);
-predicate malloc_block_uintptrs(uintptr_t *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(uintptr_t), count, 0);
-predicate malloc_block_longs(long *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(long), count, 0);
-predicate malloc_block_ulongs(unsigned long *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(unsigned long), count, 0);
-predicate malloc_block_llongs(long long *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(long long), count, 0);
-predicate malloc_block_ullongs(unsigned long long *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(unsigned long long), count, 0);
-predicate malloc_block_bools(bool *p; int count) =  alloc_block(p, ?size) &*& [_]divrem(size, sizeof(bool), count, 0);
-predicate malloc_block_floats(float *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(float), count, 0);
-predicate malloc_block_doubles(double *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(double), count, 0);
-predicate malloc_block_long_doubles(long double *p; int count) = alloc_block(p, ?size) &*& [_]divrem(size, sizeof(long double), count, 0);
-
+predicate malloc_block_integers_(void *p, int size, bool signed_; int count);
+predicate malloc_block_chars(char *p; int count);
+predicate malloc_block_uchars(unsigned char *p; int count);
+predicate malloc_block_ints(int *p; int count);
+predicate malloc_block_uints(unsigned int *p; int count);
+predicate malloc_block_shorts(short *p; int count);
+predicate malloc_block_ushorts(unsigned short *p; int count);
+predicate malloc_block_pointers(void **p; int count);
+predicate malloc_block_intptrs(intptr_t *p; int count);
+predicate malloc_block_uintptrs(uintptr_t *p; int count);
+predicate malloc_block_longs(long *p; int count);
+predicate malloc_block_ulongs(unsigned long *p; int count);
+predicate malloc_block_llongs(long long *p; int count);
+predicate malloc_block_ullongs(unsigned long long *p; int count);
+predicate malloc_block_bools(bool *p; int count);
+predicate malloc_block_floats(float *p; int count);
+predicate malloc_block_doubles(double *p; int count);
+predicate malloc_block_long_doubles(long double *p; int count);
 
 predicate string(char *s; list<char> cs) =
     character(s, ?c) &*&

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -14,9 +14,12 @@ mod intrinsics {
 
 mod mem {
 
+    //@ fix size_of_<T>() -> usize { std::mem::size_of::<T>() }
+    //@ fix align_of_<T>() -> usize;
+
     fn size_of<T>() -> usize;
     //@ req true;
-    //@ ens result == std::mem::size_of::<T>();
+    //@ ens result == std::mem::size_of_::<T>();
 
     fn drop<T>(value: T);
     //@ req thread_token(?t) &*& <T>.own(t, value);
@@ -34,7 +37,7 @@ mod ptr {
     /*@
     pred NonNull_own<T>(t: thread_id_t, v: NonNull<T>;) = NonNull_ptr(v) as usize != 0;
     pred NonNull_share<T>(k: lifetime_t, t: thread_id_t, l: *NonNull<T>);
-    fix NonNull_ptr<T>(v: NonNull<T>) -> *T;
+    fix NonNull_ptr<_T>(v: NonNull<_T>) -> *_T;
     @*/
 
     impl<T> NonNull<T> {
@@ -59,45 +62,69 @@ mod ptr {
 
 mod alloc {
 
+    struct Layout;
+    //@ fix Layout::size_(layout: Layout) -> usize;
+    //@ fix Layout::align_(layout: Layout) -> usize;
+    //@ fix Layout::from_size_align_(size: usize, align: usize) -> Layout;
+    //@ fix Layout::new_<T>() -> Layout { Layout::from_size_align_(std::mem::size_of_::<T>(), std::mem::align_of_::<T>()) }
+    
+    /*@
+    
+    lem_auto Layout_size_Layout_from_size_align(size: usize, align: usize);
+        req true;
+        ens Layout::size_(Layout::from_size_align_(size, align)) == size;
+    
+    lem_auto Layout_align_Layout_from_size_align(size: usize, align: usize);
+        req true;
+        ens Layout::align_(Layout::from_size_align_(size, align)) == align;
+    
+    @*/
+    
     impl Layout {
+    
+        fn new<T>() -> Layout;
+        //@ req true;
+        //@ ens result == Layout::new_::<T>();
 
-        fn from_size_align_unchecked(size: usize, align: usize) -> usize;
+        fn from_size_align_unchecked(size: usize, align: usize) -> Layout;
         //@ req align == 1 || align == 2 || align == 4 || align == 8 || align == 16;
-        //@ ens result == size;
+        //@ ens result == Layout::from_size_align_(size, align);
 
     }
+    
+    //@ pred alloc_block(ptr: *u8; layout: Layout);
 
-    fn alloc(size: usize) -> *u8;
-    //@ req 1 <= size;
+    fn alloc(layout: Layout) -> *u8;
+    //@ req 1 <= Layout::size_(layout);
     /*@
     ens
         if result == 0 {
             true
         } else {
-            integers__(result, 1, false, size, _) &*& alloc_block(result, size) &*&
-            object_pointer_within_limits(result, size) == true
+            integers__(result, 1, false, Layout::size_(layout), _) &*& alloc_block(result, layout) &*&
+            object_pointer_within_limits(result, Layout::size_(layout)) == true
         };
     @*/
     //@ terminates;
     
-    fn realloc(buffer: *u8, old_size: usize, new_size: usize) -> *u8;
-    //@ req integers_(buffer, 1, false, ?len, ?vs1) &*& integers__(buffer + len, 1, false, old_size - len, ?vs2) &*& alloc_block(buffer, old_size) &*& old_size <= new_size;
+    fn realloc(buffer: *u8, layout: Layout, new_size: usize) -> *u8;
+    //@ req integers_(buffer, 1, false, ?len, ?vs1) &*& integers__(buffer + len, 1, false, Layout::size_(layout) - len, ?vs2) &*& alloc_block(buffer, layout) &*& Layout::size_(layout) <= new_size;
     /*@
     ens
         if result == 0 {
-            integers_(buffer, 1, false, len, vs1) &*& integers__(buffer + len, 1, false, old_size - len, vs2) &*& alloc_block(buffer, old_size)
+            integers_(buffer, 1, false, len, vs1) &*& integers__(buffer + len, 1, false, Layout::size_(layout) - len, vs2) &*& alloc_block(buffer, layout)
         } else {
-            integers_(result, 1, false, len, vs1) &*& integers__(result + len, 1, false, old_size - len, vs2) &*&
-            integers__(result + old_size, 1, false, new_size - old_size, _) &*& alloc_block(result, new_size)
+            integers_(result, 1, false, len, vs1) &*& integers__(result + len, 1, false, Layout::size_(layout) - len, vs2) &*&
+            integers__(result + Layout::size_(layout), 1, false, new_size - Layout::size_(layout), _) &*& alloc_block(result, Layout::from_size_align_(new_size, Layout::align_(layout)))
         };
     @*/
     
-    fn dealloc(p: *u8, size: usize);
-    //@ req alloc_block(p, size) &*& integers__(p, 1, false, size, _);
+    fn dealloc(p: *u8, layout: Layout);
+    //@ req alloc_block(p, layout) &*& integers__(p, 1, false, Layout::size_(layout), _);
     //@ ens true;
     //@ terminates;
 
-    fn handle_alloc_error(layout: usize);
+    fn handle_alloc_error(layout: Layout);
     //@ req true;
     //@ ens false;
     //@ terminates;

--- a/tests/rust/purely_unsafe/account.rs
+++ b/tests/rust/purely_unsafe/account.rs
@@ -10,7 +10,7 @@ struct Account {
 /*@
 
 pred Account(account: *Account; balance: i32) =
-    alloc_block(account, std::mem::size_of::<Account>()) &*& struct_Account_padding(account) &*&
+    std::alloc::alloc_block(account as *u8, std::alloc::Layout::new_::<Account>()) &*& struct_Account_padding(account) &*&
     (*account).balance |-> balance;
 
 @*/

--- a/tests/rust/purely_unsafe/deque.rs
+++ b/tests/rust/purely_unsafe/deque.rs
@@ -16,7 +16,7 @@ pred Nodes<T>(n: *Node<T>, prev: *Node<T>, last: *Node<T>, next: *Node<T>; elems
     if n == next {
         elems == [] &*& last == prev
     } else {
-        alloc_block(n, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(n) &*&
+        std::alloc::alloc_block(n as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(n) &*&
         (*n).prev |-> prev &*&
         (*n).value |-> ?value &*&
         (*n).next |-> ?next0 &*&
@@ -28,7 +28,7 @@ lem Nodes_split_last<T>(n: *Node<T>)
     req Nodes(n, ?prev, ?last, ?next, ?elems) &*& 1 <= length(elems);
     ens
         Nodes(n, prev, ?last1, last, take(length(elems) - 1, elems)) &*&
-        alloc_block(last, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> nth(length(elems) - 1, elems) &*&
         (*last).next |-> next;
@@ -48,7 +48,7 @@ lem Nodes_split_last<T>(n: *Node<T>)
 lem Nodes_join_last<T>(n: *Node<T>)
     req
         Nodes(n, ?prev, ?last1, ?last, ?elems1) &*&
-        alloc_block(last, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> ?value &*&
         (*last).next |-> ?next &*& (*next).next |-> ?nextNext;
@@ -72,9 +72,9 @@ struct Deque<T> {
 /*@
 
 pred Deque<T>(deque: *Deque<T>; elems: list<T>) =
-    alloc_block(deque, std::mem::size_of::<Deque<T>>()) &*& struct_Deque_padding(deque) &*&
+    std::alloc::alloc_block(deque as *u8, std::alloc::Layout::new_::<Deque<T>>()) &*& struct_Deque_padding(deque) &*&
     (*deque).sentinel |-> ?sentinel &*&
-    alloc_block(sentinel, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(sentinel) &*&
+    std::alloc::alloc_block(sentinel as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(sentinel) &*&
     (*sentinel).prev |-> ?last &*&
     (*sentinel).value |-> _ &*&
     (*sentinel).next |-> ?first &*&

--- a/tests/rust/purely_unsafe/deque_i32.rs
+++ b/tests/rust/purely_unsafe/deque_i32.rs
@@ -16,7 +16,7 @@ pred Nodes(n: *Node, prev: *Node, last: *Node, next: *Node; elems: list<i32>) =
     if n == next {
         elems == [] &*& last == prev
     } else {
-        alloc_block(n, std::mem::size_of::<Node>()) &*& struct_Node_padding(n) &*&
+        std::alloc::alloc_block(n as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(n) &*&
         (*n).prev |-> prev &*&
         (*n).value |-> ?value &*&
         (*n).next |-> ?next0 &*&
@@ -28,7 +28,7 @@ lem Nodes_split_last(n: *Node)
     req Nodes(n, ?prev, ?last, ?next, ?elems) &*& 1 <= length(elems);
     ens
         Nodes(n, prev, ?last1, last, take(length(elems) - 1, elems)) &*&
-        alloc_block(last, std::mem::size_of::<Node>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> nth(length(elems) - 1, elems) &*&
         (*last).next |-> next;
@@ -48,7 +48,7 @@ lem Nodes_split_last(n: *Node)
 lem Nodes_join_last(n: *Node)
     req
         Nodes(n, ?prev, ?last1, ?last, ?elems1) &*&
-        alloc_block(last, std::mem::size_of::<Node>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> ?value &*&
         (*last).next |-> ?next &*& (*next).next |-> ?nextNext;
@@ -72,9 +72,9 @@ struct Deque {
 /*@
 
 pred Deque(deque: *Deque; elems: list<i32>) =
-    alloc_block(deque, std::mem::size_of::<Deque>()) &*& struct_Deque_padding(deque) &*&
+    std::alloc::alloc_block(deque as *u8, std::alloc::Layout::new_::<Deque>()) &*& struct_Deque_padding(deque) &*&
     (*deque).sentinel |-> ?sentinel &*&
-    alloc_block(sentinel, std::mem::size_of::<Node>()) &*& struct_Node_padding(sentinel) &*&
+    std::alloc::alloc_block(sentinel as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(sentinel) &*&
     (*sentinel).prev |-> ?last &*&
     (*sentinel).value |-> _ &*&
     (*sentinel).next |-> ?first &*&

--- a/tests/rust/purely_unsafe/httpd.rs
+++ b/tests/rust/purely_unsafe/httpd.rs
@@ -11,7 +11,7 @@ struct Buffer {
 pred Buffer_(buffer: Buffer; size: usize, length: usize) =
     size == buffer.size &*& size <= isize::MAX &*&
     length == buffer.length &*&
-    alloc_block(buffer.buffer, size) &*&
+    std::alloc::alloc_block(buffer.buffer, std::alloc::Layout::from_size_align_(size, 1)) &*&
     integers_(buffer.buffer, 1, false, length, _) &*&
     integers__(buffer.buffer + length, 1, false, size - length, _);
 

--- a/tests/rust/purely_unsafe/httpd_mt.rs
+++ b/tests/rust/purely_unsafe/httpd_mt.rs
@@ -14,7 +14,7 @@ struct Buffer {
 pred Buffer_(buffer: Buffer; size: usize, length: usize) =
     size == buffer.size &*& size <= isize::MAX &*&
     length == buffer.length &*&
-    alloc_block(buffer.buffer, size) &*&
+    std::alloc::alloc_block(buffer.buffer, std::alloc::Layout::from_size_align_(size, 1)) &*&
     integers_(buffer.buffer, 1, false, length, _) &*&
     integers__(buffer.buffer + length, 1, false, size - length, _);
 
@@ -191,7 +191,7 @@ struct Connection {
 pred_ctor mutex_inv(buffer: *mut Buffer)() = Buffer(buffer, _, _);
 
 pred Connection(connection: *mut Connection;) =
-    alloc_block(connection as *mut u8, std::mem::size_of::<Connection>()) &*&
+    std::alloc::alloc_block(connection as *mut u8, std::alloc::Layout::new_::<Connection>()) &*&
     struct_Connection_padding(connection) &*&
     (*connection).socket |-> ?socket &*& platform::sockets::Socket(socket) &*&
     (*connection).buffer |-> ?buffer &*&

--- a/tests/rust/purely_unsafe/reverse.rs
+++ b/tests/rust/purely_unsafe/reverse.rs
@@ -9,7 +9,7 @@ pred list(n: **u8; nodes: list< **u8 >) =
     if n == 0 {
         nodes == nil
     } else {
-        alloc_block(n, std::mem::size_of::< * u8>()) &*&
+        std::alloc::alloc_block(n as *u8, std::alloc::Layout::new_::< * u8>()) &*&
         *n |-> ?next &*& list(next as **u8, ?nodes1) &*& nodes == cons(n, nodes1)
     };
 

--- a/tests/rust/purely_unsafe/tree.rs
+++ b/tests/rust/purely_unsafe/tree.rs
@@ -43,7 +43,7 @@ lem_auto node_count_positive(tree: tree)
 
 pred Tree(node: *mut Tree, marked: bool; parent: *mut Tree, shape: tree) =
     node != 0 &*&
-    alloc_block(node, std::mem::size_of::<Tree>()) &*&
+    std::alloc::alloc_block(node as *u8, std::alloc::Layout::new_::<Tree>()) &*&
     struct_Tree_padding(node) &*&
     (*node).left |-> ?left &*&
     (*node).right |-> ?right &*&
@@ -75,7 +75,7 @@ pred stack(parent: *mut Tree, current: *mut Tree, cShape: tree, root: *mut Tree,
         stepsLeft == 0
     } else {
         parent != 0 &*&
-        alloc_block(parent, std::mem::size_of::<Tree>()) &*&
+        std::alloc::alloc_block(parent as *u8, std::alloc::Layout::new_::<Tree>()) &*&
         struct_Tree_padding(parent) &*&
         (*parent).left |-> ?left &*&
         (*parent).right |-> ?right &*&

--- a/tests/rust/purely_unsafe/tree2.rs
+++ b/tests/rust/purely_unsafe/tree2.rs
@@ -67,7 +67,7 @@ lem_auto node_count_positive(tree: tree)
 
 pred Tree(node: *mut Tree; parent: *mut Tree, shape: tree) =
     node != 0 &*&
-    alloc_block(node, std::mem::size_of::<Tree>()) &*&
+    std::alloc::alloc_block(node as *u8, std::alloc::Layout::new_::<Tree>()) &*&
     struct_Tree_padding(node) &*&
     node as usize & 1 == 0 &*&
     pointer_within_limits(node as *mut u8 + 1) == true &*&
@@ -104,7 +104,7 @@ pred stack(parent: *mut Tree, current: *mut Tree, cShape: tree, root: *mut Tree,
         stepsLeft == 0 &*&
         countTodo == 0
     } else {
-        alloc_block(parent, std::mem::size_of::<Tree>()) &*&
+        std::alloc::alloc_block(parent as *u8, std::alloc::Layout::new_::<Tree>()) &*&
         struct_Tree_padding(parent) &*&
         parent as usize & 1 == 0 &*&
         pointer_within_limits(parent as *mut u8 + 1) == true &*&

--- a/tests/rust/purely_unsafe/tree3.rs
+++ b/tests/rust/purely_unsafe/tree3.rs
@@ -75,7 +75,7 @@ lem_auto node_count_positive(tree: tree)
 
 pred Tree(node: *mut Tree; parent: *mut Tree, shape: tree) =
     node != 0 &*&
-    alloc_block(node, std::mem::size_of::<Tree>()) &*&
+    std::alloc::alloc_block(node as *u8, std::alloc::Layout::new_::<Tree>()) &*&
     struct_Tree_padding(node) &*&
     node as usize & 1 == 0 &*&
     pointer_within_limits(node as *mut u8 + 1) == true &*&
@@ -113,7 +113,7 @@ pred stack(parent: *mut Tree, current: *mut Tree, cShape: tree, root: *mut Tree,
         stepsLeft == 0 &*&
         elems_todo == []
     } else {
-        alloc_block(parent, std::mem::size_of::<Tree>()) &*&
+        std::alloc::alloc_block(parent as *u8, std::alloc::Layout::new_::<Tree>()) &*&
         struct_Tree_padding(parent) &*&
         parent as usize & 1 == 0 &*&
         pointer_within_limits(parent as *mut u8 + 1) == true &*&

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -77,7 +77,7 @@ pred Nodes<T>(n: *Node<T>, prev: *Node<T>, last: *Node<T>, next: *Node<T>; nodes
     if n == next {
         nodes == [] &*& last == prev
     } else {
-        alloc_block(n, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(n) &*&
+        std::alloc::alloc_block(n as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(n) &*&
         (*n).prev |-> prev &*&
         (*n).next |-> ?next0 &*&
         Nodes(next0, n, last, next, ?nodes0) &*&
@@ -88,7 +88,7 @@ lem Nodes_split_last<T>(n: *Node<T>)
     req Nodes(n, ?prev, ?last, ?next, ?nodes) &*& 1 <= length(nodes);
     ens
         Nodes(n, prev, ?last1, last, take(length(nodes) - 1, nodes)) &*&
-        alloc_block(last, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).next |-> next &*&
         append(take(length(nodes) - 1, nodes), [last]) == nodes;
@@ -108,7 +108,7 @@ lem Nodes_split_last<T>(n: *Node<T>)
 lem Nodes_join_last<T>(n: *Node<T>)
     req
         Nodes(n, ?prev, ?last1, ?last, ?nodes1) &*&
-        alloc_block(last, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).next |-> ?next &*& (*next).next |-> ?nextNext;
     ens
@@ -140,7 +140,7 @@ pred_ctor Deque_full_borrow_content<T>(t: thread_id_t, deque: *Deque<T>)() =
 /*@
 
 pred Deque__<T>(sentinel: *Node<T>; nodes: list<*Node<T>>) =
-    alloc_block(sentinel, std::mem::size_of::<Node<T>>()) &*& struct_Node_padding(sentinel) &*&
+    std::alloc::alloc_block(sentinel as *u8, std::alloc::Layout::new_::<Node<T>>()) &*& struct_Node_padding(sentinel) &*&
     (*sentinel).prev |-> ?last &*&
     (*sentinel).value |-> _ &*&
     (*sentinel).next |-> ?first &*&

--- a/tests/rust/safe_abstraction/deque_i32.rs
+++ b/tests/rust/safe_abstraction/deque_i32.rs
@@ -10,7 +10,7 @@ pred Nodes(n: *Node, prev: *Node, last: *Node, next: *Node; elems: list<i32>) =
     if n == next {
         elems == [] &*& last == prev
     } else {
-        alloc_block(n, std::mem::size_of::<Node>()) &*& struct_Node_padding(n) &*&
+        std::alloc::alloc_block(n as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(n) &*&
         (*n).prev |-> prev &*&
         (*n).value |-> ?value &*&
         (*n).next |-> ?next0 &*&
@@ -22,7 +22,7 @@ lem Nodes_split_last(n: *Node)
     req Nodes(n, ?prev, ?last, ?next, ?elems) &*& 1 <= length(elems);
     ens
         Nodes(n, prev, ?last1, last, take(length(elems) - 1, elems)) &*&
-        alloc_block(last, std::mem::size_of::<Node>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> nth(length(elems) - 1, elems) &*&
         (*last).next |-> next;
@@ -42,7 +42,7 @@ lem Nodes_split_last(n: *Node)
 lem Nodes_join_last(n: *Node)
     req
         Nodes(n, ?prev, ?last1, ?last, ?elems1) &*&
-        alloc_block(last, std::mem::size_of::<Node>()) &*& struct_Node_padding(last) &*&
+        std::alloc::alloc_block(last as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(last) &*&
         (*last).prev |-> last1 &*&
         (*last).value |-> ?value &*&
         (*last).next |-> ?next &*& (*next).next |-> ?nextNext;
@@ -70,7 +70,7 @@ pred Deque_full_borrow_content(t: thread_id_t, deque: *Deque) =
 
 /*@
 pred Deque_(sentinel: *Node; elems: list<i32> ) =
-    alloc_block(sentinel, std::mem::size_of::<Node>()) &*& struct_Node_padding(sentinel) &*&
+    std::alloc::alloc_block(sentinel as *u8, std::alloc::Layout::new_::<Node>()) &*& struct_Node_padding(sentinel) &*&
     (*sentinel).prev |-> ?last &*&
     (*sentinel).value |-> _ &*&
     (*sentinel).next |-> ?first &*&

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -24,7 +24,7 @@ pred_ctor dlft_pred(dk: lifetime_t)(gid: usize; destroyed: bool) = ghost_cell(gi
 pred_ctor rc_na_inv<T>(dk: lifetime_t, gid: usize, ptr: *RcBox<T>, t: thread_id_t)() =
     counting(dlft_pred(dk), gid, ?sn, ?destroyed) &*& if destroyed { true } else {
         (*ptr).strong |-> sn &*& sn >= 1 &*&
-        alloc_block(ptr, std::mem::size_of::<RcBox<T>>()) &*& struct_RcBox_padding::<T>(ptr) &*&
+        std::alloc::alloc_block(ptr as *u8, std::alloc::Layout::new_::<RcBox<T>>()) &*& struct_RcBox_padding::<T>(ptr) &*&
         borrow_end_token(dk, <T>.full_borrow_content(t, &(*ptr).value))
     };
 

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -12,7 +12,7 @@ pred_ctor dlft_pred(dk: lifetime_t)(gid: usize; destroyed: bool) = ghost_cell(gi
 pred_ctor rc_na_inv(dk: lifetime_t, gid: usize, ptr: *RcBoxU32, t: thread_id_t)() =
     counting(dlft_pred(dk), gid, ?sn, ?destroyed) &*& if destroyed { true } else {
         (*ptr).strong |-> sn &*& sn >= 1 &*&
-        alloc_block(ptr, std::mem::size_of::<RcBoxU32>()) &*& struct_RcBoxU32_padding(ptr) &*&
+        std::alloc::alloc_block(ptr as *u8, std::alloc::Layout::new_::<RcBoxU32>()) &*& struct_RcBoxU32_padding(ptr) &*&
         borrow_end_token(dk, u32_full_borrow_content(t, &(*ptr).value))
     };
 

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -70,7 +70,7 @@ lem_auto node_count_positive(tree: tree)
 
 pred Tree(node: *mut Node; parent: *mut Node, shape: tree) =
     node != 0 &*&
-    alloc_block(node, std::mem::size_of::<Node>()) &*&
+    std::alloc::alloc_block(node as *u8, std::alloc::Layout::new_::<Node>()) &*&
     struct_Node_padding(node) &*&
     node as usize & 1 == 0 &*&
     pointer_within_limits(node as *mut u8 + 1) == true &*&
@@ -108,7 +108,7 @@ pred stack(parent: *mut Node, current: *mut Node, cShape: tree, root: *mut Node,
         stepsLeft == 0 &*&
         elems_todo == []
     } else {
-        alloc_block(parent, std::mem::size_of::<Node>()) &*&
+        std::alloc::alloc_block(parent as *u8, std::alloc::Layout::new_::<Node>()) &*&
         struct_Node_padding(parent) &*&
         parent as usize & 1 == 0 &*&
         pointer_within_limits(parent as *mut u8 + 1) == true &*&


### PR DESCRIPTION
The spec now takes alignment into account.

Also:
- Remove special-casing of type Layout
- Add support for fixpoints with type parameters that carry a typeid.
- In Rust, try to interpret compound paths as relative to the current module, if interpreting as absolute fails.
