### PR TITLE
[Rust] Start adding spec for Box

### DIFF
--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -149,6 +149,42 @@ mod alloc {
     
 }
 
+mod boxed {
+
+    struct Box<T, A>;
+    
+    /*@
+    
+    pred Box<T, A>(self: Box<T, A>, value: T);
+    
+    lem Box_to_own<T, A>(self: Box<T, A>);
+        req thread_token(?t) &*& Box::<T, A>(self, ?value) &*& <T>.own(t, value);
+        ens thread_token(t) &*& <Box<T, A>>.own(t, self);
+    
+    @*/
+
+    impl<T> Box<T> {
+    
+        fn new(x: T) -> Box<T, std::alloc::Global>;
+        //@ req true;
+        //@ ens Box(result, x);
+        
+        fn from_raw(x: *T) -> Box<T, std::alloc::Global>;
+        //@ req *x |-> ?value &*& std::alloc::alloc_block(x as *u8, std::alloc::Layout::new_::<T>());
+        //@ ens Box(result, value);
+        
+    }
+    
+    impl<T, A> Box<T, A> {
+    
+        fn into_raw(b: Box<T, std::alloc::Global>) -> *T;
+        //@ req Box(b, ?value);
+        //@ ens *result |-> value &*& std::alloc::alloc_block(result as *u8, std::alloc::Layout::new_::<T>()) &*& result as usize != 0;
+    
+    }
+
+}
+
 mod process {
     fn abort();
     //@ req true;

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -234,6 +234,7 @@ struct Ty {
         isLocal @5: Bool;
         hirGenerics @6: Hir.Generics;
         predicates @7: List(Predicate);
+        implementsDrop @8: Bool;
     }
 
     struct AdtTy {

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -855,7 +855,7 @@ mod vf_mir_builder {
         fn encode_adt_def(
             tcx: TyCtxt<'tcx>,
             enc_ctx: &mut EncCtx<'tcx, 'a>,
-            adt_def: &ty::AdtDef,
+            adt_def: &ty::AdtDef<'tcx>,
             mut adt_def_cpn: adt_def_cpn::Builder<'_>,
         ) {
             debug!("Encoding ADT definition {:?}", adt_def);
@@ -891,6 +891,7 @@ mod vf_mir_builder {
             adt_def_cpn.fill_predicates(predicates, |pred_cpn, pred| {
                 Self::encode_predicate(enc_ctx, pred, pred_cpn);
             });
+            adt_def_cpn.set_implements_drop(adt_def.has_dtor(tcx));
         }
 
         fn encode_adt_kind(adt_kind: ty::AdtKind, mut adt_kind_cpn: adt_kind_cpn::Builder<'_>) {

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -605,6 +605,24 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       consume_c_object_core_core l real_unit_pat vp memberType h env true true $. fun _ h _ ->
       let cs = get_unique_var_symb "cs" (list_type (option_type charType)) in
       cont (Chunk ((chars__pred_symb (), true), [], real_unit, [target; sizeof_core l env memberType; cs], None)::h) env
+    | ExprStmt (CallExpr (l, "open_generic_points_to", targs, [], args, Static)) when language = CLang ->
+      require_pure();
+      let e = match (targs, args) with ([], [LitPat e]) -> e | _ -> static_error l "open_generic_points_to expects no type argument and one argument." None in
+      let (w, tp) = check_expr (pn,ilist) tparams tenv e in
+      let pointeeType = match tp with PtrType tp -> tp | _ -> static_error l "The argument of open_generic_points_to must be a pointer." None in
+      eval_h h env w $. fun h env pointerTerm ->
+      with_context (Executing (h, env, l, "Consuming generic_points_to chunk")) $. fun () ->
+      consume_chunk rules h env ghostenv [] [] l (generic_points_to_symb (), true) [pointeeType] real_unit dummypat (Some 1) [TermPat pointerTerm; SrcPat DummyPat] $. fun _ h coef [_; value] _ _ _ _ ->
+      produce_c_object l coef pointerTerm pointeeType eval_h (Term value) false true h env cont
+    | ExprStmt (CallExpr (l, "close_generic_points_to", targs, [], args, Static)) when language = CLang ->
+      require_pure();
+      let e = match (targs, args) with ([], [LitPat e]) -> e | _ -> static_error l "close_generic_points_to expects no type argument and one argument." None in
+      let (w, tp) = check_expr (pn,ilist) tparams tenv e in
+      let pointeeType = match tp with PtrType tp -> tp | _ -> static_error l "The argument of close_generic_points_to must be a pointer." None in
+      eval_h h env w $. fun h env pointerTerm ->
+      with_context (Executing (h, env, l, "Consuming object")) $. fun () ->
+      consume_c_object_core_core l real_unit_pat pointerTerm pointeeType h env true false $. fun _ h (Some value) ->
+      cont (Chunk ((generic_points_to_symb (), true), [pointeeType], real_unit, [pointerTerm; value], None)::h) env
     | ExprStmt (CallExpr (l, ("close_struct" | "close_struct_zero" as name), targs, [], args, Static)) when language = CLang ->
       require_pure ();
       let e = match (targs, args) with ([], [LitPat e]) -> e | _ -> static_error l "close_struct expects no type arguments and one argument." None in

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -6884,7 +6884,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let ctor_pts' = instantiate_types tpenv (List.map snd ctor_ps') in
             let pred_type = PredType ([], ctor_pts', inputParamCount, Inductiveness_Inductive) in
             let rhs_type = List.fold_right (fun pt ctp -> PureFuncType (pt, ctp)) ctor_pts pred_type in
-            expect_type l (Some true) rhs_type predType';
+            expect_type lrhs (Some true) rhs_type predType';
             ctxt#begin_formal;
             let targs_env = List.mapi (fun i x -> (x ^ "_typeid", ctxt#mk_bound i ctxt#type_inductive)) tparams in
             let targs = List.map snd targs_env in
@@ -6896,7 +6896,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             ctxt#assume_forall (Printf.sprintf "type_pred_def_%s_%s" predName rhs) [typePredTerm] (List.map (fun x -> ctxt#type_inductive) tparams) eq;
             iter ds
           | None ->
-            static_error l "No such predicate constructor" None
+            static_error lrhs "No such predicate constructor" None
           end
       | _::ds ->
         iter ds

--- a/tests/rust/purely_unsafe/account_with_box.rs
+++ b/tests/rust/purely_unsafe/account_with_box.rs
@@ -1,0 +1,84 @@
+unsafe fn assert(b: bool)
+//@ req b;
+//@ ens true;
+{}
+
+struct Account {
+    balance: i32
+}
+
+/*@
+
+pred Account(account: *Account; balance: i32) =
+    std::alloc::alloc_block(account as *u8, std::alloc::Layout::new_::<Account>()) &*& struct_Account_padding(account) &*&
+    (*account).balance |-> balance;
+
+pred Account_own(t: thread_id_t, balance: i32) = true;
+pred Account_share(k: lifetime_t, t: thread_id_t, l: *Account) = true;
+
+lem Account_share_full(k: lifetime_t, t: thread_id_t, l: *Account)
+    req full_borrow(k, Account_full_borrow_content(t, l));
+    ens [_]Account_share(k, t, l);
+{
+    close Account_share(k, t, l);
+    leak full_borrow(_, _) &*& Account_share(k, t, l);
+}
+
+lem Account_share_mono(k1: lifetime_t, k2: lifetime_t, t: thread_id_t, l: *Account)
+    req [_]Account_share(k1, t, l);
+    ens [_]Account_share(k2, t, l);
+{
+    close Account_share(k2, t, l);
+    leak Account_share(k2, t, l);
+}
+
+@*/
+
+impl Account {
+
+    unsafe fn new() -> *mut Account
+    //@ req true;
+    //@ ens Account(result, 0);
+    {
+        let result = Box::into_raw(Box::new(Account { balance: 0 }));
+        //@ open_generic_points_to(result);
+        result
+    }
+
+    unsafe fn get_balance(account: *mut Account) -> i32
+    //@ req Account(account, ?balance);
+    //@ ens Account(account, balance) &*& result == balance;
+    {
+        return (*account).balance;
+    }
+
+    unsafe fn deposit(account: *mut Account, amount: i32)
+    //@ req Account(account, ?balance) &*& 0 <= amount &*& balance + amount <= 2000000000;
+    //@ ens Account(account, balance + amount);
+    {
+        (*account).balance += amount;
+    }
+
+    unsafe fn dispose(account: *mut Account)
+    //@ req thread_token(?t) &*& Account(account, ?balance);
+    //@ ens thread_token(t);
+    {
+        //@ close_generic_points_to(account);
+        //@ assert *account |-> ?value;
+        let b = Box::from_raw(account);
+        //@ close Account_own(t, value.balance);
+        //@ close Account_own_(t, value);
+        //@ std::boxed::Box_to_own(b);
+        std::mem::drop(b);
+    }
+
+}
+
+fn main() {
+    unsafe {
+        let account = Account::new();
+        Account::deposit(account, 1000);
+        assert(Account::get_balance(account) == 1000);
+        Account::dispose(account);
+    }
+}

--- a/tests/rust/safe_abstraction/cell.rs
+++ b/tests/rust/safe_abstraction/cell.rs
@@ -127,3 +127,12 @@ impl<T> Cell<T> {
         //@ close thread_token(_t);
     }
 }
+
+impl<T> Drop for Cell<T> {
+
+    fn drop<'a>(self: &'a mut Cell<T>) {
+        //@ open Cell_full_borrow_content::<T>(_t, self)();
+        //@ open Cell_own::<T>(_t, ?v);
+    }
+
+}

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -15,6 +15,12 @@ About the definitions:
 
 pred SysMutex(m: sys::locks::Mutex; P: pred());
 pred SysMutex_share(l: *sys::locks::Mutex; P: pred());
+pred sys::locks::Mutex_own(t: thread_id_t, m: *u32);
+
+lem SysMutex_to_own(t: thread_id_t, m: sys::locks::Mutex);
+    req SysMutex(m, _);
+    ens sys::locks::Mutex_own(t, m.m);
+
 lem SysMutex_share_full(l: *sys::locks::Mutex);
     req *l |-> ?m &*& SysMutex(m, ?P);
     ens SysMutex_share(l, P);
@@ -107,6 +113,14 @@ pub struct MutexU32 {
 
 pred True(;) = true;
 pred MutexU32_own(t: thread_id_t, inner: sys::locks::Mutex, data: u32) = SysMutex(inner, True);
+
+lem MutexU32_drop()
+    req MutexU32_own(?t, ?inner, ?data);
+    ens sys::locks::Mutex_own(t, inner.m);
+{
+    open MutexU32_own(t, inner, data);
+    SysMutex_to_own(t, inner);
+}
 
 pred_ctor MutexU32_fbc_inner(l: *MutexU32)(;) = (*l).inner |-> ?inner &*& SysMutex(inner, True) &*& struct_MutexU32_padding(l);
 

--- a/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
+++ b/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
@@ -15,6 +15,12 @@ About the definitions:
 
 pred SysMutex(m: sys::locks::Mutex; P: pred());
 pred SysMutex_share(l: *sys::locks::Mutex; P: pred());
+pred sys::locks::Mutex_own(t: thread_id_t, m: *u32);
+
+lem SysMutex_to_own(t: thread_id_t, m: sys::locks::Mutex);
+    req SysMutex(m, _);
+    ens sys::locks::Mutex_own(t, m.m);
+
 lem SysMutex_share_full(l: *sys::locks::Mutex);
     req *l |-> ?m &*& SysMutex(m, ?P);
     ens SysMutex_share(l, P);
@@ -107,6 +113,14 @@ pub struct MutexU32 {
 
 pred True(;) = true;
 pred MutexU32_own(t: thread_id_t, inner: sys::locks::Mutex, data: u32) = SysMutex(inner, True);
+
+lem MutexU32_drop()
+    req MutexU32_own(?t, ?inner, ?data);
+    ens sys::locks::Mutex_own(t, inner.m);
+{
+    open MutexU32_own(t, inner, data);
+    SysMutex_to_own(t, inner);
+}
 
 pred_ctor MutexU32_fbc_inner(l: *MutexU32)(;) = (*l).inner |-> ?inner &*& SysMutex(inner, True) &*& struct_MutexU32_padding(l);
 

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -14,6 +14,7 @@ cd purely_unsafe
   verifast -c alloc.rs
   verifast -c reverse.rs
   verifast -c account.rs
+  verifast -c account_with_box.rs
   verifast -c deque_i32.rs
   verifast -c deque.rs
   verifast -c strlen.rs


### PR DESCRIPTION
Box can now be used instead of alloc/dealloc in certain cases.

Also:
- Add open_generic_points_to and close_generic_points_to ghost commands
- Define <S>.own and <S>.share for structs S for which custom S_own or S_share predicates are defined and that have no type parameters or lifetime parameters. Additionally, if the fields of such a struct are not trivially droppable and it does not implement the Drop trait, an S_drop proof obligation is now generated to enforce that ownership of S implies ownership of its fields.
