### PR TITLE
[Rust] Use 'points_to<T>' and 'array<T>' only

### DIFF
--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -11,7 +11,7 @@ struct std_tuple_0_ {}
 
 struct slice_ref<T> { ptr: *T, len: usize }
 
-struct str_ref { ptr: *_, len: usize }
+struct str_ref { ptr: *u8, len: usize }
 
 /*@
 

--- a/bin/rust/prelude_core.rsspec
+++ b/bin/rust/prelude_core.rsspec
@@ -115,184 +115,19 @@ fix ptr_add_(p: pointer, offset: i32, elemTypeid: *_) -> pointer {
     ptr_add(p, offset * std::mem::size_of(elemTypeid))
 }   
 
-pred generic_points_to_<t>(p: *t; v: option<t>);
-pred generic_points_to<t>(p: *t; v: t) = generic_points_to_::<t>(p, some(v));
+pred points_to_<t>(p: *t; v: option<t>);
+pred points_to<t>(p: *t; v: t) = points_to_::<t>(p, some(v));
 
-pred integer__(p: *_, size: i32, signed: bool; v: option<i32>);
-pred integer_(p: *_, size: i32, signed: bool; v: i32) = integer__(p, size, signed, some(v));
-
-pred pointer_(pp: **_; p: option<*_>);
-pred pointer(pp: **_; p: *_) = pointer_(pp, some(p));
-
-pred bool_(p: *bool; v: option<bool>);
-pred boolean(p: *bool; v: bool) = bool_(p, some(v));
-
-pred isize_(p: *isize; v: option<isize>) = integer__(p, std::mem::size_of::<isize>(), true, v) &*& has_type(p, typeid(isize)) == true;
-pred usize_(p: *usize; v: option<usize>) = integer__(p, std::mem::size_of::<usize>(), false, v) &*& has_type(p, typeid(usize)) == true;
-
-pred isize(p: *isize; v: isize) = isize_(p, some(v));
-pred usize(p: *usize; v: usize) = usize_(p, some(v));
-
-lem generic_points_to_limits<T>(p: *T);
-    req [?f]generic_points_to(p, ?v);
-    ens [f]generic_points_to(p, v) &*& object_pointer_within_limits(p, std::mem::size_of::<T>()) == true;
-
-lem integer__distinct(i: *_, j: *_);
-    req integer_(i, ?size1, ?signed1, ?v1) &*& integer_(j, ?size2, ?signed2, ?v2);
-    ens integer_(i, size1, signed1, v1) &*& integer_(j, size2, signed2, v2) &*& i as usize != j as usize;
-
-lem integer___unique(p: *_);
-    req [?f]integer__(p, ?size, ?signed, ?v);
-    ens [f]integer__(p, size, signed, v) &*& f <= 1;
-
-lem integer__unique(p: *_);
-    req [?f]integer_(p, ?size, ?signed, ?v);
-    ens [f]integer_(p, size, signed, v) &*& f <= 1;
-
-lem integer__limits(p: *_);
-    req [?f]integer_(p, ?size, ?signed, ?v);
-    ens [f]integer_(p, size, signed, v) &*& object_pointer_within_limits(p, size) == true &*& size > 0 &*& if signed { -(1<<(8*size-1)) <= v &*& v < (1<<(8*size-1)) } else { 0 <= v &*& v < (1<<(8*size)) };
-
-lem integer___limits(p: *_);
-    req [?f]integer__(p, ?size, ?signed, ?v);
-    ens [f]integer__(p, size, signed, v) &*& object_pointer_within_limits(p, size) == true &*& size > 0;
-
-pred bools_(p: *bool, count: i32; vs: list<option<bool>>) =
-    if count == 0 {
-        vs == nil 
-    } else {
-        bool_(p, ?v) &*& bools_(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0)
-    };
-    
-pred bools(p: *bool, count: i32; vs: list<bool>) =
-    if count == 0 {
-        vs == nil
-    } else {
-        boolean(p, ?v) &*& bools(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0)
-    };
-
-lem_auto bools_inv();
-    req [?f]bools(?p, ?count, ?vs); 
-    ens [f]bools(p, count, vs) &*& count == length(vs);
-
-pred integers__(p: *_, size: i32, signed: bool, count: i32; vs: list<option<i32> >) =
-    pointer_within_limits(p) == true &*&
-    if count == 0 {
-        vs == nil
-    } else {
-        integer__(p, size, signed, ?v0) &*& integers__(p + size, size, signed, count - 1, ?vs0) &*& vs == cons(v0, vs0)
-    };
-
-pred integers_(p: *_, size: i32, signed: bool, count: i32; vs: list<i32>) =
-    pointer_within_limits(p) == true &*&
-    if count == 0 {
-        vs == nil
-    } else {
-        integer_(p, size, signed, ?v0) &*& integers_(p + size, size, signed, count - 1, ?vs0) &*& vs == cons(v0, vs0)
-    };
-
-lem_auto integers__inv();
-    req [?f]integers_(?p, ?size, ?signed, ?count, ?vs);
-    ens [f]integers_(p, size, signed, count, vs) &*& length(vs) == count &*& pointer_within_limits(p + size * count) == true;
-
-lem_auto integers___inv();
-    req [?f]integers__(?p, ?size, ?signed, ?count, ?vs);
-    ens [f]integers__(p, size, signed, count, vs) &*& length(vs) == count &*& pointer_within_limits(p) && pointer_within_limits(p + size * count);
-
-lem integers__split(p: *_, offset: i32);
-    req [?f]integers_(p, ?size, ?signed, ?count, ?vs) &*& 0 <= offset &*& offset <= count;
-    ens
-        [f]integers_(p, size, signed, offset, take(offset, vs)) &*&
-        [f]integers_(p + size * offset, size, signed, count - offset, drop(offset, vs)) &*&
-        vs == append(take(offset, vs), drop(offset, vs)); 
-
-lem integers___split(p: *_, offset: i32);
-    req [?f]integers__(p, ?size, ?signed, ?count, ?vs) &*& 0 <= offset &*& offset <= count;
-    ens 
-        [f]integers__(p, size, signed, offset, take(offset, vs)) &*&
-        [f]integers__(p + size * offset, size, signed, count - offset, drop(offset, vs)) &*&
-        vs == append(take(offset, vs), drop(offset, vs));
-
-lem integers__join(p: *_);
-    req
-        [?f]integers_(p, ?size, ?signed, ?count1, ?vs1) &*&
-        [f]integers_(p + size * count1, size, signed, ?count2, ?vs2);
-    ens [f]integers_(p, size, signed, count1 + count2, append(vs1, vs2));
-
-lem integers___join(p: *_);
-    req
-        [?f]integers__(p, ?size, ?signed, ?count1, ?vs1) &*&
-        [f]integers__(p + size * count1, size, signed, ?count2, ?vs2);
-    ens [f]integers__(p, size, signed, count1 + count2, append(vs1, vs2));
-
-lem_auto integers__to_integers__(p: *_);
-    req [?f]integers_(p, ?size, ?signed, ?count, ?vs);
-    ens [f]integers__(p, size, signed, count, map(some, vs));
-
-pred pointers(pp: **_, count: i32; ps: list<*_>) =
-    if count == 0 {
-        ps == nil
-    } else {
-        pointer(pp, ?p) &*& pointers(pp + 1, count - 1, ?ps0) &*& ps == cons(p, ps0)
-    };
-
-pred pointers_(pp: **_, count: i32; ps: list<option<*_>>) =
-    if count == 0 {
-        ps == nil
-    } else {
-        pointer_(pp, ?p) &*& pointers_(pp + 1, count - 1, ?ps0) &*& ps == cons(p, ps0)
-    };
-
-pred isizes(p: *isize, count: i32; vs: list<isize>) =
-    if count == 0 {
-        vs == nil
-    } else {
-        isize(p, ?v) &*& isizes(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0)
-    };
-
-pred isizes_(p: *isize, count: i32; vs: list<option<isize>>) =
-    if count == 0 {
-        vs == nil
-    } else {
-        isize_(p, ?v) &*& isizes_(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0)
-    };
-
-pred usizes(p: *usize, count: i32; vs: list<usize>) =
-    if count == 0 {
-        vs == nil
-    } else {
-        usize(p, ?v) &*& usizes(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0)
-    };
-
-pred usizes_(p: *usize, count: i32; vs: list<option<usize>>) =
-    if count == 0 {
-        vs == nil
-    } else {
-        usize_(p, ?v) &*& usizes_(p + 1, count - 1, ?vs0) &*& vs == cons(v, vs0)
-    };
-
-lem u8s__to_integer__(p: *_, size: i32, signed: bool);
-    req [?f]integers__(p, 1, false, size, _);
-    ens [f]integer__(p, size, signed, _);
-
-lem_auto u8s__to_pointer_(p: *_);
-    req [?f]integers__(p, 1, false, std::mem::size_of::<*_>(), _);
-    ens [f]pointer_(p, _); 
-
-lem integer__to_u8s(p: *_, size: i32, signed: bool);
-    req [?f]integer_(p, size, signed, _);
-    ens [f]integers_(p, 1, false, size, _);
-
-lem_auto pointer_to_u8s(p: *_);
-    req [?f]pointer(p, _);
-    ens [f]integers_(p, 1, false, std::mem::size_of::<*_>(), _);
+lem points_to_limits<T>(p: *T);
+    req [?f]points_to(p, ?v);
+    ens [f]points_to(p, v) &*& object_pointer_within_limits(p, std::mem::size_of::<T>()) == true;
 
 pred array_<T>(p: *T, count: i32; values: list<option<T>>) =
     pointer_within_limits(p) == true &*&
     if count == 0 {
         values == nil
     } else {
-        generic_points_to_(p, ?value) &*& array_(p + 1, count - 1, ?values0) &*& values == cons(value, values0)
+        points_to_(p, ?value) &*& array_(p + 1, count - 1, ?values0) &*& values == cons(value, values0)
     };
 
 pred array<T>(p: *T, count: i32; values: list<T>) =
@@ -302,26 +137,60 @@ pred array<T>(p: *T, count: i32; values: list<T>) =
     } else {
         *p |-> ?value &*& array(p + 1, count - 1, ?values0) &*& values == cons(value, values0)
     };
+
+lem_auto array__inv<T>();
+    req [?f]array_::<T>(?p, ?count, ?elems);
+    ens [f]array_::<T>(p, count, elems) &*& count == length(elems) &*& pointer_within_limits(p) == true &*& pointer_within_limits(p + count) == true;
     
 lem_auto array_inv<T>();
     req [?f]array::<T>(?p, ?count, ?elems);
     ens [f]array::<T>(p, count, elems) &*& count == length(elems) &*& pointer_within_limits(p) == true &*& pointer_within_limits(p + count) == true;
-    
-lem u8_array__to_integers__(p: *u8);
-    req [?f]array_::<u8>(p, ?count, ?elems);
-    ens [f]integers__(p, 1, false, count, elems);
 
-lem u8_array_to_integers_(p: *u8);
-    req [?f]array::<u8>(p, ?count, ?elems);
-    ens [f]integers_(p, 1, false, count, elems);
 
-lem integers___to_u8_array_(p: *u8);
-    req [?f]integers__(p, 1, false, ?count, ?elems);
-    ens [f]array_(p, count, elems);
+lem array_split<T>(p: *T, offset: i32);
+    req [?f]p[..?count] |-> ?vs &*& 0 <= offset &*& offset <= count;
+    ens
+        [f]p[..offset] |-> take(offset, vs) &*& [f]p[offset..count] |-> drop(offset, vs) &*&
+        vs == append(take(offset, vs), drop(offset, vs));
 
-lem integers__to_u8_array(p: *u8);
-    req [?f]integers_(p, 1, false, ?count, ?elems);
-    ens [f]array(p, count, elems);
+lem array__split<T>(p: *T, offset: i32);
+    req [?f]array_(p, ?count, ?vs) &*& 0 <= offset &*& offset <= count;
+    ens
+        [f]array_(p, offset, take(offset, vs)) &*&
+        [f]array_(p + offset, count - offset, drop(offset, vs)) &*&
+        vs == append(take(offset, vs), drop(offset, vs));
+
+lem array_join<T>(p: *T);
+    req
+        [?f]array(p, ?count1, ?vs1) &*&
+        [f]array(p + count1, ?count2, ?vs2);
+    ens [f]array(p, count1 + count2, append(vs1, vs2));
+
+lem array__join<T>(p: *T);
+    req
+        [?f]array_(p, ?count1, ?vs1) &*&
+        [f]array_(p + count1, ?count2, ?vs2);
+    ens [f]array_(p, count1 + count2, append(vs1, vs2));
+
+lem array_to_array_<T>(p: *T);
+    req [?f]array(p, ?count, ?vs);
+    ens [f]array_(p, count, map(some, vs));
+
+lem from_u8s_<T>(p: *T);
+    req [?f](p as *u8)[..std::mem::size_of::<T>()] |-> _;
+    ens [f](*p |-> _);
+
+lem to_u8s_<T>(p: *T);
+    req [?f](*p |-> _);
+    ens [f](p as *u8)[..std::mem::size_of::<T>()] |-> _;
+
+lem u8s__to_array_<T>(p: *T, size: i32);
+    req [?f](p as *u8)[..size * std::mem::size_of::<T>()] |-> _;
+    ens [f]p[..size] |-> _;
+
+lem array__to_u8s_<T>(p: *T, size: i32);
+    req [?f]p[..size] |-> _;
+    ens [f](p as *u8)[..size * std::mem::size_of::<T>()] |-> _;
 
 pred ghost_rec_perm(depth: i32;); // Permission to perform `depth` nested lemma function pointer calls.
 

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -7,8 +7,8 @@ abstract_type type_info;
 mod intrinsics {
 
     unsafe fn copy_nonoverlapping<T>(src: *mut T, dst: *mut T, count: usize);
-    //@ req [?f]integers_(src as *mut u8, 1, false, count * std::mem::size_of::<T>(), ?vs) &*& integers__(dst as *mut u8, 1, false, count * std::mem::size_of::<T>(), _);
-    //@ ens [f]integers_(src as *mut u8, 1, false, count * std::mem::size_of::<T>(), vs) &*& integers_(dst as *mut u8, 1, false, count * std::mem::size_of::<T>(), vs);
+    //@ req [?f]src[..count] |-> ?vs &*& dst[..count] |-> _;
+    //@ ens [f]src[..count] |-> vs &*& dst[..count] |-> vs;
 
     unsafe fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
     /*@
@@ -117,26 +117,26 @@ mod alloc {
         if result == 0 {
             true
         } else {
-            integers__(result, 1, false, Layout::size_(layout), _) &*& alloc_block(result, layout) &*&
+            result[..Layout::size_(layout)] |-> _ &*& alloc_block(result, layout) &*&
             object_pointer_within_limits(result, Layout::size_(layout)) == true
         };
     @*/
     //@ terminates;
     
     fn realloc(buffer: *u8, layout: Layout, new_size: usize) -> *u8;
-    //@ req integers_(buffer, 1, false, ?len, ?vs1) &*& integers__(buffer + len, 1, false, Layout::size_(layout) - len, ?vs2) &*& alloc_block(buffer, layout) &*& Layout::size_(layout) <= new_size;
+    //@ req buffer[..?len] |-> ?vs1 &*& array_::<u8>(buffer + len, Layout::size_(layout) - len, ?vs2) &*& alloc_block(buffer, layout) &*& Layout::size_(layout) <= new_size;
     /*@
     ens
         if result == 0 {
-            integers_(buffer, 1, false, len, vs1) &*& integers__(buffer + len, 1, false, Layout::size_(layout) - len, vs2) &*& alloc_block(buffer, layout)
+            buffer[..len] |-> vs1 &*& array_::<u8>(buffer + len, Layout::size_(layout) - len, vs2) &*& alloc_block(buffer, layout)
         } else {
-            integers_(result, 1, false, len, vs1) &*& integers__(result + len, 1, false, Layout::size_(layout) - len, vs2) &*&
-            integers__(result + Layout::size_(layout), 1, false, new_size - Layout::size_(layout), _) &*& alloc_block(result, Layout::from_size_align_(new_size, Layout::align_(layout)))
+            result[..len] |-> vs1 &*& array_::<u8>(result + len, Layout::size_(layout) - len, vs2) &*&
+            result[Layout::size_(layout)..new_size] |-> _ &*& alloc_block(result, Layout::from_size_align_(new_size, Layout::align_(layout)))
         };
     @*/
     
     fn dealloc(p: *u8, layout: Layout);
-    //@ req alloc_block(p, layout) &*& integers__(p, 1, false, Layout::size_(layout), _);
+    //@ req alloc_block(p, layout) &*& p[..Layout::size_(layout)] |-> _;
     //@ ens true;
     //@ terminates;
 
@@ -295,8 +295,8 @@ mod io {
     trait Write {
     
         fn write(self: *Self, buf: &[u8]) -> Result<usize>;
-        //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0) &*& [?f]integers_(buf.ptr, 1, false, buf.len, ?bs);
-        //@ ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1) &*& [f]integers_(buf.ptr, 1, false, buf.len, bs) &*& std::result::Result_own::<usize, Error>(t, result);
+        //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0) &*& [?f]buf.ptr[..buf.len] |-> ?bs;
+        //@ ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1) &*& [f]buf.ptr[..buf.len] |-> bs &*& std::result::Result_own::<usize, Error>(t, result);
         
         fn flush(self: *Self) -> Result<()>;
         //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0);

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -47,7 +47,7 @@ pub mod ptr {
             };
             //@ open_full_borrow(_q_a, a, <T>.full_borrow_content(_t, reference));
             //@ open_full_borrow_content::<T>(_t, reference);
-            //@ generic_points_to_limits(reference);
+            //@ points_to_limits(reference);
             //@ close_full_borrow_content::<T>(_t, reference);
             //@ close_full_borrow(<T>.full_borrow_content(_t, reference));
             //@ close ptr::NonNull_own::<T>(_t, reference);

--- a/tests/rust/purely_unsafe/account_with_box.rs
+++ b/tests/rust/purely_unsafe/account_with_box.rs
@@ -41,7 +41,7 @@ impl Account {
     //@ ens Account(result, 0);
     {
         let result = Box::into_raw(Box::new(Account { balance: 0 }));
-        //@ open_generic_points_to(result);
+        //@ open_points_to(result);
         result
     }
 
@@ -63,7 +63,7 @@ impl Account {
     //@ req thread_token(?t) &*& Account(account, ?balance);
     //@ ens thread_token(t);
     {
-        //@ close_generic_points_to(account);
+        //@ close_points_to(account);
         //@ assert *account |-> ?value;
         let b = Box::from_raw(account);
         //@ close Account_own(t, value.balance);

--- a/tests/rust/purely_unsafe/alloc.rs
+++ b/tests/rust/purely_unsafe/alloc.rs
@@ -11,11 +11,11 @@ fn test_alloc_i8()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 1, true);
+        //@ from_u8s_(p);
         *p = -42;
         //@ assert *p |-> ?v &*& v == -42;
         assert(*p == -42);
-        //@ integer__to_u8s(p, 1, true);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -28,11 +28,11 @@ fn test_alloc_i16()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 2, true);
+        //@ from_u8s_(p);
         *p = -10000;
         //@ assert *p |-> ?v &*& v == -10000;
         assert(*p == -10000);
-        //@ integer__to_u8s(p, 2, true);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -45,11 +45,11 @@ fn test_alloc_i32()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 4, true);
+        //@ from_u8s_(p);
         *p = -1_000_000_000;
         //@ assert *p |-> ?v &*& v == -1000000000;
         assert(*p == -1_000_000_000);
-        //@ integer__to_u8s(p, 4, true);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -62,7 +62,7 @@ fn test_alloc_i64()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 8, true);
+        //@ from_u8s_(p);
         *p = -1_000_000_000_000_000_000;
         //@ assert *p |-> ?v1 &*& v1 == -1000000000000000000;
         assert(*p == -1_000_000_000_000_000_000);
@@ -72,7 +72,7 @@ fn test_alloc_i64()
         *p = -9223372036854775807;
         //@ assert *p |-> ?v3 &*& v3 == -9223372036854775807;
         assert(*p == -9223372036854775807);
-        //@ integer__to_u8s(p, 8, true);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -85,14 +85,14 @@ fn test_alloc_i128()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 16, true);
+        //@ from_u8s_(p);
         *p = -36893488147419103231i128;
         //@ assert *p |-> ?v1 &*& v1 == -36893488147419103231;
         assert(*p == -36893488147419103231i128);
         *p = -36893488147419103230i128;
         //@ assert *p |-> ?v2 &*& v2 == -36893488147419103230;
         assert(*p == -36893488147419103230i128);
-        //@ integer__to_u8s(p, 16, true);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -120,11 +120,11 @@ fn test_alloc_u16()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 2, false);
+        //@ from_u8s_(p);
         *p = 10000;
         //@ assert *p |-> ?v &*& v == 10000;
         assert(*p == 10000);
-        //@ integer__to_u8s(p, 2, false);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -137,11 +137,11 @@ fn test_alloc_u32()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 4, false);
+        //@ from_u8s_(p);
         *p = 1_000_000_000;
         //@ assert *p |-> ?v &*& v == 1000000000;
         assert(*p == 1_000_000_000);
-        //@ integer__to_u8s(p, 4, false);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -154,7 +154,7 @@ fn test_alloc_u64()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 8, false);
+        //@ from_u8s_(p);
         *p = 1_000_000_000_000_000_000;
         //@ assert *p |-> ?v1 &*& v1 == 1000000000000000000;
         assert(*p == 1_000_000_000_000_000_000);
@@ -167,7 +167,7 @@ fn test_alloc_u64()
         *p = 9223372036854775809;
         //@ assert *p |-> ?v4 &*& v4 == 9223372036854775809;
         assert(*p == 9223372036854775809);
-        //@ integer__to_u8s(p, 8, false);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }
@@ -180,7 +180,7 @@ fn test_alloc_u128()
         if p.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        //@ u8s__to_integer__(p, 16, false);
+        //@ from_u8s_(p);
         *p = 36893488147419103231u128;
         //@ assert *p |-> ?v1 &*& v1 == 36893488147419103231;
         assert(*p == 36893488147419103231u128);
@@ -190,7 +190,7 @@ fn test_alloc_u128()
         *p = 340282366920938463463374607431768211455u128;
         //@ assert *p |-> ?v3 &*& v3 == 340282366920938463463374607431768211455;
         assert(*p == 340282366920938463463374607431768211455u128);
-        //@ integer__to_u8s(p, 16, false);
+        //@ to_u8s_(p);
         std::alloc::dealloc(p as *mut u8, layout);
     }
 }

--- a/tests/rust/purely_unsafe/atomics_example.rs
+++ b/tests/rust/purely_unsafe/atomics_example.rs
@@ -64,7 +64,7 @@ fn main() {
             std::alloc::handle_alloc_error(layout);
         }
         //@ std::alloc::alloc_aligned(x_ as *u8);
-        //@ u8s__to_integer__(x_, std::mem::size_of::<usize>(), false);
+        //@ from_u8s_(x_);
         std::ptr::write(x_, 0);
         let x = AtomicUsize::from_ptr(x_);
         //@ std::sync::atomic::usize_to_AtomicUsize(x_);

--- a/tests/rust/purely_unsafe/httpd_vec.rs
+++ b/tests/rust/purely_unsafe/httpd_vec.rs
@@ -1,25 +1,24 @@
 use std::io::Write;
 
 unsafe fn memchr(mut haystack: *const u8, mut size: usize, needle: u8) -> *const u8
-//@ req [?f]integers_(haystack, 1, false, size, ?cs) &*& size <= isize::MAX;
-//@ ens [f]integers_(haystack, 1, false, size, cs) &*& 0 <= result as usize - haystack as usize &*& result as usize - haystack as usize <= size &*& result == haystack + (result as usize - haystack as usize);
+//@ req [?f]haystack[..size] |-> ?cs &*& size <= isize::MAX;
+//@ ens [f]haystack[..size] |-> cs &*& 0 <= result as usize - haystack as usize &*& result as usize - haystack as usize <= size &*& result == haystack + (result as usize - haystack as usize);
 {
-    //@ let haystack0 = haystack;
-    //@ let size0 = size;
-    //@ close [f]integers_(haystack, 1, false, 0, []);
     loop {
-        //@ inv [f]integers_(haystack0, 1, false, haystack as usize - haystack0 as usize, ?cs0) &*& [f]integers_(haystack, 1, false, size, ?cs1) &*& append(cs0, cs1) == cs &*& haystack == haystack0 + (haystack as usize - haystack0 as usize);
+        /*@
+        req [f]haystack[..size] |-> ?cs1;
+        ens
+            [f]old_haystack[..old_size] |-> cs1 &*&
+            haystack == old_haystack + (haystack as usize - old_haystack as usize) &*&
+            0 <= haystack as usize - old_haystack as usize &*&
+            haystack as usize - old_haystack as usize <= old_size;
+        @*/
+        //@ open array(haystack, _, _);
         if size == 0 || *haystack == needle {
-            //@ if size != 0 { close [f]integers_(haystack, 1, false, size, _); }
-            //@ integers__join(haystack0);
             return haystack;
         }
         haystack = haystack.offset(1);
         size -= 1;
-        //@ close [f]integers_(haystack, 1, false, 0, []);
-        //@ close [f]integers_(haystack - 1, 1, false, 1, _);
-        //@ integers__join(haystack0);
-        //@ append_assoc(cs0, [head(cs1)], tail(cs1));
     }
 }
 
@@ -34,37 +33,29 @@ unsafe fn read_line<'a>(socket: platform::sockets::Socket, buffer: &'a mut Vec<u
         buffer.reserve(RECV_BUF_SIZE);
         //@ assert *buffer |-> ?buffer2;
         //@ let buf = std::vec::Vec_separate_buffer(buffer2);
-        //@ u8_array_to_integers_(buf);
-        //@ u8_array__to_integers__(buf + offset);
-        //@ integers___split(buf + offset, 1000);
+        //@ array__split(buf + offset, 1000);
         let count = socket.receive(buffer.as_mut_ptr().add(offset), RECV_BUF_SIZE);
-        //@ integers__join(buf);
-        //@ integers___join(buf + offset + count);
+        //@ array_join(buf);
+        //@ array__join(buf + offset + count);
         if count == 0 {
-            //@ integers__to_u8_array(buf);
-            //@ integers___to_u8_array_(buf + offset + count);
             //@ std::vec::Vec_unseparate_buffer(buffer2);
             break;
         }
         buffer.set_len(offset + count);
         //@ assert *buffer |-> ?buffer3;
-        //@ integers__split(buf, offset);
+        //@ array_split(buf, offset);
         let nl_index = memchr(buffer.as_ptr().offset(offset as isize), count, b'\n') as usize - (buffer.as_ptr() as usize + offset);
         if nl_index == count {
             offset += count;
-            //@ integers__join(buf);
-            //@ integers__to_u8_array(buf);
-            //@ integers___to_u8_array_(buf + offset);
+            //@ array_join(buf);
             //@ std::vec::Vec_unseparate_buffer(buffer3);
         } else {
             buffer.set_len(offset + nl_index + 1);
             //@ assert *buffer |-> ?buffer4;
-            //@ integers__split(buf + offset, nl_index + 1);
-            //@ integers__join(buf);
-            //@ integers__to_integers__(buf + offset + nl_index + 1);
-            //@ integers___join(buf + offset + nl_index + 1);
-            //@ integers__to_u8_array(buf);
-            //@ integers___to_u8_array_(buf + offset + nl_index + 1);
+            //@ array_split(buf + offset, nl_index + 1);
+            //@ array_join(buf);
+            //@ array_to_array_(buf + offset + nl_index + 1);
+            //@ array__join(buf + offset + nl_index + 1);
             //@ std::vec::Vec_unseparate_buffer(buffer4);
             return;
         }
@@ -72,15 +63,15 @@ unsafe fn read_line<'a>(socket: platform::sockets::Socket, buffer: &'a mut Vec<u
 }
 
 unsafe fn send_bytes<'a>(socket: platform::sockets::Socket, bytes: &'a [u8])
-//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]integers_(bytes.ptr, 1, false, bytes.len, _);
-//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]integers_(bytes.ptr, 1, false, bytes.len, _);
+//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]bytes.ptr[..bytes.len] |-> ?bs;
+//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]bytes.ptr[..bytes.len] |-> bs;
 {
     socket.send(bytes.as_ptr(), bytes.len());
 }
 
 unsafe fn send_str<'a>(socket: platform::sockets::Socket, text: &'a str)
-//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]integers_(text.ptr, 1, false, text.len, _);
-//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]integers_(text.ptr, 1, false, text.len, _);
+//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]text.ptr[..text.len] |-> ?bs;
+//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]text.ptr[..text.len] |-> bs;
 {
     send_bytes(socket, text.as_bytes());
 }
@@ -94,16 +85,14 @@ unsafe fn handle_connection<'a>(buffer: &'a mut Vec<u8>, socket: platform::socke
     send_str(socket, "HTTP/1.0 200 OK\r\n\r\n");
     let len = buffer.len();
     //@ let buf = std::vec::Vec_separate_buffer(buffer1);
-    //@ u8_array_to_integers_(buf);
     socket.send(buffer.as_ptr(), len);
-    //@ integers__to_u8_array(buf);
     //@ std::vec::Vec_unseparate_buffer(buffer1);
     socket.close();
 }
 
 unsafe fn print<'a>(text: &'a str)
-//@ req thread_token(?t) &*& [?f]integers_(text.ptr, 1, false, text.len, ?cs);
-//@ ens thread_token(t) &*& [f]integers_(text.ptr, 1, false, text.len, cs);
+//@ req thread_token(?t) &*& [?f]text.ptr[..text.len] |-> ?cs;
+//@ ens thread_token(t) &*& [f]text.ptr[..text.len] |-> cs;
 {
     let mut stdout = std::io::stdout();
     stdout.write(text.as_bytes()).unwrap();

--- a/tests/rust/purely_unsafe/reverse.rs
+++ b/tests/rust/purely_unsafe/reverse.rs
@@ -26,7 +26,7 @@ unsafe fn dispose_list(mut n: *mut *mut u8)
             break;
         } else {
             let next = *n as *mut *mut u8;
-            //@ pointer_to_u8s(n);
+            //@ to_u8s_(n);
             std::alloc::dealloc(n as *mut u8, std::alloc::Layout::new::<*mut u8>());
             n = next;
         }
@@ -63,14 +63,17 @@ fn main() {
         if node1.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
+        //@ from_u8s_(node1);
         let node2 = std::alloc::alloc(layout) as *mut *mut u8;
         if node2.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
+        //@ from_u8s_(node2);
         let node3 = std::alloc::alloc(layout) as *mut *mut u8;
         if node3.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
+        //@ from_u8s_(node3);
         *node3 = std::ptr::null_mut();
         //@ close list(node3, [node3]);
         *node2 = node3 as *mut u8;
@@ -87,11 +90,11 @@ fn main() {
         assert(newNode1 == node3);
         assert(newNode2 == node2);
         assert(newNode3 == node1);
-        //@ pointer_to_u8s(node1);
+        //@ to_u8s_(node1);
         std::alloc::dealloc(node1 as *mut u8, layout);
-        //@ pointer_to_u8s(node2);
+        //@ to_u8s_(node2);
         std::alloc::dealloc(node2 as *mut u8, layout);
-        //@ pointer_to_u8s(node3);
+        //@ to_u8s_(node3);
         std::alloc::dealloc(node3 as *mut u8, layout);
     }
 }

--- a/tests/rust/purely_unsafe/str.rs
+++ b/tests/rust/purely_unsafe/str.rs
@@ -1,13 +1,13 @@
 unsafe fn is_hi<'a>(text: &'a str) -> bool
-//@ req [?f]integers_(text.ptr, 1, false, text.len, ?cs);
-//@ ens [f]integers_(text.ptr, 1, false, text.len, cs) &*& result == (cs == ['H', 'i']);
+//@ req [?f]text.ptr[..text.len] |-> ?cs;
+//@ ens [f]text.ptr[..text.len] |-> cs &*& result == (cs == ['H', 'i']);
 {
     if text.len() != 2 {
         false
     } else {
-        //@ open integers_(_, _, _, _, _);
-        //@ open integers_(_, _, _, _, _);
-        //@ open integers_(_, _, _, _, _);
+        //@ open array(_, _, _);
+        //@ open array(_, _, _);
+        //@ open array(_, _, _);
         *text.as_ptr() == b'H' && *text.as_ptr().offset(1) == b'i'
     }
 }

--- a/tests/rust/purely_unsafe/strlen.rs
+++ b/tests/rust/purely_unsafe/strlen.rs
@@ -17,10 +17,10 @@ pred zstr(p: *u8; cs: list<u8>) =
 fix neq<t>(x: t, y: t) -> bool { x != y }
 
 lem u8s_zstr_join(p: *u8)
-    req [?f]integers_(p, 1, false, ?n, ?cs0) &*& [f]zstr(p + n, ?cs1) &*& forall(cs0, (neq)(0)) == true;
+    req [?f]p[..?n] |-> ?cs0 &*& [f]zstr(p + n, ?cs1) &*& forall(cs0, (neq)(0)) == true;
     ens [f]zstr(p, append(cs0, cs1));
 {
-    open integers_(p, 1, false, n, cs0);
+    open array(p, n, cs0);
     if n == 0 {
     } else {
         u8s_zstr_join(p + 1);
@@ -39,7 +39,7 @@ unsafe fn strlen_rec(mut p: *const u8) -> i32
         return 0;
     } else {
         //@ open zstr(p + 1, ?cs1);
-        //@ integer__limits(p + 1);
+        //@ points_to_limits(p + 1);
         //@ close [f]zstr(p + 1, cs1);
         //@ assume(length(cs1) < 0x7fffffff);
         return 1 + strlen_rec(p.offset(1));
@@ -65,11 +65,11 @@ unsafe fn strlen_inv(mut p: *const u8) -> isize
             break;
         } else {
             //@ open zstr(p1 + 1, ?cs11);
-            //@ integer__limits(p1 + 1);
+            //@ points_to_limits(p1 + 1);
             //@ close [f]zstr(p1 + 1, cs11);
-            //@ close [f]integers_(p1 + 1, 1, false, 0, []);
-            //@ close [f]integers_(p1, 1, false, 1, _);
-            //@ integers__join(p);
+            //@ close [f]array(p1 + 1, 0, []);
+            //@ close [f]array(p1, 1, _);
+            //@ array_join(p);
             //@ forall_append(cs0, [head(cs1)], (neq)(0));
             //@ append_assoc(cs0, [head(cs1)], tail(cs1));
             p1 = p1.offset(1);
@@ -105,7 +105,7 @@ unsafe fn strlen(mut p: *const u8) -> isize
             break;
         } else {
             //@ open zstr(p1 + 1, ?cs11);
-            //@ integer__limits(p1 + 1);
+            //@ points_to_limits(p1 + 1);
             //@ close [f]zstr(p1 + 1, cs11);
             p1 = p1.offset(1);
         }
@@ -136,10 +136,10 @@ fn main() {
         //@ open zstr(p + 1, _);
         //@ open zstr(p + 2, _);
         //@ open zstr(p + 3, _);
-        //@ close integers_(p + 3, 1, false, 1, _);
-        //@ close integers_(p + 2, 1, false, 2, _);
-        //@ close integers_(p + 1, 1, false, 3, _);
-        //@ close integers_(p, 1, false, 4, _);
+        //@ close array_(p + 3, 1, _);
+        //@ close array_(p + 2, 2, _);
+        //@ close array_(p + 1, 3, _);
+        //@ close array_(p, 4, _);
 
         std::alloc::dealloc(p, layout);
     }

--- a/tests/rust/purely_unsafe/tree2.rs
+++ b/tests/rust/purely_unsafe/tree2.rs
@@ -269,7 +269,7 @@ fn main() {
         if count.is_null() {
             std::alloc::handle_alloc_error(std::alloc::Layout::new::<i32>());
         }
-        //@ u8s__to_integer__(count, 4, true);
+        //@ from_u8s_(count);
         *count = 0;
 
         /*@
@@ -285,7 +285,7 @@ fn main() {
         //@ open counting_tree_visitor_data(count as *mut u8, 0);
         assert(*count == 3);
         
-        //@ integer__to_u8s(count, 4, true);
+        //@ to_u8s_(count);
         std::alloc::dealloc(count as *mut u8, std::alloc::Layout::new::<i32>());
         
         Tree::dispose(root);

--- a/tests/rust/purely_unsafe/tree3.rs
+++ b/tests/rust/purely_unsafe/tree3.rs
@@ -306,7 +306,7 @@ fn main() {
         if count.is_null() {
             std::alloc::handle_alloc_error(std::alloc::Layout::new::<i32>());
         }
-        //@ u8s__to_integer__(count, 4, true);
+        //@ from_u8s_(count);
         *count = 0;
 
         //@ close TreeVisitor(typeid(CountingTreeVisitor))(count as *mut u8, [3 as *u8, 1 as *u8, 2 as *u8], wrap(3));
@@ -314,7 +314,7 @@ fn main() {
         //@ open TreeVisitor(typeid(CountingTreeVisitor))(count as *mut u8, [], wrap(3));
         assert(*count == 3);
         
-        //@ integer__to_u8s(count, 4, true);
+        //@ to_u8s_(count);
         std::alloc::dealloc(count as *mut u8, std::alloc::Layout::new::<i32>());
         
         Tree::dispose(root);

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -254,7 +254,7 @@ impl<'b, T: Send> DerefMut for MutexGuard<'b, T> {
         //@ assert [?qkml]lifetime_token(kmlong);
         //@ open_full_borrow(qkml, kmlong, <T>.full_borrow_content(t0, &(*lock).data));
         //@ open_full_borrow_content::<T>(t0, &(*lock).data);
-        //@ generic_points_to_limits(&(*lock).data);
+        //@ points_to_limits(&(*lock).data);
         //@ close_full_borrow_content::<T>(t0, &(*lock).data);
         //@ close_full_borrow(<T>.full_borrow_content(t0, &(*lock).data));
         //@ lifetime_token_trade_back(qkml, kmlong);

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -355,7 +355,7 @@ impl MutexGuardU32 {
         //@ assert [?qkml]lifetime_token(kmlong);
         //@ open_full_borrow(qkml, kmlong, u32_full_borrow_content(t0, &(*lock).data));
         //@ open u32_full_borrow_content(t0, &(*lock).data)();
-        //@ integer__limits(&(*lock).data);
+        //@ points_to_limits(&(*lock).data);
         //@ close u32_full_borrow_content(t0, &(*lock).data)();
         //@ close_full_borrow(u32_full_borrow_content(t0, &(*lock).data));
         //@ lifetime_token_trade_back(qkml, kmlong);

--- a/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
+++ b/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
@@ -341,7 +341,7 @@ impl<'b> MutexGuardU32<'b> {
         //@ assert [?qkml]lifetime_token(kmlong);
         //@ open_full_borrow(qkml, kmlong, u32_full_borrow_content(t0, &(*lock).data));
         //@ open u32_full_borrow_content(t0, &(*lock).data)();
-        //@ integer__limits(&(*lock).data);
+        //@ points_to_limits(&(*lock).data);
         //@ close u32_full_borrow_content(t0, &(*lock).data)();
         //@ close_full_borrow(u32_full_borrow_content(t0, &(*lock).data));
         //@ lifetime_token_trade_back(qkml, kmlong);

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -267,6 +267,7 @@ impl<T> Drop for Rc<T> {
                 //@ thread_token_merge(_t, mask_diff(MaskTop, MaskNshrSingle(ptr)), MaskNshrSingle(ptr));
                 //@ close thread_token(_t);
                 std::ptr::drop_in_place(&mut (*self.ptr.as_ptr()).value as *mut T);
+                //@ close RcBox_strong_(ptr, _);
                 //@ open_struct(ptr);
                 //@ close std::ptr::NonNull_own::<RcBox<T>>(_t, nnp);
                 std::alloc::dealloc(

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -2,8 +2,8 @@
 use std::{cell::UnsafeCell, process::abort, ptr::NonNull};
 /*@
 // TODO: Move to general.h
-//pred_ctor generic_points_to__<T>(p: *T)(;) = *p |-> ?v;
-//pred u32_share(k: lifetime_t, t: thread_id_t, l: *u32) = [_]frac_borrow(k, generic_points_to__(l));
+//pred_ctor points_to__<T>(p: *T)(;) = *p |-> ?v;
+//pred u32_share(k: lifetime_t, t: thread_id_t, l: *u32) = [_]frac_borrow(k, points_to__(l));
 
 // dk: dynamic lifetime
 // gh: ghost location
@@ -245,6 +245,8 @@ impl Drop for RcU32 {
                 //@ end_lifetime(dk);
                 //@ borrow_end(dk, u32_full_borrow_content(_t, &(*ptr).value));
                 //@ open u32_full_borrow_content(_t, &(*ptr).value)();
+                //@ close RcBoxU32_strong_(ptr, _);
+                //@ close RcBoxU32_value_(ptr, _);
                 //@ open_struct(ptr);
                 // No need to drop a u32
                 //@ close std::ptr::NonNull_own::<RcBoxU32>(_t, nnp);

--- a/tests/rust/unverified/platform/spec/lib.rsspec
+++ b/tests/rust/unverified/platform/spec/lib.rsspec
@@ -16,18 +16,18 @@ mod sockets {
         //@ ens [q]ServerSocket(self) &*& Socket(result);
 
         unsafe fn receive(self: Socket, buffer: *mut u8, length: usize) -> usize;
-        //@ req [?q]Socket(self) &*& integers__(buffer, 1, false, length, _);
+        //@ req [?q]Socket(self) &*& buffer[..length] |-> _;
         /*@
         ens
             result <= length &*&
             [q]Socket(self) &*&
-            integers_(buffer, 1, false, result, _) &*&
-            integers__(buffer + result, 1, false, length - result, _);
+            buffer[..result] |-> ?_ &*&
+            buffer[result..length] |-> _;
         @*/
 
         unsafe fn send(self: Socket, buffer: *const u8, length: usize);
-        //@ req [?f]Socket(self) &*& [?fb]integers_(buffer, 1, false, length, ?vs);
-        //@ ens [f]Socket(self) &*& [fb]integers_(buffer, 1, false, length, vs);
+        //@ req [?f]Socket(self) &*& [?fb]buffer[..length] |-> ?vs;
+        //@ ens [f]Socket(self) &*& [fb]buffer[..length] |-> vs;
 
         unsafe fn close(self: Socket);
         //@ req Socket(self);


### PR DESCRIPTION
This commit decommissions the type-specific points-to predicates
(integer_, pointer, etc.)
in favor of generic_points_to, which it renames to just points_to.
Similarly, the type-specific array predicates (integers_ etc.)
are decommissioned in favor of the generic 'array' predicate.
