### PR TITLE
Check effective types for pointer-typed accesses

### DIFF
--- a/bin/prelude.h
+++ b/bin/prelude.h
@@ -1068,9 +1068,9 @@ predicate module_code(int moduleId;);
 
 predicate argv(char **argv, int argc; list<list<char> > arguments) =
     argc <= 0 ?
-        pointer(argv, 0) &*& arguments == nil
+        *argv |-> 0 &*& arguments == nil
     :
-        pointer(argv, ?arg)
+        *argv |-> ?arg
         &*& string(arg, ?head_arguments)
         &*& argv(argv + 1, argc - 1, ?tail_arguments)
         &*& arguments == cons(head_arguments, tail_arguments); // fix output parameter.

--- a/examples/BeepDriver/BeepKernel.c
+++ b/examples/BeepDriver/BeepKernel.c
@@ -20,9 +20,9 @@ static struct beep_info *beepInfo;
 /*@
 
 predicate kernel_state() =
-    [1/2]pointer(&beepInfo, ?info) &*&
+    [1/2]beepInfo |-> ?info &*&
     info == 0 ?
-        [1/2]pointer(&beepInfo, 0)
+        [1/2]beepInfo |-> 0
     :
         beep_info_beepFunc(info, ?f) &*&
         [1/2]beep_info_beepState(info, ?s) &*&
@@ -31,7 +31,7 @@ predicate kernel_state() =
         malloc_block_beep_info(info);
 
 predicate beep_func_registration(predicate() beepState) =
-    [1/2]pointer(&beepInfo, ?info) &*&
+    [1/2]beepInfo |-> ?info &*&
     [1/2]beep_info_beepState(info, beepState);
 
 @*/

--- a/examples/MockKernel/AdderModule.c
+++ b/examples/MockKernel/AdderModule.c
@@ -13,8 +13,8 @@ static int acc;
 static struct lock *adderLock;
 
 //@ predicate adderLockInv() = integer(&acc, _);
-//@ predicate adderDeviceState(;) = [1/2]module_code(AdderModule) &*& pointer(&adderLock, ?adderLock_) &*& lock(adderLock_, _, adderLockInv);
-//@ predicate adderFile(real frac, void *file) = [frac/2]module_code(AdderModule) &*& [frac]pointer(&adderLock, ?adderLock_) &*& [frac]lock(adderLock_, _, adderLockInv);
+//@ predicate adderDeviceState(;) = [1/2]module_code(AdderModule) &*& adderLock |-> ?adderLock_ &*& lock(adderLock_, _, adderLockInv);
+//@ predicate adderFile(real frac, void *file) = [frac/2]module_code(AdderModule) &*& [frac]adderLock |-> ?adderLock_ &*& [frac]lock(adderLock_, _, adderLockInv);
 
 void *adder_open()
     //@ requires [?f]adderDeviceState() &*& lockset(currentThread, nil);
@@ -80,7 +80,7 @@ static struct device *adderDevice;
 predicate adderState(struct module *self, int deviceCount) =
     [1/2]module_code(AdderModule) &*&
     deviceCount == 1 &*&
-    pointer(&adderDevice, ?adderDevice_) &*&
+    adderDevice |-> ?adderDevice_ &*&
     kernel_device(adderDevice_, self, adderName, ?adderNameChars, &adderOps, adderDeviceState) &*&
     struct_file_ops_padding(&adderOps) &*&
     length(adderNameChars) == 10;

--- a/examples/abstract_io/chat_server/queues.c
+++ b/examples/abstract_io/chat_server/queues.c
@@ -79,7 +79,7 @@ bool queue_is_empty/*@ <t> @*/(queue queue)
 {
     //@ open queue(queue, pred, elems);
     //@ open nodes(?first, ?last, _, _);
-    //@ if ((uintptr_t)queue->first == (uintptr_t)queue->last && queue->first != queue->last) pointer__fractions_same_address(&queue->first->next, &queue->last->next);
+    //@ if ((uintptr_t)queue->first == (uintptr_t)queue->last && queue->first != queue->last) { pointer__fractions_same_address(&queue->first->next, &queue->last->next); }
     //@ close [f]nodes(first, last, pred, elems);
     return queue->first == queue->last;
     //@ close [f]queue(queue, pred, elems);

--- a/examples/chat.mysh
+++ b/examples/chat.mysh
@@ -1,6 +1,6 @@
-verifast CRT/threading.o stringBuffers.c sockets.o lists.c ghostlist.o -fno-strict-aliasing -assume_no_subobject_provenance chat.c
+verifast CRT/threading.o stringBuffers.c sockets.o ghostlist.o -fno-strict-aliasing -assume_no_subobject_provenance lists.c chat.c
 verifast -c -emit_vfmanifest stringBuffers.c
-verifast -c -emit_vfmanifest lists.c
+verifast -c -emit_vfmanifest -fno-strict-aliasing -assume_no_subobject_provenance lists.c
 verifast -c -emit_vfmanifest -fno-strict-aliasing -assume_no_subobject_provenance chat.c
 verifast CRT/threading.o stringBuffers.o sockets.o lists.o ghostlist.o chat.o
 del stringBuffers.vfmanifest

--- a/examples/crypto_ccs/symbolic_model/protocols/recursive_otway_rees/recursive_otway_rees.c
+++ b/examples/crypto_ccs/symbolic_model/protocols/recursive_otway_rees/recursive_otway_rees.c
@@ -253,11 +253,11 @@ int participant(bool initial, int server, int current, int next,
                item(key, ?k, ror_pub) &*&
                  info_for_item(k) == int_pair(0, server) &*&
                  k == symmetric_key_item(current, ?c1) &*&
-               pointer(key1, _) &*& pointer(key2, _); @*/
+               *key1 |-> ?_ &*& *key2 |-> ?_; @*/
   /*@ ensures  [f0]world(ror_pub, ror_key_clsfy) &*&
                principal(current, count + 1) &*&
                item(key, k, ror_pub) &*&
-               pointer(key1, ?p_key1) &*& pointer(key2, ?p_key2) &*&
+               *key1 |-> ?p_key1 &*& *key2 |-> ?p_key2 &*&
                item(p_key2, ?k2, ror_pub) &*&
                col || ror_key_clsfy(current, c1, true) ||
                info_for_item(k2) ==

--- a/examples/crypto_ccs/symbolic_model/protocols/recursive_otway_rees/recursive_otway_rees.h
+++ b/examples/crypto_ccs/symbolic_model/protocols/recursive_otway_rees/recursive_otway_rees.h
@@ -194,11 +194,11 @@ int participant(bool initial, int server, int current, int next,
                item(key, ?k, ror_pub) &*&
                  info_for_item(k) == int_pair(0, server) &*&
                  k == symmetric_key_item(current, ?cc) &*&
-               pointer(key1, _) &*& pointer(key2, _); @*/
+               *key1 |-> ?_ &*& *key2 |-> ?_; @*/
   /*@ ensures  [f0]world(ror_pub, ror_key_clsfy) &*& 
                principal(current, count + 1) &*&
                item(key, k, ror_pub) &*&
-               pointer(key1, ?p_key1) &*& pointer(key2, ?p_key2) &*&
+               *key1 |-> ?p_key1 &*& *key2 |-> ?p_key2 &*&
                item(p_key2, ?k2, ror_pub) &*&
                col || ror_key_clsfy(current, cc, true) ||
                info_for_item(k2) == int_pair(1, int_pair(current, next)) &*&

--- a/examples/globals.c
+++ b/examples/globals.c
@@ -9,8 +9,8 @@ struct counter {
 static struct counter *c;
 
 void m()
-    //@ requires integer(&x, 7) &*& pointer(&c, ?ctr) &*& counter_f(ctr, ?v);
-    //@ ensures integer(&x, 8) &*& pointer(&c, ctr) &*& counter_f(ctr, v + 1);
+    //@ requires x |-> 7 &*& c |-> ?ctr &*& ctr->f |-> ?v;
+    //@ ensures x |-> 8 &*& c |-> ctr &*& ctr->f |-> v + 1;
 {
     int y = x;
     x = y + 1;

--- a/examples/helloproc/helloproc_main.c
+++ b/examples/helloproc/helloproc_main.c
@@ -39,14 +39,14 @@ predicate callback_data_mutexed() =
 predicate_family_instance
 	vf_procfs_read_callback_data(read_proc_callback)() =
 	
-	pointer(&mutex, ?mutex_ptr)
+	mutex |-> ?mutex_ptr
 	&*& vf_mutex(mutex_ptr, callback_data_mutexed);
 @*/
 
 
 /*@
 predicate module_state() =
-	pointer(&dir, ?dir_ptr)
+	dir |-> ?dir_ptr
 	&*& vf_procfs_dir(
 		dir_ptr,
 		cons(
@@ -63,7 +63,7 @@ predicate module_state() =
 		)
 		, 1
 	)
-	&*& pointer(&file, ?file_ptr)
+	&*& file |-> ?file_ptr
 	&*& vf_procfs_file(
 		file_ptr,
 		cons(

--- a/examples/insertion_sort.c
+++ b/examples/insertion_sort.c
@@ -135,8 +135,8 @@ static int compare(struct list_node* n0, struct list_node* n1)
 
 
 void insertion_sort_core(struct list_node** pfirst)
-//@ requires pointer(pfirst, ?l) &*& list_pred(l);
-//@ ensures pointer(pfirst, ?l0) &*& list_pred(l0);
+//@ requires *pfirst |-> ?l &*& list_pred(l);
+//@ ensures *pfirst |-> ?l0 &*& list_pred(l0);
 {
   if (*pfirst == 0) {
     // Empty list is trivially sorted

--- a/examples/io/matching_brackets/matching_brackets_checker.c
+++ b/examples/io/matching_brackets/matching_brackets_checker.c
@@ -15,7 +15,7 @@
 
 
 int *c;
-//@ predicate buffer(int *cc, int ccc) = pointer(&c, cc) &*& integer(cc, ccc);
+//@ predicate buffer(int *cc, int ccc) = c |-> cc &*& integer(cc, ccc);
 
 int pop_read_ahead()
 //@ requires buffer(?cc, ?c_old) &*& token(?t1) &*& read_char_io(t1, stdin, ?new_char, ?success, ?t2);

--- a/examples/queue/queue.c
+++ b/examples/queue/queue.c
@@ -203,13 +203,13 @@ bool queue_try_dequeue(struct queue *queue, void **pvalue)
     requires
         [?f]atomic_space(?inv) &*&
         is_queue_try_dequeue_context(?ctxt, inv, queue, ?pre, ?post) &*& pre() &*&
-        queue_consumer(queue) &*& pointer(pvalue, _);
+        queue_consumer(queue) &*& *pvalue |-> ?_;
     @*/
     /*@
     ensures
         [f]atomic_space(inv) &*&
         is_queue_try_dequeue_context(ctxt, inv, queue, pre, post) &*& post(result, ?value0) &*&
-        pointer(pvalue, ?value) &*& queue_consumer(queue) &*& result ? value0 == value : true;
+        *pvalue |-> ?value &*& queue_consumer(queue) &*& result ? value0 == value : true;
     @*/
 {
     //@ open queue_consumer(queue);

--- a/examples/queue/queue.h
+++ b/examples/queue/queue.h
@@ -64,13 +64,13 @@ bool queue_try_dequeue(struct queue *queue, void **pvalue);
     requires
         [?f]atomic_space(?inv) &*&
         is_queue_try_dequeue_context(?ctxt, inv, queue, ?pre, ?post) &*& pre() &*&
-        queue_consumer(queue) &*& pointer(pvalue, _);
+        queue_consumer(queue) &*& *pvalue |-> ?_;
     @*/
     /*@
     ensures
         [f]atomic_space(inv) &*&
         is_queue_try_dequeue_context(ctxt, inv, queue, pre, post) &*& post(result, ?value0) &*&
-        pointer(pvalue, ?value) &*& queue_consumer(queue) &*& result ? value0 == value : true;
+        *pvalue |-> ?value &*& queue_consumer(queue) &*& result ? value0 == value : true;
     @*/
 
 void queue_dispose(struct queue *queue);

--- a/examples/vstte2012/problem4/treerec.c
+++ b/examples/vstte2012/problem4/treerec.c
@@ -284,9 +284,9 @@ lemma void build_rec1_eq(int d, list<int> s)
 @*/
 
 bool build_rec(int d, struct list *s, struct tree **t)
-    //@ requires list(s, ?vs) &*& pointer(t, _);
+    //@ requires list(s, ?vs) &*& *t |-> ?_;
     /*@
-    ensures list(s, ?rvs) &*& pointer(t, ?rt) &*&
+    ensures list(s, ?rvs) &*& *t |-> ?rt &*&
         switch (build_rec1(d, vs)) {
             case fail: return result == false;
             case success(rvt, rvs0): return result == true &*& rvs == rvs0 &*& tree(rt, rvt);
@@ -338,9 +338,9 @@ lemma void build_complete(tree t)
 @*/
 
 bool build(struct list *s, struct tree **t)
-    //@ requires list(s, ?vs) &*& pointer(t, _);
+    //@ requires list(s, ?vs) &*& *t |-> ?_;
     /*@
-    ensures list(s, ?rvs) &*& pointer(t, ?rt) &*&
+    ensures list(s, ?rvs) &*& *t |-> ?rt &*&
     switch (build0(vs)) {
         case build_fail: return result == false;
         case build_success(rvt): return result == true &*& tree(rt, rvt) &*& rvs == nil;

--- a/examples/vstte2012/problem4/treerec_tree.c
+++ b/examples/vstte2012/problem4/treerec_tree.c
@@ -45,14 +45,14 @@ bool tree_is_leaf(struct tree *t)
 }
 
 void tree_destruct_node(struct tree *t, struct tree **left, struct tree **right)
-    //@ requires tree(t, ?value) &*& value != leaf &*& pointer(left, _) &*& pointer(right, _);
+    //@ requires tree(t, ?value) &*& value != leaf &*& *left |-> _ &*& *right |-> _;
     /*@
     ensures
         switch (value) {
             case leaf: return false;
             case node(vl, vr): return
-                pointer(left, ?l) &*& tree(l, vl) &*&
-                pointer(right, ?r) &*& tree(r, vr);
+                *left |-> ?l &*& tree(l, vl) &*&
+                *right |-> ?r &*& tree(r, vr);
         };
     @*/
 {

--- a/examples/vstte2012/problem4/treerec_tree.h
+++ b/examples/vstte2012/problem4/treerec_tree.h
@@ -24,14 +24,14 @@ bool tree_is_leaf(struct tree *t);
     //@ ensures tree(t, value) &*& switch (value) { case leaf: return result == true; case node(l, r): return result == false; };
 
 void tree_destruct_node(struct tree *t, struct tree **left, struct tree **right);
-    //@ requires tree(t, ?value) &*& value != leaf &*& pointer(left, _) &*& pointer(right, _);
+    //@ requires tree(t, ?value) &*& value != leaf &*& *left |-> _ &*& *right |-> _;
     /*@
     ensures
         switch (value) {
             case leaf: return false;
             case node(vl, vr): return
-                pointer(left, ?l) &*& tree(l, vl) &*&
-                pointer(right, ?r) &*& tree(r, vr);
+                *left |-> ?l &*& tree(l, vl) &*&
+                *right |-> ?r &*& tree(r, vr);
         };
     @*/
 

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -319,6 +319,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     end $. fun () ->
     match try_pointee_pred_symb type_ with
       Some symb ->
+      assume_has_type_if (is_ptr_type type_) l [] addr type_ @@ fun () ->
       produce_chunk h (symb, true) [] coef (Some 1) [addr; value] None cont
     | None ->
     match integer__chunk_args type_ with
@@ -337,6 +338,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     end $. fun () ->
     match try_pointee_pred_symb0 type_ with
       Some (_, _, _, _, _, _, _, _, _, uninit_predsym, _, _) ->
+      assume_has_type_if (is_ptr_type type_) l [] addr type_ @@ fun () ->
       produce_chunk h (uninit_predsym, true) [] coef (Some 1) [addr; value] None cont
     | None ->
     match integer__chunk_args type_ with
@@ -347,6 +349,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       produce_chunk h (generic_points_to__symb (), true) [type_] coef (Some 1) [addr; value] None cont
 
   let produce_points_to_chunk_ l h type_ coef addr kind value cont =
+    assume_neq (mk_ptr_address addr) int_zero_term @@ fun () ->
     match kind, value with
       _, None -> produce_uninit_points_to_chunk l h type_ coef addr (get_unique_var_symb_ "dummy" (option_type type_) true) cont
     | RegularPointsTo, Some v -> produce_points_to_chunk l h type_ coef addr v cont
@@ -934,7 +937,10 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
                (ctxt#pprint a)
                (ctxt#pprint i))
             None
-        | Some v -> v
+        | Some v ->
+          if is_ptr_type tp then
+            assert_has_type env a tp h env l "Cannot prove consistency with C's effective types rules" None;
+          v
         end
     | Some v -> v
   
@@ -946,7 +952,11 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let deref_pointer h env l pointerTerm pointeeType =
     match try_pointee_pred_symb pointeeType with
       None -> lookup_integer__chunk h env l pointeeType pointerTerm
-    | Some predsym -> lookup_points_to_chunk h env l predsym [] pointerTerm
+    | Some predsym ->
+      let result = lookup_points_to_chunk h env l predsym [] pointerTerm in
+      if is_ptr_type pointeeType then
+        assert_has_type env pointerTerm pointeeType h env l "Cannot prove consistency with C's effective types rules" None;
+      result
   
   let lists_disjoint xs ys =
     List.for_all (fun x -> not (List.mem x ys)) xs
@@ -1136,7 +1146,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let srcpats pats = List.map srcpat pats
 
   let dummypat = SrcPat DummyPat
-  
+
   let consume_points_to_chunk__core rules h typeid_env ghostenv env env' l type0 type_ coef coefpat addr kind rhs consumeUninitChunk cont =
     let type_ = unfold_inferred_type type_ in
     let consumeUninitChunk = consumeUninitChunk && (kind = MaybeUninit || rhs = dummypat) in
@@ -1149,7 +1159,10 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     match try_pointee_pred_symb0 type_ with
       Some (_, predsym, _, _, _, _, _, _, _, uninit_predsym, _, _) ->
       consume_chunk_core rules h typeid_env ghostenv env env' l ((if consumeUninitChunk then uninit_predsym else predsym), true) [] coef coefpat (Some 1) [TermPat addr; rhs] [voidPtrType; tp0] [voidPtrType; tp]
-        (fun chunk h coef [_; value] size ghostenv env env' -> cont chunk h coef value ghostenv env env')
+        $. fun chunk h coef [_; value] size ghostenv env env' ->
+      if is_ptr_type type_ then
+        assert_has_type env addr type_ h env l "Cannot prove compliance with C's effective types rules" None;
+      cont chunk h coef value ghostenv env env'
     | None ->
     match integer__chunk_args type_ with
       Some (k, signedness) ->

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -150,6 +150,11 @@ and inferred_type_state =
   | ContainsAnyConstraint of bool (* allow the type to contain 'any' in positive positions *)
   | EqConstraint of type_
 
+let is_ptr_type tp =
+  match tp with
+    PtrType _ -> true
+  | _ -> false
+
 let inferred_type_constraint_le c1 c2 =
   match c1, c2 with
     _, Unconstrained -> true

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -2505,6 +2505,8 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         end with
         | Some (Chunk (_, _, coef, [a; n; vs], _), h) ->
           if not (definitely_equal coef real_unit) then assert_false h0 env l "Assignment requires full permission." None;
+          if is_ptr_type elem_tp then
+            assert_has_type env a elem_tp h env l "Cannot prove consistency with C's effective types rules" None;
           let (_, _, _, _, update_symb) = List.assoc "update" purefuncmap in
           let updated = mk_app update_symb [i; apply_conversion (provertype_of_type elem_tp) ProverInductive value; vs] in
           assume (ctxt#mk_eq (mk_length updated) n) $. fun () ->
@@ -2584,7 +2586,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let n, elemTp, arrayPredSymb, mallocBlockSymb, extra_args, produce_has_type =
             match try_pointee_pred_symb0 elemTp with
               Some (_, _, _, asym, _, mbsym, _, _, _, _, _, uasym) ->
-              n, (if g = "calloc" then elemTp else option_type elemTp), (if g = "calloc" then asym else uasym), mbsym (), [], false
+              n, (if g = "calloc" then elemTp else option_type elemTp), (if g = "calloc" then asym else uasym), mbsym (), [], is_ptr_type elemTp
             | None ->
             match integer__chunk_args elemTp with
               Some (r, s) ->

--- a/tests/cxx/c_copy/globals.cpp
+++ b/tests/cxx/c_copy/globals.cpp
@@ -24,8 +24,8 @@ static Counter *c;
 static Counter cc;
 
 void m()
-    //@ requires integer(&x, 7) &*& pointer(&c, ?ctr) &*& Counter_f(ctr, ?v) &*& Counter_f(&cc, _);
-    //@ ensures integer(&x, 8) &*& pointer(&c, ctr) &*& Counter_f(ctr, v + 1) &*& Counter_f(&cc, 10);
+    //@ requires x |-> 7 &*& c |-> ?ctr &*& ctr->f |-> ?v &*& cc.f |-> _;
+    //@ ensures x |-> 8 &*& c |-> ctr &*& ctr->f |-> v + 1 &*& cc.f |-> 10;
 {
     int y = x;
     x = y + 1;

--- a/tutorial_solutions/byref.c
+++ b/tutorial_solutions/byref.c
@@ -64,8 +64,8 @@ typedef bool int_predicate(int x);
     //@ ensures true;
 
 void nodes_filter(struct node **n, int_predicate *p)
-    //@ requires pointer(n, ?node) &*& nodes(node, _) &*& is_int_predicate(p) == true;
-    //@ ensures pointer(n, ?node0) &*& nodes(node0, _);
+    //@ requires *n |-> ?node &*& nodes(node, _) &*& is_int_predicate(p) == true;
+    //@ ensures *n |-> ?node0 &*& nodes(node0, _);
 {
     if (*n != 0) {
         //@ open nodes(node, _);

--- a/tutorial_solutions/students.c
+++ b/tutorial_solutions/students.c
@@ -36,7 +36,7 @@ int main() //@ : main
     printf("How many students do you have? ");
     int n = read_int();
     if (n < 0 || 0x20000000 <= n) abort();
-    char **names = malloc(n * sizeof(char **));
+    char **names = malloc(n * sizeof(char *));
     if (names == 0) abort();
     for (int i = 0; ; i++)
         //@ requires names[i..n] |-> _;


### PR DESCRIPTION
This breaking change causes VeriFast to check effective types
when accessing a variable of type T*. Fixes #542, an unsoundness.
You can disable the effective types checks by specifying the
-fno-strict-aliasing command-line option.
