### PR TITLE
[C++] RValue Reference support

### DIFF
--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -158,6 +158,8 @@ let rec sexpr_of_type_expr : type_expr -> sexpression = function
         [ "type-exprs", sexpr_of_list sexpr_of_type_expr exprs ]
   | LValueRefTypeExpr (_, te) -> 
       List [ Symbol "type-expr-lvalue-ref"; sexpr_of_type_expr te ]
+  | RValueRefTypeExpr (_, te) ->
+      List [ Symbol "type-expr-rvalue-ref"; sexpr_of_type_expr te ]
 
 let sexpr_of_type_expr_option : type_expr option -> sexpression = function
   | Some t -> sexpr_of_type_expr t

--- a/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
+++ b/src/cxx_frontend/ast_exporter/ExprSerializer.cpp
@@ -409,6 +409,12 @@ struct ExprSerializerImpl
     return true;
   }
 
+  bool VisitMaterializeTemporaryExpr(clang::MaterializeTemporaryExpr const * expr) {
+    ExprNodeBuilder tempBuilder = m_builder.initMaterializeTemporary();
+    m_ASTSerializer->serialize(tempBuilder, expr->getSubExpr());
+    return true;
+  }
+
   void serialize(const clang::Expr *expr) {
     const Annotation *truncatingOpt =
         m_ASTSerializer->getAnnotationManager().getTruncating(expr);

--- a/src/cxx_frontend/expr_translator.ml
+++ b/src/cxx_frontend/expr_translator.ml
@@ -37,6 +37,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     | BindTemporary t -> transl_bind_temporary_expr t
     | IntegralCast c -> transl_integral_cast loc c
     | ConditionalOp op -> transl_conditional_op loc op
+    | MaterializeTemporary t -> transl_materialize_temporary_expr t
     | Undefined _ -> failwith "Undefined expression"
     | _ -> Error.error loc "Unsupported expression."
 
@@ -255,4 +256,5 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
 
   and transl_cleanups_expr (e : R.Node.t) : Ast.expr = translate e
   and transl_bind_temporary_expr (e : R.Node.t) = translate e
+  and transl_materialize_temporary_expr (e : R.Node.t) = translate e
 end

--- a/src/cxx_frontend/stubs/stubs_ast.capnp
+++ b/src/cxx_frontend/stubs/stubs_ast.capnp
@@ -456,6 +456,7 @@ struct Expr {
     bindTemporary @21 :ExprNode;
     integralCast @22 :Cast;
     conditionalOp @23 :ConditionalOp;
+    materializeTemporary @24 :ExprNode;
   }
 }
 

--- a/src/cxx_frontend/type_translator.ml
+++ b/src/cxx_frontend/type_translator.ml
@@ -19,6 +19,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     | Typedef t -> transl_typedef_type loc t
     | FixedWidth f -> transl_fixed_width_type loc f
     | LValueRef l -> transl_lvalue_ref_type loc l
+    | RValueRef l -> transl_rvalue_ref_type loc l
     | SubstTemplateTypeParam s -> transl_subst_template_type_param loc s
     | Undefined _ -> failwith "Undefined type."
     | _ -> Error.error loc "Unsupported type."
@@ -58,6 +59,10 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
   and transl_lvalue_ref_type (loc : Ast.loc) (l : R.Node.t) : Ast.type_expr =
     let ref_type = translate l in
     Ast.LValueRefTypeExpr (loc, ref_type)
+
+  and transl_rvalue_ref_type (loc : Ast.loc) (l : R.Node.t) : Ast.type_expr =
+    let ref_type = translate l in
+    Ast.RValueRefTypeExpr (loc, ref_type)
 
   and transl_elaborated_type (e : R.Node.t) : Ast.type_expr = translate e
 

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -276,6 +276,7 @@ type type_expr = (* ?type_expr *)
   | PredTypeExpr of loc * type_expr list * int option (* if None, not necessarily precise; if Some n, precise with n input parameters *)
   | PureFuncTypeExpr of loc * type_expr list   (* Potentially uncurried *)
   | LValueRefTypeExpr of loc * type_expr
+  | RValueRefTypeExpr of loc * type_expr
 and
   operator =  (* ?operator *)
   | Add | Sub | PtrDiff | Le | Ge | Lt | Gt | Eq | Neq | And | Or | Xor | Not | Mul | Div | Mod | BitNot | BitAnd | BitXor | BitOr | ShiftLeft | ShiftRight

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -196,6 +196,11 @@ let rec of_type_expr = function
     of_loc l;
     of_type_expr tp
   ])
+| RValueRefTypeExpr (l, tp) ->
+  C ("RValueRefTypeExpr", [
+    of_loc l;
+    of_type_expr tp
+  ])
 and of_operator = function
   MinValue t -> C ("MinValue", [of_type t])
 | MaxValue t -> C ("MaxValue", [of_type t])

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -1464,6 +1464,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         [] -> cont tddm
       | TypedefDecl (l, LValueRefTypeExpr _, _, _) :: _ ->
         static_error l "Typedefs for lvalue reference types are not supported." None
+      | TypedefDecl (l, RValueRefTypeExpr _, _, _) :: _ ->
+        static_error l "Typedefs for rvalue reference types are not supported." None
       | TypedefDecl (l, te, d, tparams)::ds ->
         (* C compiler detects duplicate typedefs *)
         iter pn ilist ((full_name pn d, (pn, ilist, l, tparams, te))::tddm) ds cont
@@ -2097,6 +2099,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       in
       iter ts
     | LValueRefTypeExpr (l, te) -> RefType (check te)
+    | RValueRefTypeExpr (l, te) -> RefType (check te)
     in
     check te
   

--- a/tests/cxx/rvalue_refs.cpp
+++ b/tests/cxx/rvalue_refs.cpp
@@ -1,0 +1,84 @@
+int getRef(int i)
+//@ requires true;
+//@ ensures i == result;
+{
+  return i;
+}
+
+int unpackRef(int && i)
+//@ requires integer(&i, ?v);
+//@ ensures integer(&i, v) &*& result == v;
+{
+  return i;
+}
+
+struct Object {
+	/*@
+	predicate Object(int val) = this->i |-> val;
+	@*/
+
+  int i;
+
+  Object() : i(0)
+  //@ requires true;
+  //@ ensures this->i |-> 0;
+  {}
+
+  // Move constructor (int)
+  Object(int && i_) : i(i_)
+  // @ requires integer(&i_, ?v);
+  // @ ensures integer(&i_, v) &*& this->i == i_;
+  {}
+
+  // Move constructor
+  Object(Object && other) : i(other.i)
+  //@ requires other.i |-> ?i_;
+  //@ ensures this->i |-> i_ &*& other.i |-> _;
+  {}
+
+  // Move assignment operator
+	Object & operator=(Object && other)
+	//@ requires other.i |-> ?i &*& this->Object(_);
+	//@ ensures other.i |-> i &*& this->Object(i) &*& &result == this;
+	{
+		i = other.i;
+		return *this;
+	}
+
+  ~Object()
+  //@ requires this->i |-> _;
+  //@ ensures true;
+  {}
+};
+
+Object construct()
+//@ requires true;
+//@ ensures (&result)->i |-> 0 &*& struct_Object_padding(&result);
+{
+  return Object();
+}
+
+int main()
+//@ requires true;
+//@ ensures true;
+{
+  int && li = 48;
+  int & li2 = li;
+  //@ assert (li == 48);
+  //@ assert (li2 == 48);
+
+  Object o(0); // Call move constructor (int)
+  int && iRef = getRef(42);
+  int iUnpacked = unpackRef(42);
+  //@ assert (iRef.i == 42);
+  //@ assert (iUnpacked == 42);
+
+  // The following expression cannot yet be parsed
+  //Object o2(Object(21)); // Call move constructor
+  // @ assert (o2.i == 21);
+
+  Object o2;
+
+  o2 = construct(); // Call move assignment operator
+  //@ assert (o2.i == 6);
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -692,6 +692,7 @@ cd tests
     verifast -c constructors.cpp
     verifast -c destructors.cpp
     verifast -c -disable_overflow_check lvalue_refs.cpp
+    verifast -c rvalue_refs.cpp
     verifast -c -allow_should_fail typeid.cpp
     verifast -c ghost_field.cpp
     verifast -c -disable_overflow_check non_compound_stmts.cpp


### PR DESCRIPTION
I'd like verifast to be able to verify move constructors and move assignment operators. This is my try to implement it, but I'm stuck. My understanding of verifast seems not to be sufficient to complete it.