### PR TITLE
[Rust] _own takes struct value, not field values

### DIFF
--- a/src/rust_frontend/vf_mir_translator/rust_parser.ml
+++ b/src/rust_frontend/vf_mir_translator/rust_parser.ml
@@ -240,6 +240,8 @@ let rec parse_expr_funcs allowStructExprs =
     [ (_, Kwd "{"); parse_struct_expr_fields as es; (_, Kwd "}") ] when allowStructExprs ->
     begin match e with
       Var (l, x) -> CastExpr (l, StructTypeExpr (l, Some x, None, [], []), InitializerList (l, es))
+    | CallExpr (l, x, targs, [], [], Static) ->
+      CastExpr (l, StructTypeExpr (l, Some x, None, [], targs), InitializerList (l, es))
     | _ -> raise (ParseException (expr_loc e, "This expression form is not supported in this position"))
     end
   | [ ] -> e

--- a/src/rust_frontend/vf_mir_translator/rustbelt.ml
+++ b/src/rust_frontend/vf_mir_translator/rustbelt.ml
@@ -8,7 +8,7 @@ type vid = string (* value id *)
 
 type ty_interp = {
   size : expr;
-  own : tid -> v list -> (asn, string) result;
+  own : tid -> v -> (asn, string) result;
   own_pred : (Ast.expr, string) result;
   shr : lft -> tid -> l -> (asn, string) result; (* Should be duplicable, e.g. a dummy pattern. The caller will not wrap this in a dummy coef asn. *)
   shr_pred : (Ast.expr, string) result; (* Need not be duplicable; the caller will wrap this in a dummy pattern. *)

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -1,6 +1,6 @@
 /*@
-pred ptr::NonNull_own<T>(t: thread_id_t, pointer: *T;) = pointer as usize != 0;
-pred_ctor ptr::NonNull_frac_bc<T>(t: thread_id_t, l: *ptr::NonNull<T>)(;) = (*l).pointer |-> ?p &*& struct_ptr::NonNull_padding(l) &*& ptr::NonNull_own(t, p);
+pred ptr::NonNull_own<T>(t: thread_id_t, nonNull: ptr::NonNull<T>;) = nonNull.pointer as usize != 0;
+pred_ctor ptr::NonNull_frac_bc<T>(t: thread_id_t, l: *ptr::NonNull<T>)(;) = (*l).pointer |-> ?p &*& struct_ptr::NonNull_padding(l) &*& ptr::NonNull_own(t, ptr::NonNull::<T> { pointer: p });
 pred ptr::NonNull_share<T>(k: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T>) =
     frac_borrow(k, ptr::NonNull_frac_bc(t, l));
 
@@ -50,7 +50,7 @@ pub mod ptr {
             //@ points_to_limits(reference);
             //@ close_full_borrow_content::<T>(_t, reference);
             //@ close_full_borrow(<T>.full_borrow_content(_t, reference));
-            //@ close ptr::NonNull_own::<T>(_t, reference);
+            //@ close ptr::NonNull_own::<T>(_t, r);
             //@ leak full_borrow(_, _);
             r
         }

--- a/tests/rust/purely_unsafe/account_with_box.rs
+++ b/tests/rust/purely_unsafe/account_with_box.rs
@@ -13,7 +13,7 @@ pred Account(account: *Account; balance: i32) =
     std::alloc::alloc_block(account as *u8, std::alloc::Layout::new_::<Account>()) &*& struct_Account_padding(account) &*&
     (*account).balance |-> balance;
 
-pred Account_own(t: thread_id_t, balance: i32) = true;
+pred Account_own(t: thread_id_t, account: Account) = true;
 pred Account_share(k: lifetime_t, t: thread_id_t, l: *Account) = true;
 
 lem Account_share_full(k: lifetime_t, t: thread_id_t, l: *Account)
@@ -66,8 +66,7 @@ impl Account {
         //@ close_points_to(account);
         //@ assert *account |-> ?value;
         let b = Box::from_raw(account);
-        //@ close Account_own(t, value.balance);
-        //@ close Account_own_(t, value);
+        //@ close Account_own(t, value);
         //@ std::boxed::Box_to_own(b);
         std::mem::drop(b);
     }

--- a/tests/rust/safe_abstraction/cell.rs
+++ b/tests/rust/safe_abstraction/cell.rs
@@ -6,7 +6,7 @@ pub struct Cell<T> {
 
 /*@
 
-pred Cell_own<T>(t: thread_id_t, v: T) = <T>.own(t, v);
+pred Cell_own<T>(t: thread_id_t, cell: Cell<T>) = <T>.own(t, cell.v);
 
 /*
 
@@ -19,7 +19,7 @@ is derivable.
 */
 
 pred_ctor Cell_nonatomic_borrow_content<T>(l: *Cell<T>, t: thread_id_t)() =
-  Cell_v(l, ?v) &*& struct_Cell_padding(l) &*& Cell_own(t, v);
+  Cell_v(l, ?v) &*& struct_Cell_padding(l) &*& Cell_own(t, Cell::<T> { v });
 
 // `SHR` for Cell<u32>
 pred Cell_share<T>(k: lifetime_t, t: thread_id_t, l: *Cell<T>) =
@@ -64,7 +64,7 @@ impl<T> Cell<T> {
         let c = Cell {
             v: std::cell::UnsafeCell::new(v),
         };
-        //@ close Cell_own::<T>(_t, v);
+        //@ close Cell_own::<T>(_t, c);
         c
     }
     
@@ -76,13 +76,13 @@ impl<T> Cell<T> {
             //@ thread_token_split(_t, MaskTop, mask);
             //@ open_nonatomic_borrow('a, _t, mask, _q_a);
             //@ open Cell_nonatomic_borrow_content::<T>(self, _t)();
-            //@ open Cell_own::<T>(_t, ?v0);
-            //@ open Cell_v(self, v0);
+            //@ open Cell_own::<T>(_t, ?cell);
+            //@ open Cell_v(self, cell.v);
             let result = std::ptr::read(self.v.get());
             std::ptr::write(self.v.get(), v);
             //@ assert partial_thread_token(_t, ?mask0);
             //@ close Cell_v(self, v);
-            //@ close Cell_own::<T>(_t, v);
+            //@ close Cell_own::<T>(_t, Cell::<T> { v });
             //@ close Cell_nonatomic_borrow_content::<T>(self, _t)();
             //@ close_nonatomic_borrow();
             //@ thread_token_merge(_t, mask0, mask);

--- a/tests/rust/safe_abstraction/cell_u32.rs
+++ b/tests/rust/safe_abstraction/cell_u32.rs
@@ -7,7 +7,7 @@ pub struct CellU32 {
 // Interpretation
 // `OWN` for Cell<u32>
 // [[cell(tau)]].OWN(t, vs) = [[tau]].OWN(t, vs)
-pred CellU32_own(t: thread_id_t, v: u32;) = true; // The `v` parameter type carries the info
+pred CellU32_own(t: thread_id_t, cellU32: CellU32;) = true; // The `v` parameter type carries the info
 
 /* A note on `|= cell(tau) copy` judgement:
 In RustBelt `|= tau copy => |= cell(tau) copy` but it is not the case in Rust as it is prohibited
@@ -63,7 +63,7 @@ impl CellU32 {
         let c = CellU32 {
             v: std::cell::UnsafeCell::new(u),
         };
-        //@ close CellU32_own(_t, u);
+        //@ close CellU32_own(_t, c);
         c
     }
 

--- a/tests/rust/safe_abstraction/deque_i32.rs
+++ b/tests/rust/safe_abstraction/deque_i32.rs
@@ -76,14 +76,14 @@ pred Deque_(sentinel: *Node; elems: list<i32> ) =
     (*sentinel).next |-> ?first &*&
     Nodes(first, sentinel, last, sentinel, elems);
 
-pred Deque_own(t: thread_id_t, sentinel: *Node; size: i32) =
-    Deque_(sentinel, ?elems) &*& size == length(elems);
+pred Deque_own(t: thread_id_t, deque: Deque;) =
+    Deque_(deque.sentinel, ?elems) &*& deque.size == length(elems);
 
 pred Deque(deque: *Deque; elems: list<i32>) =
     (*deque).sentinel |-> ?sentinel &*& (*deque).size |-> ?size &*& Deque_(sentinel, elems) &*& size == length(elems);
 
 pred_ctor Deque_frac_borrow_content(t: thread_id_t, l: *Deque)(;) =
-    (*l).sentinel |-> ?sentinel &*& (*l).size |-> ?size &*& Deque_own(t, sentinel, size) &*& struct_Deque_padding(l);
+    (*l).sentinel |-> ?sentinel &*& (*l).size |-> ?size &*& Deque_own(t, Deque { sentinel, size }) &*& struct_Deque_padding(l);
 pred Deque_share(k: lifetime_t, t: thread_id_t, l: *Deque) = [_]frac_borrow(k, Deque_frac_borrow_content(t, l));
 
 // Proof obligations
@@ -126,7 +126,7 @@ impl Deque {
             //@ close_struct(sentinel);
             (*sentinel).prev = sentinel;
             (*sentinel).next = sentinel;
-            //@ close Deque_own(_t, sentinel, 0);
+            //@ close Deque_own(_t, Deque { sentinel, size: 0 });
             Deque { sentinel, size: 0 }
         }
     }

--- a/tests/rust/safe_abstraction/drop_test.rs
+++ b/tests/rust/safe_abstraction/drop_test.rs
@@ -5,7 +5,7 @@ pub struct Foo {
 
 /*@
 
-pred Foo_own(t: thread_id_t, fields1: i32, field2: u8) = true;
+pred Foo_own(t: thread_id_t, foo: Foo) = true;
 
 pred Foo_share(k: lifetime_t, t: thread_id_t, l: *Foo) = true;
 
@@ -42,7 +42,7 @@ pub struct Bar {
 
 /*@
 
-pred Bar_own(t: thread_id_t, fd: *mut u8) = true;
+pred Bar_own(t: thread_id_t, bar: Bar) = true;
 
 pred Bar_share(k: lifetime_t, t: thread_id_t, l: *Bar) = true;
 

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -156,7 +156,7 @@ pub struct Tree {
 
 /*@
 
-pred Tree_own(t: thread_id_t, root: *mut Node;) = Tree(root, 0, ?shape);
+pred Tree_own(t: thread_id_t, tree: Tree;) = Tree(tree.root, 0, ?shape);
 
 pred Tree_share(k: lifetime_t, t: thread_id_t, l: *Tree) = true;
 
@@ -226,9 +226,9 @@ impl Tree {
         unsafe {
             //@ open_full_borrow(_q_a/2, 'a, Tree_full_borrow_content(_t, self));
             //@ open Tree_full_borrow_content(_t, self)();
-            //@ open Tree_own(_t, (*self).root);
+            //@ open Tree_own(_t, ?tree);
             Self::accept0::<V>(self.root, true, visitor);
-            //@ close Tree_own(_t, (*self).root);
+            //@ close Tree_own(_t, tree);
             //@ close Tree_full_borrow_content(_t, self)();
             //@ close_full_borrow(Tree_full_borrow_content(_t, self));
             //@ leak full_borrow(_, _) &*& full_borrow(_, _);


### PR DESCRIPTION
For a struct S, the S_own predicate now takes a thread_id_t and an S value, instead of a thread_id_t and a value for each field of S.

This is in preparation for retiring _own predicates in favor of <T>.own. It also eliminates the difference between the treatment of structs whose body is known and those whose body is not known.

Also improves support for dereferencing struct pointers.
