### PR TITLE
[Rust] Define <S>.own and <S>.share for generic structs S

### DIFF
--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -1289,7 +1289,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           | None -> 
             let PredCtorInfo (_, tparams, ps1, ps2, inputParamCount, body, funcsym) = List.assoc g#name predctormap in
             let typeid_msg () = Printf.sprintf "Taking typeids of predicate constructor type arguments <%s>: " (String.concat ", " (List.map string_of_type targs)) in
-            let targs_typeids = List.map (typeid_of_core_core l typeid_msg env) targs' in
+            let targs_typeids = List.map (typeid_of_core_core l typeid_msg env) targs in
             let ctorargs = List.map (function SrcPat (LitPat e | WCtorPat (_, _, _, _, _, _, _, Some e)) -> ev e | _ -> static_error l "Patterns are not supported in predicate constructor argument positions." None) pats0 in
             let tpenv0 = List.combine tparams targs in
             let ctorargs = List.map2 (fun (_, pt) v -> prover_convert_term v (instantiate_type tpenv0 pt) pt) ps1 ctorargs in

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -1,17 +1,17 @@
 /*@
-pred ptr::NonNull_own<T>(t: thread_id_t, nonNull: ptr::NonNull<T>;) = nonNull.pointer as usize != 0;
+pred_ctor ptr::NonNull_own<T>()(t: thread_id_t, nonNull: ptr::NonNull<T>;) = nonNull.pointer as usize != 0;
 pred_ctor ptr::NonNull_frac_bc<T>(t: thread_id_t, l: *ptr::NonNull<T>)(;) = (*l).pointer |-> ?p &*& struct_ptr::NonNull_padding(l) &*& ptr::NonNull_own(t, ptr::NonNull::<T> { pointer: p });
-pred ptr::NonNull_share<T>(k: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T>) =
+pred_ctor ptr::NonNull_share<T>()(k: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T>) =
     frac_borrow(k, ptr::NonNull_frac_bc(t, l));
 
 lem ptr::NonNull_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T>)
     req lifetime_inclusion(k1, k) == true &*& [_]ptr::NonNull_share(k, t, l);
     ens [_]ptr::NonNull_share(k1, t, l);
 {
-    open ptr::NonNull_share(k, t, l);
+    open ptr::NonNull_share::<T>()(k, t, l);
     frac_borrow_mono(k, k1, ptr::NonNull_frac_bc(t, l));
     assert [?q]frac_borrow(k1, _);
-    close [q]ptr::NonNull_share(k1, t, l);
+    close [q]ptr::NonNull_share::<T>()(k1, t, l);
 }
 
 lem ptr::NonNull_share_full<T>(k: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T>)
@@ -79,14 +79,16 @@ pub mod ptr {
     impl<T> Copy for NonNull<T> {}
     impl<T> Clone for NonNull<T> {
         fn clone<'a>(&'a self) -> Self {
-            //@ open ptr::NonNull_share('a, _t, self);
+            //@ open ptr::NonNull_share::<T>()('a, _t, self);
             //@ open_frac_borrow('a, ptr::NonNull_frac_bc(_t, self), _q_a);
             //@ open ptr::NonNull_frac_bc::<T>(_t, self)();
             let r = *self;
-            //@ open ptr::NonNull_own::<T>(_t, _);
+            //@ open ptr::NonNull_own::<T>(_t, ?nnp);
             //@ assert [?qp](*self).pointer |-> _;
+            //@ close [qp]ptr::NonNull_own::<T>()(_t, nnp);
             //@ close [qp]ptr::NonNull_frac_bc::<T>(_t, self)();
             //@ close_frac_borrow(qp, ptr::NonNull_frac_bc(_t, self));
+            //@ close ptr::NonNull_own::<T>(_t, r);
             r
         }
     }

--- a/tests/rust/safe_abstraction/cell.rs
+++ b/tests/rust/safe_abstraction/cell.rs
@@ -6,7 +6,7 @@ pub struct Cell<T> {
 
 /*@
 
-pred Cell_own<T>(t: thread_id_t, cell: Cell<T>) = <T>.own(t, cell.v);
+pred_ctor Cell_own<T>()(t: thread_id_t, cell: Cell<T>) = <T>.own(t, cell.v);
 
 /*
 
@@ -22,7 +22,7 @@ pred_ctor Cell_nonatomic_borrow_content<T>(l: *Cell<T>, t: thread_id_t)() =
   Cell_v(l, ?v) &*& struct_Cell_padding(l) &*& Cell_own(t, Cell::<T> { v });
 
 // `SHR` for Cell<u32>
-pred Cell_share<T>(k: lifetime_t, t: thread_id_t, l: *Cell<T>) =
+pred_ctor Cell_share<T>()(k: lifetime_t, t: thread_id_t, l: *Cell<T>) =
   [_]nonatomic_borrow(k, t, MaskNshrSingle(l), Cell_nonatomic_borrow_content(l, t));
 
 // Proof obligations
@@ -30,11 +30,11 @@ lem Cell_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Cell<T
   req lifetime_inclusion(k1, k) == true &*& [_]Cell_share(k, t, l);
   ens [_]Cell_share(k1, t, l);
 {
-  open Cell_share(k, t, l);
+  open Cell_share::<T>()(k, t, l);
   assert [_]nonatomic_borrow(k, t, ?m, _);
   nonatomic_borrow_mono(k, k1, t, m, Cell_nonatomic_borrow_content(l, t));
-  close Cell_share(k1, t, l);
-  leak Cell_share(k1, t, l);
+  close Cell_share::<T>()(k1, t, l);
+  leak Cell_share::<T>()(k1, t, l);
 }
 
 lem Cell_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Cell<T>)
@@ -53,8 +53,8 @@ lem Cell_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Cell<T>)
     }
   }
   full_borrow_into_nonatomic_borrow_m(k, t, MaskNshrSingle(l), Cell_nonatomic_borrow_content(l, t));
-  close Cell_share(k, t, l);
-  leak Cell_share(k, t, l);
+  close Cell_share::<T>()(k, t, l);
+  leak Cell_share::<T>()(k, t, l);
 }
 @*/
 
@@ -70,7 +70,7 @@ impl<T> Cell<T> {
     
     fn replace<'a>(&'a self, v: T) -> T {
         unsafe {
-            //@ open Cell_share('a, _t, self);
+            //@ open Cell_share::<T>()('a, _t, self);
             //@ assert [_]nonatomic_borrow('a, _t, ?mask, Cell_nonatomic_borrow_content(self, _t));
             //@ open thread_token(_t);
             //@ thread_token_split(_t, MaskTop, mask);
@@ -92,8 +92,8 @@ impl<T> Cell<T> {
     }
 
     fn swap<'a>(&'a self, other: &'a Self) {
-        //@ open Cell_share('a, _t, self);
-        //@ open Cell_share('a, _t, other);
+        //@ open Cell_share::<T>()('a, _t, self);
+        //@ open Cell_share::<T>()('a, _t, other);
         if self as *const Cell<T> == other as *const Cell<T> {
             return;
         }

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -154,7 +154,7 @@ pred Deque_<T>(sentinel: *Node<T>; elems: list<T>) =
 pred_ctor elem_own<T>(t: thread_id_t)(elem: T) =
     <T>.own(t, elem);
 
-pred Deque_own<T>(t: thread_id_t, deque: Deque<T>) =
+pred_ctor Deque_own<T>()(t: thread_id_t, deque: Deque<T>) =
     Deque_(deque.sentinel, ?elems) &*& deque.size == length(elems) &*& foreach(elems, elem_own::<T>(t));
 
 pred Deque<T>(deque: *Deque<T>, elems: list<T>) =
@@ -168,7 +168,7 @@ pred_ctor Deque_frac_borrow_content<T>(nodes: list<*Node<T>>, t: thread_id_t, l:
 pred_ctor elem_share<T>(k: lifetime_t, t: thread_id_t)(l: *Node<T>) =
     [_](<T>.share)(k, t, &(*l).value);
 
-pred Deque_share<T>(k: lifetime_t, t: thread_id_t, l: *Deque<T>) =
+pred_ctor Deque_share<T>()(k: lifetime_t, t: thread_id_t, l: *Deque<T>) =
     exists::<list<*Node<T>>>(?nodes) &*&
     [_]frac_borrow(k, Deque_frac_borrow_content(nodes, t, l)) &*&
     foreach(nodes, elem_share::<T>(k, t));
@@ -228,7 +228,7 @@ lem Deque_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Deque<T>)
 {
     let klong = open_full_borrow_strong_m(k, Deque_full_borrow_content(t, l), q);
     open Deque_full_borrow_content::<T>(t, l)();
-    open Deque_own(t, ?deque);
+    open Deque_own::<T>()(t, ?deque);
     open Deque_(deque.sentinel, _);
     assert Deque__(deque.sentinel, ?nodes);
     produce_lem_ptr_chunk full_borrow_convert_strong(True, sep(Deque_frac_borrow_content(nodes, t, l), elems_fbc(t, nodes)), klong, Deque_full_borrow_content(t, l))() {
@@ -249,8 +249,8 @@ lem Deque_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Deque<T>)
     full_borrow_into_frac_m(k, Deque_frac_borrow_content(nodes, t, l));
     elems_share_full(t, nodes);
     close exists(nodes);
-    close Deque_share(k, t, l);
-    leak Deque_share(k, t, l);
+    close Deque_share::<T>()(k, t, l);
+    leak Deque_share::<T>()(k, t, l);
 }
 
 lem foreach_elem_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t)
@@ -279,7 +279,7 @@ lem Deque_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Deque
     frac_borrow_mono(k, k1, Deque_frac_borrow_content(nodes, t, l));
     foreach_elem_share_mono::<T>(k, k1, t);
     close [q]exists(nodes);
-    close [q]Deque_share(k1, t, l);
+    close [q]Deque_share::<T>()(k1, t, l);
 }
 
 @*/
@@ -296,13 +296,13 @@ impl<T> Deque<T> {
             (*sentinel).prev = sentinel;
             (*sentinel).next = sentinel;
             //@ close foreach(nil, elem_own::<T>(_t));
-            //@ close Deque_own(_t, Deque::<T> { sentinel, size: 0 });
+            //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: 0 });
             Deque { sentinel, size: 0 }
         }
     }
 
     pub fn get_size<'a>(&'a self) -> i32 {
-        //@ open Deque_share('a, _t, self);
+        //@ open Deque_share::<T>()('a, _t, self);
         //@ assert [?q]exists(?nodes);
         //@ open_frac_borrow('a, Deque_frac_borrow_content(nodes, _t, self), _q_a);
         //@ open [?qf]Deque_frac_borrow_content::<T>(nodes, _t, self)();
@@ -341,7 +341,7 @@ impl<T> Deque<T> {
     pub fn push_front<'a>(&'a mut self, value: T) {
         //@ open_full_borrow(_q_a, 'a, Deque_full_borrow_content(_t, self));
         //@ open Deque_full_borrow_content::<T>(_t, self)();
-        //@ open Deque_own(_t, ?deque);
+        //@ open Deque_own::<T>()(_t, ?deque);
         if (*self).size < 0x7fffffff {
             unsafe {
                 //@ close Deque(self, ?elems);
@@ -354,7 +354,7 @@ impl<T> Deque<T> {
         //@ let sentinel = (*self).sentinel;
         //@ close elem_own::<T>(_t)(value);
         //@ close foreach(cons(value, elems), elem_own::<T>(_t));
-        //@ close Deque_own(_t, Deque::<T> { sentinel, size: deque.size + 1 });
+        //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size + 1 });
         //@ close Deque_full_borrow_content::<T>(_t, self)();
         //@ close_full_borrow(Deque_full_borrow_content(_t, self));
         //@ leak full_borrow(_, _);
@@ -407,7 +407,7 @@ impl<T> Deque<T> {
     pub fn push_back<'a>(&'a mut self, value: T) {
         //@ open_full_borrow(_q_a, 'a, Deque_full_borrow_content(_t, self));
         //@ open Deque_full_borrow_content::<T>(_t, self)();
-        //@ open Deque_own(_t, ?deque);
+        //@ open Deque_own::<T>()(_t, ?deque);
         if (*self).size < 0x7fffffff {
             unsafe {
                 //@ close Deque(self, ?elems);
@@ -422,7 +422,7 @@ impl<T> Deque<T> {
         //@ close foreach([], elem_own::<T>(_t));
         //@ close foreach([value], elem_own::<T>(_t));
         //@ foreach_append(elems, [value]);
-        //@ close Deque_own(_t, Deque::<T> { sentinel, size: deque.size + 1 });
+        //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size + 1 });
         //@ close Deque_full_borrow_content::<T>(_t, self)();
         //@ close_full_borrow(Deque_full_borrow_content(_t, self));
         //@ leak full_borrow(_, _);
@@ -456,7 +456,7 @@ impl<T> Deque<T> {
     {
         //@ open_full_borrow(_q, a, Deque_full_borrow_content(_t, self));
         //@ open Deque_full_borrow_content::<T>(_t, self)();
-        //@ open Deque_own(_t, ?deque);
+        //@ open Deque_own::<T>()(_t, ?deque);
         if (*self).size == 0 {
             std::process::abort();
         }
@@ -467,7 +467,7 @@ impl<T> Deque<T> {
             //@ let sentinel = (*self).sentinel;
             //@ open foreach(_, _);
             //@ open elem_own::<T>(_t)(result);
-            //@ close Deque_own(_t, Deque::<T> { sentinel, size: deque.size - 1 });
+            //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size - 1 });
             //@ close Deque_full_borrow_content::<T>(_t, self)();
             //@ close_full_borrow(Deque_full_borrow_content(_t, self));
             //@ leak full_borrow(_, _);
@@ -518,7 +518,7 @@ impl<T> Deque<T> {
     pub fn pop_back<'a>(&'a mut self) -> T {
         //@ open_full_borrow(_q_a, 'a, Deque_full_borrow_content(_t, self));
         //@ open Deque_full_borrow_content::<T>(_t, self)();
-        //@ open Deque_own(_t, ?deque);
+        //@ open Deque_own::<T>()(_t, ?deque);
         if (*self).size == 0 {
             std::process::abort();
         }
@@ -533,7 +533,7 @@ impl<T> Deque<T> {
             //@ open foreach(tail(drop(length(elems) - 1, elems)), _);
             //@ nth_drop(0, length(elems) - 1, elems);
             //@ open elem_own::<T>(_t)(result);
-            //@ close Deque_own(_t, Deque::<T> { sentinel, size: deque.size - 1 });
+            //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size - 1 });
             //@ close Deque_full_borrow_content::<T>(_t, self)();
             //@ close_full_borrow(Deque_full_borrow_content(_t, self));
             //@ leak full_borrow(_, _);
@@ -578,7 +578,7 @@ impl<T> Drop for Deque<T> {
     {
         unsafe {
             //@ open Deque_full_borrow_content::<T>(_t, self)();
-            //@ open Deque_own(_t, ?deque);
+            //@ open Deque_own::<T>()(_t, ?deque);
             Self::dispose_nodes((*(self.sentinel)).next, self.sentinel);
             //@ open_struct((*self).sentinel);
             std::alloc::dealloc(self.sentinel as *mut u8, std::alloc::Layout::new::<Node<T>>());

--- a/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
+++ b/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
@@ -230,7 +230,7 @@ pub struct MutexGuardU32<'a> {
 /*@
 
 // TODO: Is this extra lifetime `klong` necessary here?
-pred MutexGuardU32_own<'a>(t: thread_id_t, mutexGuardU32: MutexGuardU32<'a>) =
+pred_ctor MutexGuardU32_own<'a>()(t: thread_id_t, mutexGuardU32: MutexGuardU32<'a>) =
     [_]exists_np(?klong) &*& lifetime_inclusion('a, klong) == true &*& [_]frac_borrow('a, MutexU32_frac_borrow_content(klong, mutexGuardU32.lock))
     &*& SysMutex_locked(&(*mutexGuardU32.lock).inner, full_borrow_(klong, u32_full_borrow_content(t0, &(*mutexGuardU32.lock).data)), t)
     &*& full_borrow(klong, u32_full_borrow_content(t0, &(*mutexGuardU32.lock).data));
@@ -240,7 +240,7 @@ pred_ctor MutexGuardU32_fbc_rest<'a>(klong: lifetime_t, t: thread_id_t, l: *Mute
     &*& [_]frac_borrow('a, MutexU32_frac_borrow_content(klong, lock))
     &*& SysMutex_locked(&(*lock).inner, full_borrow_(klong, u32_full_borrow_content(t0, &(*lock).data)), t);
 
-pred MutexGuardU32_share<'a>(k: lifetime_t, t: thread_id_t, l: *MutexGuardU32<'a>) = true;
+pred_ctor MutexGuardU32_share<'a>()(k: lifetime_t, t: thread_id_t, l: *MutexGuardU32<'a>) = true;
 
 lem MutexGuardU32_share_mono<'a>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *MutexGuardU32<'a>)
     req lifetime_inclusion(k1, k) == true &*& [_]MutexGuardU32_share::<'a>(k, t, l);

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -30,7 +30,7 @@ pred_ctor rc_na_inv<T>(dk: lifetime_t, gid: usize, ptr: *RcBox<T>, t: thread_id_
 
 inductive wrap<t> = wrap(t);
 
-pred Rc_own<T>(t: thread_id_t, rc: Rc<T>) =
+pred_ctor Rc_own<T>()(t: thread_id_t, rc: Rc<T>) =
     wrap::<*RcBox<T>>(std::ptr::NonNull_ptr(rc.ptr)) == wrap(?ptr) &*&
     ptr as usize != 0 &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(ptr), rc_na_inv(dk, gid, ptr, t)) &*&
@@ -42,7 +42,7 @@ pred_ctor Rc_frac_bc<T>(l: *Rc<T>, nnp: std::ptr::NonNull<RcBox<T>>)(;) = (*l).p
 
 pred_ctor ticket_(dk: lifetime_t, gid: usize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);
 
-pred Rc_share<T>(k: lifetime_t, t: thread_id_t, l: *Rc<T>) =
+pred_ctor Rc_share<T>()(k: lifetime_t, t: thread_id_t, l: *Rc<T>) =
     [_]exists(?nnp) &*& [_]frac_borrow(k, Rc_frac_bc(l, nnp)) &*&
     wrap::<*RcBox<T>>(std::ptr::NonNull_ptr(nnp)) == wrap(?ptr) &*& ptr as usize != 0 &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(ptr), rc_na_inv(dk, gid, ptr, t)) &*&

--- a/tests/rust/unverified/sys/spec/lib.rsspec
+++ b/tests/rust/unverified/sys/spec/lib.rsspec
@@ -3,8 +3,14 @@ mod locks {
     struct Mutex;
 
     /*@
+    
+    pred Mutex_own(t: thread_id_t, m: sys::locks::Mutex);
 
     pred SysMutex(m: sys::locks::Mutex; P: pred());
+    
+    lem SysMutex_to_own(t: thread_id_t);
+        req SysMutex(?m, _);
+        ens Mutex_own(t, m);
 
     pred SysMutex_share(l: *sys::locks::Mutex; P: pred());
 


### PR DESCRIPTION
This requires that S_own and S_share be predicate constructors, because it must be possible to pre-apply the type arguments.

VeriFast now also generates an S_drop proof obligation for generic structs S that are not trivially droppable and that do not implement the Drop trait.
