### PR TITLE
[Rust] Inline type predicate definitions

### DIFF
--- a/bin/rust/rust_belt/general.rsspec
+++ b/bin/rust/rust_belt/general.rsspec
@@ -139,7 +139,7 @@ pred u32_share(k: lifetime_t, t: thread_id_t, l: *u32) = [_]frac_borrow(k, u32_f
 
 type_pred_decl <Self>.own : pred(thread_id_t, Self);
 type_pred_decl <Self>.full_borrow_content : fix(thread_id_t, *_, pred());
-type_pred_decl <Self>.share : pred(lifetime_t, thread_id_t, *_);
+type_pred_decl <Self>.share : pred(lifetime_t, thread_id_t, *Self);
 
 pred_ctor own<T>(t: thread_id_t)(v: T) = (<T>.own)(t, v);
 

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -932,7 +932,7 @@ and
   | RequireModuleDecl of loc * string
   | ModuleDecl of loc * string * import list * decl list (* A Rust module. Is flattened into a list of PackageDecl after parsing. *)
   | TypePredDecl of loc * type_expr * string * string
-  | TypePredDef of loc * string list * type_expr * string * loc * string
+  | TypePredDef of loc * string list * type_expr * string * (loc * string, string list * int option * asn) Either.t
   | TypeWithTypeidDecl of (* introduce a local type name whose typeid is given by the expression *)
       loc *
       string *

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -1039,14 +1039,17 @@ and of_decl = function
     S selfTypeName;
     S predName
   ])
-| TypePredDef (l, tparams, te, predName, lrhs, rhs) ->
+| TypePredDef (l, tparams, te, predName, rhs) ->
   C ("TypePredDef", [
     of_loc l;
     of_list s tparams;
     of_type_expr te;
     S predName;
-    of_loc lrhs;
-    S rhs
+    match rhs with
+      Left (lrhs, rhs) ->
+      C ("Left", [of_loc lrhs; S rhs])
+    | Right (ps, inputParamCount, a) ->
+      C ("Right", [of_list s ps; of_option i inputParamCount; of_expr a])
   ])
 | TypeWithTypeidDecl (l, tn, e) ->
   C ("TypeWithTypeidDecl", [of_loc l; s tn; of_expr e])

--- a/src/frontend/parser.ml
+++ b/src/frontend/parser.ml
@@ -1144,7 +1144,7 @@ and
   | te -> raise (ParseException (type_expr_loc te, "Type parameter name expected"))
   in
   if targ_names <> tparams then raise (ParseException (lrhs, "Right-hand side type arguments must match definition type parameters"));
-  [TypePredDef (l, tparams, tp, predName, lrhs, rhs)]
+  [TypePredDef (l, tparams, tp, predName, Left (lrhs, rhs))]
 and
   parse_action_decls = function%parser
 | [ parse_action_decl as ad; 

--- a/src/rust_frontend/vf_mir_translator/rustbelt.ml
+++ b/src/rust_frontend/vf_mir_translator/rustbelt.ml
@@ -9,9 +9,7 @@ type vid = string (* value id *)
 type ty_interp = {
   size : expr;
   own : tid -> v -> (asn, string) result;
-  own_pred : (Ast.expr, string) result;
   shr : lft -> tid -> l -> (asn, string) result; (* Should be duplicable, e.g. a dummy pattern. The caller will not wrap this in a dummy coef asn. *)
-  shr_pred : (Ast.expr, string) result; (* Need not be duplicable; the caller will wrap this in a dummy pattern. *)
   full_bor_content : tid -> l -> (Ast.expr, string) result;
   points_to : tid -> l -> vid option -> (asn, string) result;
 }
@@ -22,9 +20,7 @@ let emp_ty_interp loc =
   {
     size = True loc;
     own = (fun _ _ -> Ok (True loc));
-    own_pred = Error "Not yet supported";
     shr = (fun _ _ _ -> Error "Not yet supported");
-    shr_pred = Error "Not yet supported";
     full_bor_content = (fun _ _ -> Error "Not yet supported");
     points_to = (fun _ _ _ -> Ok (True loc));
   }

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -1,7 +1,7 @@
 /*@
-pred_ctor ptr::NonNull_own<T>()(t: thread_id_t, nonNull: ptr::NonNull<T>;) = nonNull.pointer as usize != 0;
+pred<T> <ptr::NonNull<T>>.own(t, nonNull;) = nonNull.pointer as usize != 0;
 pred_ctor ptr::NonNull_frac_bc<T>(t: thread_id_t, l: *ptr::NonNull<T>)(;) = (*l).pointer |-> ?p &*& struct_ptr::NonNull_padding(l) &*& ptr::NonNull_own(t, ptr::NonNull::<T> { pointer: p });
-pred_ctor ptr::NonNull_share<T>()(k: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T>) =
+pred<T> <ptr::NonNull<T>>.share(k, t, l) =
     frac_borrow(k, ptr::NonNull_frac_bc(t, l));
 
 lem ptr::NonNull_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T>)

--- a/tests/rust/purely_unsafe/account_with_box.rs
+++ b/tests/rust/purely_unsafe/account_with_box.rs
@@ -13,8 +13,8 @@ pred Account(account: *Account; balance: i32) =
     std::alloc::alloc_block(account as *u8, std::alloc::Layout::new_::<Account>()) &*& struct_Account_padding(account) &*&
     (*account).balance |-> balance;
 
-pred Account_own(t: thread_id_t, account: Account) = true;
-pred Account_share(k: lifetime_t, t: thread_id_t, l: *Account) = true;
+pred <Account>.own(t, account) = true;
+pred <Account>.share(k, t, l) = true;
 
 lem Account_share_full(k: lifetime_t, t: thread_id_t, l: *Account)
     req full_borrow(k, Account_full_borrow_content(t, l));

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -24,14 +24,14 @@ pred_ctor Arc_inv<T>(dk: lifetime_t, gid: isize, ptr: *ArcInner<T>)() = counting
     std::alloc::alloc_block(ptr as *u8, std::alloc::Layout::new_::<ArcInner<T>>()) &*& struct_ArcInner_padding::<T>(ptr) &*&
     borrow_end_token(dk, <T>.full_borrow_content(default_tid, &(*ptr).data)) };
 
-pred_ctor Arc_own<T>()(t: thread_id_t, arc: Arc<T>) = [_]std::ptr::NonNull_own(default_tid, arc.ptr) &*& [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInner<T>>(arc.ptr) == ptr &*&
+pred<T> <Arc<T>>.own(t, arc) = [_]std::ptr::NonNull_own(default_tid, arc.ptr) &*& [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInner<T>>(arc.ptr) == ptr &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*& ticket(dlft_pred(dk), gid, ?frac) &*& [frac]dlft_pred(dk)(gid, false) &*&
     [_](<T>.share)(dk, default_tid, &(*ptr).data) &*& pointer_within_limits(&(*ptr).data) == true &*& is_Send(typeid(T)) == true;
 
 pred_ctor Arc_frac_bc<T>(l: *Arc<T>, nnp: std::ptr::NonNull<ArcInner<T>>)(;) = (*l).ptr |-> nnp;
 pred_ctor ticket_(dk: lifetime_t, gid: isize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);
 
-pred_ctor Arc_share<T>()(k: lifetime_t, t: thread_id_t, l: *Arc<T>) = [_]exists(?nnp) &*& [_]frac_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
+pred<T> <Arc<T>>.share(k, t, l) = [_]exists(?nnp) &*& [_]frac_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
     [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInner<T>>(nnp) == ptr &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
     [_]exists(?frac) &*& [_]frac_borrow(k, ticket_(dk, gid, frac)) &*& [_]frac_borrow(k, lifetime_token_(frac, dk)) &*& [_](<T>.share)(dk, default_tid, &(*ptr).data) &*&
     pointer_within_limits(&(*ptr).data) == true;

--- a/tests/rust/safe_abstraction/arc_u32.rs
+++ b/tests/rust/safe_abstraction/arc_u32.rs
@@ -26,14 +26,14 @@ pred_ctor Arc_inv(dk: lifetime_t, gid: isize, ptr: *ArcInnerU32)() = counting(dl
     std::alloc::alloc_block(ptr as *u8, std::alloc::Layout::new_::<ArcInnerU32>()) &*& struct_ArcInnerU32_padding(ptr) &*&
     borrow_end_token(dk, u32_full_borrow_content(default_tid, &(*ptr).data)) };
 
-pred ArcU32_own(t: thread_id_t, arcU32: ArcU32) = [_]std::ptr::NonNull_own(default_tid, arcU32.ptr) &*& [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInnerU32>(arcU32.ptr) == ptr &*&
+pred <ArcU32>.own(t, arcU32) = [_]std::ptr::NonNull_own(default_tid, arcU32.ptr) &*& [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInnerU32>(arcU32.ptr) == ptr &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*& ticket(dlft_pred(dk), gid, ?frac) &*& [frac]dlft_pred(dk)(gid, false) &*&
     [_]u32_share(dk, default_tid, &(*ptr).data) &*& pointer_within_limits(&(*ptr).data) == true;
 
 pred_ctor Arc_frac_bc(l: *ArcU32, nnp: std::ptr::NonNull<ArcInnerU32>)(;) = (*l).ptr |-> nnp;
 pred_ctor ticket_(dk: lifetime_t, gid: isize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);
 
-pred ArcU32_share(k: lifetime_t, t: thread_id_t, l: *ArcU32) = [_]exists(?nnp) &*& [_]frac_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
+pred <ArcU32>.share(k, t, l) = [_]exists(?nnp) &*& [_]frac_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
     [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInnerU32>(nnp) == ptr &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
     [_]exists(?frac) &*& [_]frac_borrow(k, ticket_(dk, gid, frac)) &*& [_]frac_borrow(k, lifetime_token_(frac, dk)) &*& [_]u32_share(dk, default_tid, &(*ptr).data) &*&
     pointer_within_limits(&(*ptr).data) == true;

--- a/tests/rust/safe_abstraction/cell.rs
+++ b/tests/rust/safe_abstraction/cell.rs
@@ -6,7 +6,7 @@ pub struct Cell<T> {
 
 /*@
 
-pred_ctor Cell_own<T>()(t: thread_id_t, cell: Cell<T>) = <T>.own(t, cell.v);
+pred<T> <Cell<T>>.own(t, cell) = <T>.own(t, cell.v);
 
 /*
 
@@ -22,13 +22,13 @@ pred_ctor Cell_nonatomic_borrow_content<T>(l: *Cell<T>, t: thread_id_t)() =
   Cell_v(l, ?v) &*& struct_Cell_padding(l) &*& Cell_own(t, Cell::<T> { v });
 
 // `SHR` for Cell<u32>
-pred_ctor Cell_share<T>()(k: lifetime_t, t: thread_id_t, l: *Cell<T>) =
+pred<T> <Cell<T>>.share(k, t, l) =
   [_]nonatomic_borrow(k, t, MaskNshrSingle(l), Cell_nonatomic_borrow_content(l, t));
 
 // Proof obligations
 lem Cell_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Cell<T>)
-  req lifetime_inclusion(k1, k) == true &*& [_]Cell_share(k, t, l);
-  ens [_]Cell_share(k1, t, l);
+  req lifetime_inclusion(k1, k) == true &*& [_]Cell_share::<T>(k, t, l);
+  ens [_]Cell_share::<T>(k1, t, l);
 {
   open Cell_share::<T>()(k, t, l);
   assert [_]nonatomic_borrow(k, t, ?m, _);
@@ -39,7 +39,7 @@ lem Cell_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Cell<T
 
 lem Cell_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Cell<T>)
   req atomic_mask(Nlft) &*& full_borrow(k, Cell_full_borrow_content(t, l)) &*& [?q]lifetime_token(k);
-  ens atomic_mask(Nlft) &*& [_]Cell_share(k, t, l) &*& [q]lifetime_token(k);
+  ens atomic_mask(Nlft) &*& [_]Cell_share::<T>(k, t, l) &*& [q]lifetime_token(k);
 {
   produce_lem_ptr_chunk implies(Cell_full_borrow_content(t, l), Cell_nonatomic_borrow_content(l, t))() {
     open Cell_full_borrow_content::<T>(t, l)();

--- a/tests/rust/safe_abstraction/cell_u32.rs
+++ b/tests/rust/safe_abstraction/cell_u32.rs
@@ -7,7 +7,7 @@ pub struct CellU32 {
 // Interpretation
 // `OWN` for Cell<u32>
 // [[cell(tau)]].OWN(t, vs) = [[tau]].OWN(t, vs)
-pred CellU32_own(t: thread_id_t, cellU32: CellU32;) = true; // The `v` parameter type carries the info
+pred <CellU32>.own(t, cellU32;) = true; // The `v` parameter type carries the info
 
 /* A note on `|= cell(tau) copy` judgement:
 In RustBelt `|= tau copy => |= cell(tau) copy` but it is not the case in Rust as it is prohibited
@@ -22,7 +22,7 @@ pred_ctor CellU32_nonatomic_borrow_content(l: *CellU32, t: thread_id_t)(;) =
   (*l).v |-> ?v &*& struct_CellU32_padding(l);
 
 // `SHR` for Cell<u32>
-pred CellU32_share(k: lifetime_t, t: thread_id_t, l: *CellU32) =
+pred <CellU32>.share(k, t, l) =
   [_]nonatomic_borrow(k, t, MaskNshrSingle(l), CellU32_nonatomic_borrow_content(l, t));
 
 // Proof obligations

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -154,7 +154,7 @@ pred Deque_<T>(sentinel: *Node<T>; elems: list<T>) =
 pred_ctor elem_own<T>(t: thread_id_t)(elem: T) =
     <T>.own(t, elem);
 
-pred_ctor Deque_own<T>()(t: thread_id_t, deque: Deque<T>) =
+pred<T> <Deque<T>>.own(t, deque) =
     Deque_(deque.sentinel, ?elems) &*& deque.size == length(elems) &*& foreach(elems, elem_own::<T>(t));
 
 pred Deque<T>(deque: *Deque<T>, elems: list<T>) =
@@ -168,7 +168,7 @@ pred_ctor Deque_frac_borrow_content<T>(nodes: list<*Node<T>>, t: thread_id_t, l:
 pred_ctor elem_share<T>(k: lifetime_t, t: thread_id_t)(l: *Node<T>) =
     [_](<T>.share)(k, t, &(*l).value);
 
-pred_ctor Deque_share<T>()(k: lifetime_t, t: thread_id_t, l: *Deque<T>) =
+pred<T> <Deque<T>>.share(k, t, l) =
     exists::<list<*Node<T>>>(?nodes) &*&
     [_]frac_borrow(k, Deque_frac_borrow_content(nodes, t, l)) &*&
     foreach(nodes, elem_share::<T>(k, t));

--- a/tests/rust/safe_abstraction/deque_i32.rs
+++ b/tests/rust/safe_abstraction/deque_i32.rs
@@ -76,7 +76,7 @@ pred Deque_(sentinel: *Node; elems: list<i32> ) =
     (*sentinel).next |-> ?first &*&
     Nodes(first, sentinel, last, sentinel, elems);
 
-pred Deque_own(t: thread_id_t, deque: Deque;) =
+pred <Deque>.own(t, deque;) =
     Deque_(deque.sentinel, ?elems) &*& deque.size == length(elems);
 
 pred Deque(deque: *Deque; elems: list<i32>) =
@@ -84,7 +84,7 @@ pred Deque(deque: *Deque; elems: list<i32>) =
 
 pred_ctor Deque_frac_borrow_content(t: thread_id_t, l: *Deque)(;) =
     (*l).sentinel |-> ?sentinel &*& (*l).size |-> ?size &*& Deque_own(t, Deque { sentinel, size }) &*& struct_Deque_padding(l);
-pred Deque_share(k: lifetime_t, t: thread_id_t, l: *Deque) = [_]frac_borrow(k, Deque_frac_borrow_content(t, l));
+pred <Deque>.share(k, t, l) = [_]frac_borrow(k, Deque_frac_borrow_content(t, l));
 
 // Proof obligations
 lem Deque_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Deque)

--- a/tests/rust/safe_abstraction/drop_test.rs
+++ b/tests/rust/safe_abstraction/drop_test.rs
@@ -5,9 +5,9 @@ pub struct Foo {
 
 /*@
 
-pred Foo_own(t: thread_id_t, foo: Foo) = true;
+pred <Foo>.own(t, foo) = true;
 
-pred Foo_share(k: lifetime_t, t: thread_id_t, l: *Foo) = true;
+pred <Foo>.share(k, t, l) = true;
 
 lem Foo_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Foo)
     req lifetime_inclusion(k1, k) == true &*& [_]Foo_share(k, t, l);

--- a/tests/rust/safe_abstraction/generic_pair.rs
+++ b/tests/rust/safe_abstraction/generic_pair.rs
@@ -5,7 +5,7 @@ pub struct Pair<A, B> {
 
 /*@
 
-pred_ctor Pair_own<A, B>()(t: thread_id_t, pair: Pair<A, B>) = <A>.own(t, pair.fst) &*& <B>.own(t, pair.snd);
+pred<A, B> <Pair<A, B>>.own(t, pair) = <A>.own(t, pair.fst) &*& <B>.own(t, pair.snd);
 
 lem Pair_drop<A, B>()
     req Pair_own::<A, B>(?t, ?pair);
@@ -14,7 +14,7 @@ lem Pair_drop<A, B>()
     open Pair_own::<A, B>(t, pair);
 }
 
-pred_ctor Pair_share<A, B>()(k: lifetime_t, t: thread_id_t, l: *Pair<A, B>) =
+pred<A, B> <Pair<A, B>>.share(k, t, l) =
     [_](<A>.share)(k, t, &(*l).fst) &*&
     pointer_within_limits(&(*l).snd) == true &*&
     [_](<B>.share)(k, t, &(*l).snd);

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -1,3 +1,5 @@
+// verifast_options{extern:../unverified/sys}
+
 #![feature(negative_impls)]
 #![allow(dead_code)]
 
@@ -14,7 +16,7 @@ pub struct Mutex<T: Send> {
 /*@
 
 pred True(;) = true;
-pred_ctor Mutex_own<T>()(t: thread_id_t, mutex: Mutex<T>) =
+pred<T> <Mutex<T>>.own(t, mutex) =
     sys::locks::SysMutex(mutex.inner, True) &*& <T>.own(t, mutex.data);
 
 lem Mutex_drop<T>()
@@ -32,7 +34,7 @@ fix t0() -> thread_id_t { default_value }
 pred_ctor Mutex_frac_borrow_content<T>(kfcc: lifetime_t, l: *Mutex<T>)(;) =
     sys::locks::SysMutex_share(&(*l).inner, full_borrow_(kfcc, <T>.full_borrow_content(t0, &(*l).data))) &*& struct_Mutex_padding(l);
 
-pred_ctor Mutex_share<T>()(k: lifetime_t, t: thread_id_t, l: *Mutex<T>) =
+pred<T> <Mutex<T>>.share(k, t, l) =
     exists_np(?kfcc) &*& lifetime_inclusion(k, kfcc) == true &*& frac_borrow(k, Mutex_frac_borrow_content::<T>(kfcc, l));
 
 lem Mutex_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Mutex<T>)
@@ -144,7 +146,7 @@ pub struct MutexGuard<'a, T: Send> {
 /*@
 
 // TODO: Is this extra lifetime `klong` necessary here?
-pred_ctor MutexGuard_own<'a, T>()(t: thread_id_t, mutexGuard: MutexGuard<'a, T>) =
+pred<'a, T> <MutexGuard<'a, T>>.own(t, mutexGuard) =
     [_]exists_np(?klong) &*& lifetime_inclusion('a, klong) == true &*& [_]frac_borrow('a, Mutex_frac_borrow_content(klong, mutexGuard.lock))
     &*& sys::locks::SysMutex_locked(&(*mutexGuard.lock).inner, full_borrow_(klong, <T>.full_borrow_content(t0, &(*mutexGuard.lock).data)), t)
     &*& full_borrow(klong, <T>.full_borrow_content(t0, &(*mutexGuard.lock).data));
@@ -154,7 +156,7 @@ pred_ctor MutexGuard_fbc_rest<'a, T>(klong: lifetime_t, t: thread_id_t, l: *Mute
     &*& [_]frac_borrow('a, Mutex_frac_borrow_content(klong, lock))
     &*& sys::locks::SysMutex_locked(&(*lock).inner, full_borrow_(klong, <T>.full_borrow_content(t0, &(*lock).data)), t);
 
-pred_ctor MutexGuard_share<'a, T>()(k: lifetime_t, t: thread_id_t, l: *MutexGuard<'a, T>) = true;
+pred<'a, T> <MutexGuard<'a, T>>.share(k, t, l) = true;
 
 lem MutexGuard_share_mono<'a, T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *MutexGuard<'a, T>)
     req lifetime_inclusion(k1, k) == true &*& [_]MutexGuard_share::<'a, T>(k, t, l);

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -112,7 +112,7 @@ pub struct MutexU32 {
 /*@
 
 pred True(;) = true;
-pred MutexU32_own(t: thread_id_t, mutexU32: MutexU32) = SysMutex(mutexU32.inner, True);
+pred <MutexU32>.own(t, mutexU32) = SysMutex(mutexU32.inner, True);
 
 lem MutexU32_drop()
     req MutexU32_own(?t, ?mutexU32);
@@ -129,7 +129,7 @@ fix t0() -> thread_id_t { default_value }
 pred_ctor MutexU32_frac_borrow_content(kfcc: lifetime_t, l: *MutexU32)(;) =
     SysMutex_share(&(*l).inner, full_borrow_(kfcc, u32_full_borrow_content(t0, &(*l).data))) &*& struct_MutexU32_padding(l);
 
-pred MutexU32_share(k: lifetime_t, t: thread_id_t, l: *MutexU32) =
+pred <MutexU32>.share(k, t, l) =
     exists_np(?kfcc) &*& lifetime_inclusion(k, kfcc) == true &*& frac_borrow(k, MutexU32_frac_borrow_content(kfcc, l));
 
 lem MutexU32_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *MutexU32)

--- a/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
+++ b/tests/rust/safe_abstraction/mutex_u32_with_lft_param.rs
@@ -112,7 +112,7 @@ pub struct MutexU32 {
 /*@
 
 pred True(;) = true;
-pred MutexU32_own(t: thread_id_t, mutexU32: MutexU32) = SysMutex(mutexU32.inner, True);
+pred <MutexU32>.own(t, mutexU32) = SysMutex(mutexU32.inner, True);
 
 lem MutexU32_drop()
     req MutexU32_own(?t, ?mutexU32);
@@ -129,7 +129,7 @@ fix t0() -> thread_id_t { default_value }
 pred_ctor MutexU32_frac_borrow_content(kfcc: lifetime_t, l: *MutexU32)(;) =
     SysMutex_share(&(*l).inner, full_borrow_(kfcc, u32_full_borrow_content(t0, &(*l).data))) &*& struct_MutexU32_padding(l);
 
-pred MutexU32_share(k: lifetime_t, t: thread_id_t, l: *MutexU32) =
+pred <MutexU32>.share(k, t, l) =
     exists_np(?kfcc) &*& lifetime_inclusion(k, kfcc) == true &*& frac_borrow(k, MutexU32_frac_borrow_content(kfcc, l));
 
 lem MutexU32_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *MutexU32)

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -30,7 +30,7 @@ pred_ctor rc_na_inv<T>(dk: lifetime_t, gid: usize, ptr: *RcBox<T>, t: thread_id_
 
 inductive wrap<t> = wrap(t);
 
-pred_ctor Rc_own<T>()(t: thread_id_t, rc: Rc<T>) =
+pred<T> <Rc<T>>.own(t, rc) =
     wrap::<*RcBox<T>>(std::ptr::NonNull_ptr(rc.ptr)) == wrap(?ptr) &*&
     ptr as usize != 0 &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(ptr), rc_na_inv(dk, gid, ptr, t)) &*&
@@ -42,7 +42,7 @@ pred_ctor Rc_frac_bc<T>(l: *Rc<T>, nnp: std::ptr::NonNull<RcBox<T>>)(;) = (*l).p
 
 pred_ctor ticket_(dk: lifetime_t, gid: usize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);
 
-pred_ctor Rc_share<T>()(k: lifetime_t, t: thread_id_t, l: *Rc<T>) =
+pred<T> <Rc<T>>.share(k, t, l) =
     [_]exists(?nnp) &*& [_]frac_borrow(k, Rc_frac_bc(l, nnp)) &*&
     wrap::<*RcBox<T>>(std::ptr::NonNull_ptr(nnp)) == wrap(?ptr) &*& ptr as usize != 0 &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(ptr), rc_na_inv(dk, gid, ptr, t)) &*&

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -19,7 +19,7 @@ pred_ctor rc_na_inv(dk: lifetime_t, gid: usize, ptr: *RcBoxU32, t: thread_id_t)(
 //pred_ctor ticket_(dk: lifetime_t, gid: usize, frac: real, destroyed: bool)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]dlft_pred(dk)(gid, destroyed);
 
 // TODO: Add the following syntax to parser: `let ptr = std::ptr::NonNull_ptr(nnp);`
-pred RcU32_own(t: thread_id_t, rcU32: RcU32) =
+pred <RcU32>.own(t, rcU32) =
     std::ptr::NonNull_ptr(rcU32.ptr) as usize != 0 &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(std::ptr::NonNull_ptr(rcU32.ptr)), rc_na_inv(dk, gid, std::ptr::NonNull_ptr(rcU32.ptr), t)) &*&
     ticket(dlft_pred(dk), gid, ?frac) &*& [frac]dlft_pred(dk)(gid, false) &*&
@@ -28,7 +28,7 @@ pred RcU32_own(t: thread_id_t, rcU32: RcU32) =
 
 pred_ctor Rc_frac_bc(l: *RcU32, nnp: std::ptr::NonNull<RcBoxU32>)(;) = (*l).ptr |-> nnp;
 pred_ctor ticket_(dk: lifetime_t, gid: usize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);
-pred RcU32_share(k: lifetime_t, t: thread_id_t, l: *RcU32) =
+pred <RcU32>.share(k, t, l) =
     [_]exists(?nnp) &*& [_]frac_borrow(k, Rc_frac_bc(l, nnp)) &*& std::ptr::NonNull_ptr(nnp) as usize != 0 &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(std::ptr::NonNull_ptr(nnp)), rc_na_inv(dk, gid, std::ptr::NonNull_ptr(nnp), t)) &*&
     [_]exists(?frac) &*& [_]frac_borrow(k, ticket_(dk, gid, frac)) &*& [_]frac_borrow(k, lifetime_token_(frac, dk)) &*&

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -156,9 +156,9 @@ pub struct Tree {
 
 /*@
 
-pred Tree_own(t: thread_id_t, tree: Tree;) = Tree(tree.root, 0, ?shape);
+pred <Tree>.own(t, tree;) = Tree(tree.root, 0, ?shape);
 
-pred Tree_share(k: lifetime_t, t: thread_id_t, l: *Tree) = true;
+pred <Tree>.share(k, t, l) = true;
 
 lem Tree_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Tree)
     req lifetime_inclusion(k1, k) == true &*& [_]Tree_share(k, t, l);


### PR DESCRIPTION
Adds support for

pred<T> <S<T>>.own(t, v) = ...;

syntax. This is shorthand for

pred S_own<T>(t, v) = ...;
type_pred_def<T> <S<T>>.own = S_own;

The Rust translator no longer generates type predicate definitions for .own and .share; if the user wants them, they have to use this new syntax.

Adapted the examples to use the new syntax, which will become mandatory in a future commit.

Also refactored the Rust translator: removed the .own_pred and .shr_pred fields of the ty_interp struct, which were no longer being used.
