### PR TITLE
[Rust] Forbid public fields for now

### DIFF
--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -106,7 +106,6 @@ struct Visibility {
     union {
         public @0: Void;
         restricted @1: Void;
-        invisible @2: Void;
     }
 }
 

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -398,7 +398,7 @@ module Mir = struct
   }
 
   type debug_info = { id : Ast.loc; info : var_debug_info list }
-  type visibility = Public | Restricted | Invisible
+  type visibility = Public | Restricted
   type adt_kind = Struct | Enum | Union
 
   let decl_mir_adt_kind (d : Ast.decl) =
@@ -3818,7 +3818,6 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
     match get vis_cpn with
     | Public -> Ok Mir.Public
     | Restricted -> Ok Mir.Restricted
-    | Invisible -> Ok Mir.Invisible
     | Undefined _ -> Error (`TrVisibility "Unknown visibility kind")
 
   let translate_field_def (fdef_cpn : FieldDefRd.t) =
@@ -3832,6 +3831,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
     let* ty_info = translate_ty ty_cpn loc in
     let vis_cpn = vis_get fdef_cpn in
     let* vis = translate_visibility vis_cpn in
+    if vis = Public then raise (Ast.StaticError (loc, "Public fields are not yet supported", None));
     Ok Mir.{ name; ty = ty_info; vis; loc }
 
   let translate_to_vf_field_def

--- a/tests/rust/duplicate_type_pred_defs.rs
+++ b/tests/rust/duplicate_type_pred_defs.rs
@@ -1,0 +1,6 @@
+struct Foo {
+    v: i32,
+}
+
+//@ pred_ctor my_fbc(t: thread_id_t, l: *Foo)() = false;
+//@ type_pred_def <Foo>.full_borrow_content = my_fbc; //~should_fail

--- a/tests/rust/public_fields.rs
+++ b/tests/rust/public_fields.rs
@@ -1,0 +1,3 @@
+struct Foo {
+    pub v: i32, //~should_fail
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -1,5 +1,8 @@
 verifast -c ghost_cmd_inj.rs
 verifast -c parser_test.rs
+verifast -c -allow_should_fail type_pred_defs_for_imported_structs.rs
+verifast -c -allow_should_fail duplicate_type_pred_defs.rs
+verifast -c -allow_should_fail public_fields.rs
 begin_sequential
 cd unverified
   cd platform

--- a/tests/rust/type_pred_defs_for_imported_structs.rs
+++ b/tests/rust/type_pred_defs_for_imported_structs.rs
@@ -1,0 +1,2 @@
+//@ pred_ctor my_fbc(t: thread_id_t, l: *std::io::Stdout)() = false;
+//@ type_pred_def <std::io::Stdout>.full_borrow_content = my_fbc; //~should_fail


### PR DESCRIPTION
Allowing public fields is unsound unless we generate additional proof obligations.
