### PR TITLE
[Rust] Generate Send/Sync proof obligations

### DIFF
--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -661,8 +661,13 @@ struct Trait {
 
 struct TraitImpl {
     span @3: SpanData;
+    isUnsafe @4: Bool;
+    isNegative @5: Bool;
     ofTrait @0: Text;
+    genArgs @8: List(Ty.GenArg); # The first argument is the self type
     selfTy @1: Text;
+    generics @6: List(GenericParamDef);
+    predicates @7: List(Predicate);
     items @2: List(Text);
 }
 

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -107,27 +107,6 @@ lem Arc_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Arc<T>)
 unsafe impl<T: Sync + Send> Send for Arc<T> {}
 unsafe impl<T: Sync + Send> Sync for Arc<T> {}
 
-/*@
-
-lem Arc_send<T>(t: thread_id_t, t1: thread_id_t)
-    req Arc_own::<T>(t, ?nnp);
-    ens Arc_own::<T>(t1, nnp);
-{
-    open Arc_own::<T>(t, nnp);
-    close Arc_own::<T>(t1, nnp);
-}
-
-lem Arc_sync<T>(k: lifetime_t, t: thread_id_t, t1: thread_id_t, l: *Arc<T>)
-    req [_]Arc_share(k, t, l);
-    ens [_]Arc_share(k, t1, l);
-{
-    open Arc_share::<T>()(k, t, l);
-    close Arc_share::<T>()(k, t1, l);
-    leak Arc_share(k, t1, l);
-}
-
-@*/
-
 impl<T: Sync + Send> Arc<T> {
     pub fn new(data: T) -> Arc<T> {
         unsafe {

--- a/tests/rust/safe_abstraction/arc_u32.rs
+++ b/tests/rust/safe_abstraction/arc_u32.rs
@@ -107,24 +107,6 @@ lem ArcU32_share_full(k: lifetime_t, t: thread_id_t, l: *ArcU32)
 
 unsafe impl Send for ArcU32 {}
 unsafe impl Sync for ArcU32 {}
-/*@
-lem ArcU32_send(t: thread_id_t, t1: thread_id_t)
-    req ArcU32_own(t, ?nnp);
-    ens ArcU32_own(t1, nnp);
-{
-    open ArcU32_own(t, nnp);
-    close ArcU32_own(t1, nnp);
-}
-
-lem ArcU32_sync(k: lifetime_t, t: thread_id_t, t1: thread_id_t, l: *ArcU32)
-    req [_]ArcU32_share(k, t, l);
-    ens [_]ArcU32_share(k, t1, l);
-{
-    open ArcU32_share(k, t, l);
-    close ArcU32_share(k, t1, l);
-    leak ArcU32_share(k, t1, l);
-}
-@*/
 
 impl ArcU32 {
     pub fn new(data: u32) -> ArcU32 {

--- a/tests/rust/safe_abstraction/cell.rs
+++ b/tests/rust/safe_abstraction/cell.rs
@@ -8,6 +8,15 @@ pub struct Cell<T> {
 
 pred<T> <Cell<T>>.own(t, cell) = <T>.own(t, cell.v);
 
+lem Cell_send<T>(t1: thread_id_t)
+    req type_interp::<T>() &*& Cell_own::<T>(?t, ?cell) &*& is_Send(typeid(T)) == true;
+    ens type_interp::<T>() &*& Cell_own::<T>(t1, cell);
+{
+    open Cell_own::<T>(t, cell);
+    Send::send(t, t1, cell.v);
+    close Cell_own::<T>(t1, cell);
+}
+
 /*
 
 A note on `|= cell(tau) copy` judgement:

--- a/tests/rust/safe_abstraction/generic_pair.rs
+++ b/tests/rust/safe_abstraction/generic_pair.rs
@@ -14,6 +14,16 @@ lem Pair_drop<A, B>()
     open Pair_own::<A, B>(t, pair);
 }
 
+lem Pair_send<A, B>(t1: thread_id_t)
+    req type_interp::<A>() &*& type_interp::<B>() &*& Pair_own::<A, B>(?t, ?pair) &*& is_Send(typeid(A)) && is_Send(typeid(B));
+    ens type_interp::<A>() &*& type_interp::<B>() &*& Pair_own::<A, B>(t1, pair);
+{
+    open Pair_own::<A, B>(t, pair);
+    Send::send::<A>(t, t1, pair.fst);
+    Send::send::<B>(t, t1, pair.snd);
+    close Pair_own::<A, B>(t1, pair);
+}
+
 pred<A, B> <Pair<A, B>>.share(k, t, l) =
     [_](<A>.share)(k, t, &(*l).fst) &*&
     pointer_within_limits(&(*l).snd) == true &*&
@@ -130,6 +140,17 @@ lem Pair_share_full<A, B>(k: lifetime_t, t: thread_id_t, l: *Pair<A, B>)
     share_full_borrow_m::<B>(k, t, &(*l).snd);
     close Pair_share::<A, B>(k, t, l);
     leak Pair_share(k, t, l);
+}
+
+lem Pair_sync<A, B>(t1: thread_id_t)
+    req type_interp::<A>() &*& type_interp::<B>() &*& [_]Pair_share::<A, B>(?k, ?t, ?l) &*& is_Sync(typeid(A)) && is_Sync(typeid(B));
+    ens type_interp::<A>() &*& type_interp::<B>() &*& [_]Pair_share::<A, B>(k, t1, l);
+{
+    open Pair_share::<A, B>(k, t, l);
+    Sync::sync::<A>(k, t, t1, &(*l).fst);
+    Sync::sync::<B>(k, t, t1, &(*l).snd);
+    close Pair_share::<A, B>(k, t1, l);
+    leak Pair_share::<A, B>(k, t1, l);
 }
 
 @*/

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -114,8 +114,8 @@ unsafe impl<T: Send> Send for Mutex<T> {}
 
 /*@
 
-lem Mutex_send<T>(t: thread_id_t, t1: thread_id_t) // TODO: Enforce this proof obligation
-    req is_Send(typeid(T)) == true &*& type_interp::<T>() &*& Mutex_own::<T>(t, ?mutex);
+lem Mutex_send<T>(t1: thread_id_t)
+    req is_Send(typeid(T)) == true &*& type_interp::<T>() &*& Mutex_own::<T>(?t, ?mutex);
     ens type_interp::<T>() &*& Mutex_own(t1, mutex);
 {
     open Mutex_own::<T>()(t, mutex);
@@ -126,18 +126,6 @@ lem Mutex_send<T>(t: thread_id_t, t1: thread_id_t) // TODO: Enforce this proof o
 @*/
 
 unsafe impl<T: Send> Sync for Mutex<T> {}
-
-/*@
-
-lem Mutex_sync<T>(t: thread_id_t, t1: thread_id_t) // TODO: Enforce this proof obligation
-    req Mutex_share::<T>(?k, t, ?l);
-    ens Mutex_share(k, t1, l);
-{
-    open Mutex_share::<T>()(k, t, l);
-    close Mutex_share::<T>()(k, t1, l);
-}
-
-@*/
 
 pub struct MutexGuard<'a, T: Send> {
     lock: &'a Mutex<T>,
@@ -161,18 +149,6 @@ pred_ctor MutexGuard_fbc_rest<'a, T>(klong: lifetime_t, t: thread_id_t, l: *Mute
 impl<'a, T: Send> !Send for MutexGuard<'a, T> {}
 
 unsafe impl<'a, T: Send> Sync for MutexGuard<'a, T> {}
-
-/*@
-
-lem MutexGuard_sync<'a, T>(t: thread_id_t, t1: thread_id_t)
-    req MutexGuard_share::<'a, T>(?k, t, ?l);
-    ens MutexGuard_share::<'a, T>(k, t1, l);
-{
-    open MutexGuard_share::<'a, T>(k, t, l);
-    close MutexGuard_share::<'a, T>(k, t1, l);
-}
-
-@*/
 
 impl<T: Send> Mutex<T> {
     pub fn new(v: T) -> Mutex<T> {

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -105,8 +105,8 @@ unsafe impl Send for MutexU32 {}
 
 /*@
 
-lem MutexU32_send(t: thread_id_t, t1: thread_id_t)
-    req MutexU32_own(t, ?mutexU32);
+lem MutexU32_send(t1: thread_id_t)
+    req MutexU32_own(?t, ?mutexU32);
     ens MutexU32_own(t1, mutexU32);
 {
     open MutexU32_own(t, mutexU32);
@@ -116,18 +116,6 @@ lem MutexU32_send(t: thread_id_t, t1: thread_id_t)
 @*/
 
 unsafe impl Sync for MutexU32 {}
-
-/*@
-
-lem MutexU32_sync(t: thread_id_t, t1: thread_id_t)
-    req MutexU32_share(?k, t, ?l);
-    ens MutexU32_share(k, t1, l);
-{
-    open MutexU32_share(k, t, l);
-    close MutexU32_share(k, t1, l);
-}
-
-@*/
 
 impl MutexU32 {
     pub fn new(v: u32) -> MutexU32 {


### PR DESCRIPTION
For each struct S defined in the crate being verified:
- VeriFast determines whether the struct is Send/Sync:
  - It computes whether the struct automatically implements Send or Sync. This is the case if each field's type is Send/Sync. Currently, VeriFast computes a very rough approximation of whether a field type is Send/Sync. Apart from a few special cases (raw pointers, NonNull, UnsafeCell, type parameters) for the purposes of this computation it considers each type to implement Send and Sync. If the struct is generic, VeriFast computes an approximation of the trait bounds on the type parameters under which the struct is Send/Sync. (Specifically, for Send, it only records Send bounds, and for Sync, it only records Sync bounds.)
  - It takes into account negative and positive impl items.
- If it determines the struct is Send and the .own predicate's body mentions the thread id parameter, it generates an S_send proof obligation.
- If it determines the struct is Sync and the .share predicate's body mentions the thread id parameter, it generates an S_sync proof obligation.
