### PR TITLE
[Rust] Always run in targeted mode

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
  (c_library_flags
   %{env:OCAMLOPT_CCLIB_FLAGS=}
   -L %{env:Z3_DLL_DIR=../../../lib})
- (libraries num Z3 stopwatch perf (re_export frontend) java_frontend cxx_frontend rust_frontend))
+ (libraries num Z3 vfconfig stopwatch perf (re_export frontend) java_frontend cxx_frontend rust_frontend))
 (env
   (dev
     ; OCaml warning numbers:

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -232,6 +232,10 @@ let data_model_of_string s =
   match head_flatmap_option (fun (k, v) -> if String.uppercase_ascii k = s then Some v else None) data_models with
     None -> failwith ("Data model must be one of " ^ String.concat ", " (List.map fst data_models))
   | Some v -> v
+let string_of_data_model data_model =
+  match Util.flatmap (fun (name, model) -> if model = data_model then [name] else []) data_models with
+    name::_ -> name
+  | [] -> "(unnamed)"
 let intmax_width = 3 (* Assume that sizeof(intmax_t) is always 8 *)
 
 let java_byte_type = Int (Signed, FixedWidthRank 0)

--- a/src/frontend/stats.ml
+++ b/src/frontend/stats.ml
@@ -9,6 +9,7 @@ class stats =
   object (self)
     val startTime = Perf.time()
     val startTicks = Stopwatch.processor_ticks()
+    val mutable successQualifier: string option = None
     val mutable stmtsParsedCount = 0
     val mutable openParsedCount = 0
     val mutable closeParsedCount = 0
@@ -25,6 +26,19 @@ class stats =
     val mutable functionTimings: (string * float) list = []
     
     method tickLength = let t1 = Perf.time() in let ticks1 = Stopwatch.processor_ticks() in (t1 -. startTime) /. Int64.to_float (Int64.sub ticks1 startTicks)
+
+    method success_qualifier = successQualifier
+    method set_success_qualifier qualifier =
+      assert (successQualifier = None);
+      successQualifier <- Some qualifier
+
+    method get_success_message =
+      let qualifierText =
+        match successQualifier with
+          None -> ""
+        | Some qualifier -> Printf.sprintf " (%s)" qualifier
+      in
+      Printf.sprintf "0 errors found (%d statements verified)%s" self#getStmtExec qualifierText
 
     method stmtParsed = stmtsParsedCount <- stmtsParsedCount + 1
     method openParsed = openParsedCount <- openParsedCount + 1

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -680,6 +680,8 @@ struct Module {
 }
 
 struct VfMir {
+    targetTriple @7: Text;
+    pointerWidth @8: UInt8;
     directives @4: List(Annotation);
     # Todo @Nima: We are using an inductive list to encode ADT definitions because the total size of `List`s
     # shoule be determined before initializing them which is not the case for ADT definitions. The standard way to

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -141,7 +141,19 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   let reportStmt l = reportStmt (root_caller_token l)
   let reportStmtExec l = reportStmtExec (root_caller_token l)
 
-  let data_model = match language with Java -> Some data_model_java | CLang -> data_model
+  let data_model =
+    match language with
+      Java -> Some data_model_java
+    | CLang ->
+      match dialect with
+        Some Rust ->
+        if data_model = None then
+          match Vfconfig.platform with
+            Windows -> Some data_model_llp64
+          | _ -> Some data_model_lp64
+        else
+          data_model
+      | _ -> data_model
   let int_width, long_width, ptr_width = decompose_data_model data_model
   let intType = Int (Signed, IntRank)
   let sizeType = Int (Unsigned, PtrRank)

--- a/src/vfconsole/vfconsole.ml
+++ b/src/vfconsole/vfconsole.ml
@@ -247,7 +247,7 @@ let _ =
       reportDeadCode ();
       dumpPerLineStmtExecCounts ();
       if print_stats then stats#printStats;
-      let msg = "0 errors found (" ^ (string_of_int (stats#getStmtExec)) ^ " statements verified)" in
+      let msg = stats#get_success_message in
       if json then
         exit_with_json_result (A [S "success"; S msg])
       else

--- a/src/vfide/vfide.ml
+++ b/src/vfide/vfide.ml
@@ -1706,7 +1706,7 @@ let show_ide initialPath prover codeFont traceFont vfbindings layout javaFronten
                 else if runToCursor then
                   (msg := Some("0 errors found (cursor is unreachable)"); false)
                 else
-                  (msg := Some("0 errors found (" ^ (string_of_int (stats#getStmtExec)) ^ " statements verified)"); true)
+                  (msg := Some(stats#get_success_message); true)
               in
               updateMessageEntry(success)
             with

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -236,7 +236,7 @@ impl<T: Sync + Send> Arc<T> {
     //@ ens [qa]lifetime_token(a) &*& ticket(dlft_pred(dk), gid, ?frac1) &*& [frac1]dlft_pred(dk)(gid, false);
     {
         let current = Self::strong_count_inner(ptr);
-        if current >= 0xFFFF { abort(); } //TODO: Use `usize::MAX` instead of `0xFFFF`
+        if current >= usize::MAX { abort(); }
         let cas_res;
         {
         /*@

--- a/tests/rust/safe_abstraction/arc_u32.rs
+++ b/tests/rust/safe_abstraction/arc_u32.rs
@@ -231,7 +231,7 @@ impl ArcU32 {
     //@ ens [qa]lifetime_token(a) &*& ticket(dlft_pred(dk), gid, ?frac1) &*& [frac1]dlft_pred(dk)(gid, false);
     {
         let current = Self::strong_count_inner(ptr);
-        if current >= 0xFFFF { abort(); } //TODO: Use `usize::MAX` instead of `0xFFFF`
+        if current >= usize::MAX { abort(); }
         let cas_res;
         {
         /*@

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -218,10 +218,7 @@ impl<T> Clone for Rc<T> {
             //@ counting_match_fraction(dlft_pred(dk), gid);
             //@ close_frac_borrow(qp_t, ticket_(dk, gid, frac));
             //@ close_frac_borrow(qp_dk, lifetime_token_(frac, dk));
-            /* TODO: `*strong == usize::MAX` instead of the following check leads to the error:
-               "Truncating cast to target-dependent-sized integer type is not yet supported."
-               for more infor see the `usize` type translation */
-            if *strong >= 0xFFFF {
+            if *strong >= usize::MAX {
                 abort();
             }
             *strong = *strong + 1;

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -204,10 +204,7 @@ impl Clone for RcU32 {
             //@ counting_match_fraction(dlft_pred(dk), gid);
             //@ close_frac_borrow(qp_t, ticket_(dk, gid, frac));
             //@ close_frac_borrow(qp_dk, lifetime_token_(frac, dk));
-            /* TODO: `*strong == usize::MAX` instead of the following check leads to the error:
-               "Truncating cast to target-dependent-sized integer type is not yet supported."
-               for more infor see the `usize` type translation */
-            if *strong >= 0xFFFF {
+            if *strong >= usize::MAX {
                 abort();
             }
             *strong = *strong + 1;


### PR DESCRIPTION
Since VeriFast uses rustc, which always assumes a specific target triple, a VeriFast run is sound only for that target triple. From now on, VeriFast mentions the target triple in the success message.

Also, a default C target (aka data model) is now assumed if none is specified: LLP64 on Windows and LP64 on Linux and MacOS. The data model is also mentioned in the success message.

This resolves some TODOs in the examples.

Fixes #579
