### PR TITLE
[Rust] Improve UX on rustc errors

### DIFF
--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -2,4 +2,4 @@
  (name frontend)
  (wrapped false)
  (preprocess (pps ppx_parser))
- (libraries num camlp-streams perf stopwatch))
+ (libraries num camlp-streams perf stopwatch json))

--- a/src/frontend/verifast0.ml
+++ b/src/frontend/verifast0.ml
@@ -293,6 +293,7 @@ end) = struct
   
 end
 
+exception RustcErrors of loc * string * Json.json list
 exception SymbolicExecutionError of string context list * loc * string * string option
 
 (* prepends '~' to the given record name *)

--- a/src/json/json.ml
+++ b/src/json/json.ml
@@ -10,6 +10,10 @@ type json =
 | A of json list
 | O of (string * json) list
 
+let s_value (S value) = value
+let i_value (I value) = value
+let o_assoc name (O ps) = List.assoc name ps
+
 let hex_char_of_int i =
   char_of_int
     (if i <= 9 then int_of_char '0' + i else int_of_char 'a' - 10 + i)

--- a/src/rust_frontend/dune
+++ b/src/rust_frontend/dune
@@ -1,4 +1,4 @@
 (library
  (name rust_frontend)
  (wrapped false)
- (libraries (re_export frontend) vf_mir_translator vfconfig capnp capnp.unix perf))
+ (libraries (re_export frontend) vf_mir_translator vfconfig capnp capnp.unix perf json))

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -69,6 +69,7 @@ pub fn run_compiler() -> i32 {
         rustc_args.push("-Zpolonius".to_owned());
         // To have MIR dump annotated with lifetimes
         rustc_args.push("-Zverbose_internals".to_owned());
+        rustc_args.push("--error-format=json".to_owned());
 
         // Todo @Nima: Find the correct sysroot by yourself. for now we get it as an argument.
         // See filesearch::get_or_default_sysroot()

--- a/src/vfconsole/vfconsole.ml
+++ b/src/vfconsole/vfconsole.ml
@@ -275,6 +275,13 @@ let _ =
       end
     | StaticError (l, msg, url) ->
       exit_with_msg l msg
+    | RustcErrors (l, msg, diagnostics) ->
+      if json then
+        exit_with_json_result (A [S "StaticError"; json_of_loc l; S msg; O ["rustc_diagnostics", A diagnostics]])
+      else begin
+        List.iter (fun d -> Printf.printf "%s" (o_assoc "rendered" d |> s_value)) diagnostics;
+        exit 1
+      end
     | SymbolicExecutionError (ctxts, l, msg, url) ->
       let language, dialect = file_specs path in
       let open JsonOf(struct let string_of_type = string_of_type language dialect end) in

--- a/src/vfide/dune
+++ b/src/vfide/dune
@@ -1,3 +1,3 @@
 (executable
  (name vfide)
- (libraries linemarks branch_png java_frontend verifast vfconfig shape_analysis))
+ (libraries linemarks branch_png java_frontend verifast vfconfig shape_analysis json))

--- a/src/vfide/vfide.ml
+++ b/src/vfide/vfide.ml
@@ -1731,6 +1731,11 @@ let show_ide initialPath prover codeFont traceFont vfbindings layout javaFronten
               updateMessageEntry false
             | StaticError (l, emsg, eurl) ->
               handleStaticError l emsg eurl 
+            | RustcErrors (l, emsg, diagnostics) ->
+              let open Json in
+              List.iter (fun d -> Printf.printf "%s" (o_assoc "rendered" d |> s_value)) diagnostics;
+              print_newline ();
+              handleStaticError l (emsg ^ " (see console for details)") None
             | SymbolicExecutionError (ctxts, l, emsg, eurl) ->
               ctxts_lifo := Some (path, ctxts);
               updateStepItems();


### PR DESCRIPTION
If rustc aborts because of compilation errors, show the first error just like a regular VeriFast verification failure.
