### PR TITLE
[Rust] Add README; add missing verifast_options

### DIFF
--- a/tests/rust/README.md
+++ b/tests/rust/README.md
@@ -1,0 +1,15 @@
+VeriFast for Rust test cases and examples
+=========================================
+
+Subdirectories:
+- `unverified`: contains some library crates used by the verified examples, but which have not been verified themselves. However, a specification for their API is available in their `spec` subdirectories.
+- `purely_unsafe`: some purely unsafe examples that have been verified using VeriFast to have no undefined behavior.
+- `safe_abstraction`: some examples of crates offering functions that are verified using VeriFast to be safe for use by typechecked code but that use `unsafe` code internally. This functionality is based on the ideas of the [RustBelt](https://plv.mpi-sws.org/rustbelt/) project.
+
+Open an example in the VeriFast IDE (`bin/vfide`) to verify it. After verifying a program, you can inspect a function's symbolic execution tree by choosing Show execution tree and selecting the function in the drop-down menu in the upper right corner of the VeriFast window. Click any node in the tree to step through the symbolic execution path leading up to that node and inspect the symbolic heap, symbolic store (local variable bindings), and path condition at each step in a debugger-like experience.
+
+To verify all examples using the command-line tool, run `mysh testsuite.mysh`.
+
+Disclaimer:
+- We aim for VeriFast to be sound (i.e. to report "0 errors found" only if no execution of the input program has undefined behavior and safe functions comply with their type's interpretation as defined by RustBelt); however, in contrast to some other tools such as [RefinedRust](https://plv.mpi-sws.org/refinedrust/), VeriFast itself has not been formally verified, so unknown bugs are almost certainly present in the tool that may cause the tool to report "0 errors found" incorrectly in some cases. There may also be known unsoundnesses; these should all be recorded either here or as [issues](https://github.com/verifast/verifast/issues?q=is%3Aissue+is%3Aopen+label%3Aunsoundness) with label `unsoundness`.
+- One known unsoundness is that VeriFast currently does not take into account [all of the sources of undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html). For now, VeriFast does (absent bugs) verify absence of data races, out-of-bounds pointer arithmetic, and accesses of dangling places, but it currently does not verify compliance with Rust's alignment requirements or its [aliasing restrictions](https://perso.crans.org/vanille/treebor/), or its rules on producing invalid values.

--- a/tests/rust/purely_unsafe/README.md
+++ b/tests/rust/purely_unsafe/README.md
@@ -1,0 +1,11 @@
+VeriFast for Rust purely unsafe test cases and examples
+=======================================================
+
+To play with an example, open it in the VeriFast IDE (`bin/vfide`).
+
+- `httpd.rs`, `httpd_vec.rs`, and `httpd_mt.rs` implement a tiny HTTP daemon that listens on port 10000, appends each request to a buffer, and responds to each request with the contents of this buffer. They use the unverified `platform` crate at `../unverified/platform` to access the operating system's sockets and multithreading APIs. To build them, type
+
+      rustc --extern platform=../unverified/platform/target/debug/libplatform.rlib -L dependency=../unverified/platform/target/debug/deps httpd.rs
+
+- `tree.rs`, `tree2.rs`, and `tree3.rs` are variations of a function that marks a tree in constant space, by rotating the nodes on the path from the root to the current node
+- `deque.rs` implements a doubly-linked list

--- a/tests/rust/purely_unsafe/httpd.rs
+++ b/tests/rust/purely_unsafe/httpd.rs
@@ -1,3 +1,5 @@
+// verifast_options{extern:../unverified/platform}
+
 use std::io::Write;
 //@ use std::alloc::{alloc_block, Layout};
 

--- a/tests/rust/purely_unsafe/httpd_mt.rs
+++ b/tests/rust/purely_unsafe/httpd_mt.rs
@@ -1,3 +1,5 @@
+// verifast_options{extern:../unverified/platform}
+
 use std::io::Write;
 
 #[path = "simple_mutex.rs"]

--- a/tests/rust/purely_unsafe/httpd_vec.rs
+++ b/tests/rust/purely_unsafe/httpd_vec.rs
@@ -1,3 +1,5 @@
+// verifast_options{extern:../unverified/platform}
+
 use std::io::Write;
 
 unsafe fn memchr(mut haystack: *const u8, mut size: usize, needle: u8) -> *const u8

--- a/tests/rust/purely_unsafe/mt_account_transfer.rs
+++ b/tests/rust/purely_unsafe/mt_account_transfer.rs
@@ -1,3 +1,5 @@
+// verifast_options{extern:../unverified/platform}
+
 mod simple_mutex;
 
 struct Accounts {


### PR DESCRIPTION
The verifast_options make it so that the program verifies
in vfide without having to provide any command-line arguments or
change any settings in the menu.
