### PR TITLE
[Rust] Stop conflating raw pointers and references

### DIFF
--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -9,9 +9,9 @@ include!{"rust_belt/lem_aux.rsspec"}
 union std_empty_ {}
 struct std_tuple_0_ {}
 
-struct slice_ref<T> { ptr: *T, len: usize }
+struct slice_ref<'a, T> { ptr: *T, len: usize }
 
-struct str_ref { ptr: *u8, len: usize }
+struct str_ref<'a> { ptr: *u8, len: usize }
 
 /*@
 

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -273,7 +273,7 @@ mod vec {
         //@ req [?f](*self |-> ?self_) &*& [f]Vec_minus_buffer::<T, A>(self_, ?capacity, ?len, ?buffer);
         //@ ens [f](*self |-> self_) &*& [f]Vec_minus_buffer::<T, A>(self_, capacity, len, buffer) &*& result == buffer;
 
-        fn spare_capacity_mut<'a>(self: &'a Vec<T, A>) -> &[T];
+        fn spare_capacity_mut<'a>(self: &'a Vec<T, A>) -> &'a [T];
         //@ req [?f](*self |-> ?self_) &*& [f]Vec_minus_buffer::<T, A>(self_, ?capacity, ?len, ?buffer);
         //@ ens [f](*self |-> self_) &*& [f]Vec_minus_buffer::<T, A>(self_, capacity, len, buffer) &*& result.ptr == buffer + len &*& result.len == capacity - len;
 

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -27,6 +27,10 @@ let of_int_rank = function
 | PtrRank -> c "PtrRank"
 | FixedWidthRank k -> C ("FixedWidthRank", [I k])
 
+let of_rust_ref_kind = function
+  Mutable -> c "Mutable"
+| Shared -> c "Shared"
+
 let rec of_type = function
   Bool -> c "Bool"
 | Void -> c "Void"
@@ -38,6 +42,7 @@ let rec of_type = function
 | StructType (s, targs) -> C ("StructType", [S s; of_list of_type targs])
 | UnionType u -> C ("UnionType", [S u])
 | PtrType t -> C ("PtrType", [of_type t])
+| RustRefType (lft, kind, t) -> C ("RustRefType", [of_type lft; of_rust_ref_kind kind; of_type t])
 | FuncType f -> C ("FuncType", [S f])
 | InductiveType (i, ts) -> C ("InductiveType", [S i; of_list of_type ts])
 | PredType (xs, ts, precise, ind) ->
@@ -150,6 +155,13 @@ let rec of_type_expr = function
 | PtrTypeExpr (l, t) ->
   C ("PtrTypeExpr", [
     of_loc l; 
+    of_type_expr t
+  ])
+| RustRefTypeExpr (l, lft, kind, t) ->
+  C ("RustRefTypeExpr", [
+    of_loc l;
+    of_type_expr lft;
+    of_rust_ref_kind kind;
     of_type_expr t
   ])
 | ArrayTypeExpr (l, elemTp) ->

--- a/src/frontend/verifast0.ml
+++ b/src/frontend/verifast0.ml
@@ -222,6 +222,7 @@ let rec rust_string_of_type t =
   | UnionType un -> "union " ^ un
   | PtrType Void -> "*_"
   | PtrType t -> "*" ^ rust_string_of_type t
+  | RustRefType (lft, kind, t) -> "&" ^ rust_string_of_type lft ^ (match kind with Mutable -> " mut " | Shared -> " ") ^ rust_string_of_type t
   | FuncType ft -> ft
   | InlineFuncType rt -> Printf.sprintf "fn(?) -> %s" (rust_string_of_type rt)
   | PredType (tparams, ts, inputParamCount, inductiveness) ->

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -1688,7 +1688,7 @@ mod vf_mir_builder {
                 ty::RegionKind::ReStatic => bug!(),
                 ty::RegionKind::ReVar(_) | ty::RegionKind::ReErased => {
                     // Todo @Nima: We should find a mapping of `RegionVid`s and lifetime variable names at `hir`
-                    region_cpn.set_id(/*&format!("{:?}", region)*/ "'erased");
+                    region_cpn.set_id(/*&format!("{:?}", region)*/ "'<erased>");
                 }
                 ty::RegionKind::RePlaceholder(_placeholder_region) => bug!(),
                 _ => bug!(),

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -610,7 +610,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       require_pure();
       let e = match (targs, args) with ([], [LitPat e]) -> e | _ -> static_error l "open_points_to expects no type argument and one argument." None in
       let (w, tp) = check_expr (pn,ilist) tparams tenv e in
-      let pointeeType = match tp with PtrType tp -> tp | _ -> static_error l "The argument of open_points_to must be a pointer." None in
+      let pointeeType = match tp with PtrType tp | RustRefType (_, _, tp) -> tp | _ -> static_error l "The argument of open_points_to must be a pointer." None in
       eval_h h env w $. fun h env pointerTerm ->
       with_context (Executing (h, env, l, "Consuming points_to chunk")) $. fun () ->
       consume_chunk rules h env ghostenv [] [] l (generic_points_to_symb (), true) [pointeeType] real_unit dummypat (Some 1) [TermPat pointerTerm; SrcPat DummyPat] $. fun _ h coef [_; value] _ _ _ _ ->
@@ -619,7 +619,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       require_pure();
       let e = match (targs, args) with ([], [LitPat e]) -> e | _ -> static_error l "close_points_to expects no type argument and one argument." None in
       let (w, tp) = check_expr (pn,ilist) tparams tenv e in
-      let pointeeType = match tp with PtrType tp -> tp | _ -> static_error l "The argument of close_points_to must be a pointer." None in
+      let pointeeType = match tp with PtrType tp | RustRefType (_, _, tp) -> tp | _ -> static_error l "The argument of close_points_to must be a pointer." None in
       eval_h h env w $. fun h env pointerTerm ->
       with_context (Executing (h, env, l, "Consuming object")) $. fun () ->
       consume_c_object_core_core l real_unit_pat pointerTerm pointeeType h env true false $. fun _ h (Some value) ->

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1880,7 +1880,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       Int (_, _) ->
       let (min_term, max_term) = limits_of_type tp in
       assume (ctxt#mk_and (ctxt#mk_le min_term t) (ctxt#mk_le t max_term)) cont
-    | PtrType _ ->
+    | PtrType _ | RustRefType _ ->
       assume (mk_pointer_within_limits t) cont
     | _ -> static_error l (Printf.sprintf "Producing the limits of a variable of type '%s' is not yet supported." (string_of_type tp)) None
   
@@ -2999,7 +2999,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       eval_h_core (true, heapReadonly || not e2_safe) h env e1 $. fun h env v1 ->
       eval_h_core (true, heapReadonly || not e1_safe) h env e2 $. fun h env v2 ->
       begin match t with
-        PtrType tp when not pure && not assume_no_provenance && not (ctxt#query (ctxt#mk_or (ctxt#mk_eq (mk_ptr_address v1) int_zero_term) (ctxt#mk_eq (mk_ptr_address v2) int_zero_term))) ->
+        (PtrType tp | RustRefType (_, _, tp)) when not pure && not assume_no_provenance && not (ctxt#query (ctxt#mk_or (ctxt#mk_eq (mk_ptr_address v1) int_zero_term) (ctxt#mk_eq (mk_ptr_address v2) int_zero_term))) ->
         branch
           begin fun () ->
             assume (ctxt#mk_eq (mk_ptr_address v1) (mk_ptr_address v2)) $. fun () ->


### PR DESCRIPTION
The MIR translator used to translate reference types to pointer types, which meant all of these had the same typeid and the same OWN and SHR predicates, which is unsound. This commit introduces `RustRefType (lifetime, mutability, pointeeType)` as a first-class type in the VeriFast engine. The typeid of a Rust reference type depends on its lifetime, its mutability, and its pointee type. However, otherwise the engine still treats Rust references just like pointers: the type checker ignores lifetimes and allows references to be supplied where pointers are expected and vice versa.

Also:
- All pointer types now have the same typeid under -fno-strict-aliasing
- Slice references and string references (`&str`) now also carry a lifetime
