### PR TITLE
[Rust] Define S_own, <S>.own, S_fbc, <S>.fbc for structs S in .rsspec files

### DIFF
--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -46,8 +46,14 @@ mod ptr {
     //@ ens thread_token(t) &*& *to_drop |-> _;
 
     struct NonNull<T>;
+    
     /*@
-    pred_ctor NonNull_own<T>()(t: thread_id_t, v: NonNull<T>;) = NonNull_ptr(v) as usize != 0;
+    lem close_NonNull_own<T>(t: thread_id_t, v: NonNull<T>);
+        req NonNull_ptr(v) as usize != 0;
+        ens (NonNull_own::<T>())(t, v);
+    lem open_NonNull_own<T>(t: thread_id_t, v: NonNull<T>);
+        req [_](NonNull_own::<T>())(t, v);
+        ens NonNull_ptr(v) as usize != 0;
     fix NonNull_ptr<_T>(v: NonNull<_T>) -> *_T;
     @*/
 

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -423,7 +423,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let (_, _, _, declared_paramtypes, symb, _, _) = List.assoc g_name predfammap in
           ((symb, true), targs', pats0, pats, g#domain, Some (g_name, declared_paramtypes))
         | true, PredCtor g ->
-          let PredCtorInfo (_, tparams, ps1, ps2, inputParamCount, body, funcsym) = List.assoc g predctormap in
+          let (_, tparams, PredType ([], ps2, inputParamCount, _), ps1, funcsym) = List.assoc g purefuncmap in
           let typeid_msg () = Printf.sprintf "Taking typeids of predicate constructor type arguments <%s>: " (String.concat ", " (List.map string_of_type targs)) in
           let targs_typeids = List.map (typeid_of_core_core l typeid_msg typeid_env) targs' in
           let ctorargs = List.map (function (LitPat e | WCtorPat (_, _, _, _, _, _, _, Some e)) -> ev e | _ -> static_error l "Patterns are not supported in predicate constructor argument positions." None) pats0 in
@@ -436,7 +436,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let g_symb = mk_app funcsym (targs_typeids @ ctorargs) in
           let (symbol, symbol_term) = funcsym in
           register_pred_ctor_application g_symb symbol symbol_term targs' ctorargs inputParamCount;
-          let pts = List.map (fun (_, pt) -> instantiate_type tpenv0 pt) ps2 in
+          let pts = List.map (instantiate_type tpenv0) ps2 in
           ((g_symb, false), [], [], pats, pts, None)
       in
       let targs = targs' in
@@ -1288,7 +1288,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let (_, _, _, _, symb, _, _) = List.assoc g_name predfammap in
           ((symb, true), targs', pats0, pats, g#domain)
         | true, PredCtor g_name ->
-          let PredCtorInfo (_, tparams, ps1, ps2, inputParamCount, body, funcsym) = List.assoc g_name predctormap in
+          let (_, tparams, PredType ([], ps2, inputParamCount, _), ps1, funcsym) = List.assoc g_name purefuncmap in
           let typeid_msg () = Printf.sprintf "Taking typeids of predicate constructor type arguments <%s>: " (String.concat ", " (List.map string_of_type targs)) in
           let targs_typeids = List.map (typeid_of_core_core l typeid_msg env) targs in
           let ctorargs = List.map (function SrcPat (LitPat e | WCtorPat (_, _, _, _, _, _, _, Some e)) -> ev e | _ -> static_error l "Patterns are not supported in predicate constructor argument positions." None) pats0 in
@@ -1297,7 +1297,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let g_symb = mk_app funcsym (targs_typeids @ ctorargs) in
           let (symbol, symbol_term) = funcsym in
           register_pred_ctor_application g_symb symbol symbol_term targs' ctorargs inputParamCount;
-          ((g_symb, false), [], [], pats, List.map (fun (_, pt) -> instantiate_type tpenv0 pt) ps2)
+          ((g_symb, false), [], [], pats, List.map (instantiate_type tpenv0) ps2)
         | false, LocalVar g_name ->
           match try_assoc g_name env with
             None -> assert_false [] env l (Printf.sprintf "Unbound variable '%s'" g_name) None

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -619,6 +619,7 @@ struct Body {
         closeBraceSpan @1: SpanData; # After preprocessing, to match against the span of the inserted VeriFast_ghost_command() call.
     }
 
+    fnSigSpan @21: SpanData;
     defKind @0: DefKind;
     defPath @1: Text;
     moduleDefPath @18: Text; # Empty string if in crate root

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -145,7 +145,7 @@ impl<T: Sync + Send> Arc<T> {
             //@ leak exists(p);
             //@ leak exists(dk);
             //@ leak exists::<isize>(gid);
-            //@ close std::ptr::NonNull_own::<ArcInner<T>>()(default_tid, nnp);
+            //@ std::ptr::close_NonNull_own::<ArcInner<T>>()(default_tid, nnp);
             //@ leak std::ptr::NonNull_own::<ArcInner<T>>()(default_tid, nnp);
             //@ close Arc_own::<T>()(_t, ret);
             ret
@@ -377,8 +377,8 @@ impl<T: Sync + Send> Drop for Arc<T> {
             //@ close Pre();
             let sco = self.ptr.as_ref().strong.fetch_sub(1, Ordering::SeqCst);
             //@ open Post(sco);
-            //@ open std::ptr::NonNull_own::<ArcInner<T>>(default_tid, arc.ptr);
-            //@ close std::ptr::NonNull_own::<ArcInner<T>>()(_t, arc.ptr);
+            //@ std::ptr::open_NonNull_own::<ArcInner<T>>(default_tid, arc.ptr);
+            //@ std::ptr::close_NonNull_own::<ArcInner<T>>()(_t, arc.ptr);
             if sco != 1 { return; }
             }
             //@ assert (*ptr).data |-> ?v;

--- a/tests/rust/safe_abstraction/arc_u32.rs
+++ b/tests/rust/safe_abstraction/arc_u32.rs
@@ -142,7 +142,7 @@ impl ArcU32 {
             //@ leak exists(p);
             //@ leak exists(dk);
             //@ leak exists::<isize>(gid);
-            //@ close std::ptr::NonNull_own::<ArcInnerU32>()(default_tid, nnp);
+            //@ std::ptr::close_NonNull_own::<ArcInnerU32>(default_tid, nnp);
             //@ leak std::ptr::NonNull_own::<ArcInnerU32>()(default_tid, nnp);
             //@ close ArcU32_own(_t, ret);
             ret
@@ -368,8 +368,8 @@ impl Drop for ArcU32 {
             //@ close Pre();
             let sco = self.ptr.as_ref().strong.fetch_sub(1, Ordering::SeqCst);
             //@ open Post(sco);
-            //@ open std::ptr::NonNull_own::<ArcInnerU32>(default_tid, arcU32.ptr);
-            //@ close std::ptr::NonNull_own::<ArcInnerU32>(_t, arcU32.ptr);
+            //@ std::ptr::open_NonNull_own::<ArcInnerU32>(default_tid, arcU32.ptr);
+            //@ std::ptr::close_NonNull_own::<ArcInnerU32>(_t, arcU32.ptr);
             if sco != 1 { return; }
             }
             //@ open_struct(ptr);

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -268,7 +268,7 @@ impl<T> Drop for Rc<T> {
                 std::ptr::drop_in_place(&mut (*self.ptr.as_ptr()).value as *mut T);
                 //@ close RcBox_strong_(ptr, _);
                 //@ open_struct(ptr);
-                //@ close std::ptr::NonNull_own::<RcBox<T>>(_t, nnp);
+                //@ std::ptr::close_NonNull_own::<RcBox<T>>(_t, nnp);
                 std::alloc::dealloc(
                     self.ptr.as_ptr() as *mut u8,
                     std::alloc::Layout::new::<RcBox<T>>(),
@@ -278,7 +278,7 @@ impl<T> Drop for Rc<T> {
                 //@ close_na_inv(_t, MaskNshrSingle(ptr));
                 //@ thread_token_merge(_t, mask_diff(MaskTop, MaskNshrSingle(ptr)), MaskNshrSingle(ptr));
                 //@ close thread_token(_t);
-                //@ close std::ptr::NonNull_own::<RcBox<T>>()(_t, nnp);
+                //@ std::ptr::close_NonNull_own::<RcBox<T>>(_t, nnp);
             }
         }
     }

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -248,7 +248,7 @@ impl Drop for RcU32 {
                 //@ close RcBoxU32_value_(ptr, _);
                 //@ open_struct(ptr);
                 // No need to drop a u32
-                //@ close std::ptr::NonNull_own::<RcBoxU32>(_t, nnp);
+                //@ std::ptr::close_NonNull_own::<RcBoxU32>(_t, nnp);
                 std::alloc::dealloc(
                     self.ptr.as_ptr() as *mut u8,
                     std::alloc::Layout::new::<RcBoxU32>(),
@@ -257,7 +257,7 @@ impl Drop for RcU32 {
                 //@ close dlft_pred(dk)(gid, true);
                 //@ start_counting(dlft_pred(dk), gid);
             } else {
-                //@ close std::ptr::NonNull_own::<RcBoxU32>()(_t, nnp);
+                //@ std::ptr::close_NonNull_own::<RcBoxU32>(_t, nnp);
             }
             //@ close rc_na_inv(dk, gid, ptr, _t)();
             //@ close_na_inv(_t, MaskNshrSingle(ptr));


### PR DESCRIPTION
Also:
- Improve source locations for generated contracts
- Support type predicate definitions in modules
- Allow fixpoints that return predicates where predicate constructors are expected when typechecking, producing, and consuming assertions

TODO: Define S_shared, <S>.shared for structs S in .rsspec files
