### PR TITLE
[Rust] Support elided lifetimes

### DIFF
--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -1166,6 +1166,23 @@ let stmt_loc s =
   | Continue l -> l
   | SuperConstructorCall(l, _) -> l
 
+let type_expr_fold_open f state te =
+  match te with
+    StructTypeExpr (l, sn, body_opt, attrs, targs) -> List.fold_left f state targs
+  | UnionTypeExpr (l, un, body_opt) -> state
+  | EnumTypeExpr (l, en, body_opt) -> state
+  | PtrTypeExpr (l, te) -> f state te
+  | RustRefTypeExpr (l, lft, kind, te) -> f (f state lft) te
+  | ArrayTypeExpr (l, te) -> f state te
+  | StaticArrayTypeExpr (l, elemTp, n) -> f state elemTp
+  | FuncTypeExpr (l, retTp, ps) -> List.fold_left f (f state retTp) (List.map fst ps)
+  | ManifestTypeExpr (l, tp) -> state
+  | IdentTypeExpr (l, pn, x) -> state
+  | ConstructedTypeExpr (l, x, targs) -> List.fold_left f state targs
+  | PredTypeExpr (l, paramTps, inputParamCount) -> List.fold_left f state paramTps
+  | PureFuncTypeExpr (l, tps) -> List.fold_left f state tps
+  | LValueRefTypeExpr (l, tp) -> f state tp
+
 let stmt_fold_open f state s =
   match s with
     PureStmt (l, s) -> f state s

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -1691,7 +1691,12 @@ mod vf_mir_builder {
                 ty::RegionKind::ReBound(de_bruijn_index, bound_region) => match bound_region.kind {
                     ty::BoundRegionKind::BrAnon => todo!(),
                     ty::BoundRegionKind::BrNamed(def_id, symbol) => {
-                        region_cpn.set_id(symbol.as_str());
+                        if symbol.as_str() == "'_" {
+                            let id = format!("'_{}", def_id.index.as_usize());
+                            region_cpn.set_id(&id);
+                        } else {
+                            region_cpn.set_id(symbol.as_str());
+                        }
                     }
                     ty::BoundRegionKind::BrEnv => todo!(),
                 },

--- a/src/rust_frontend/vf_mir_translator/rustbelt.ml
+++ b/src/rust_frontend/vf_mir_translator/rustbelt.ml
@@ -12,6 +12,7 @@ type ty_interp = {
   shr : lft -> tid -> l -> (asn, string) result; (* Should be duplicable, e.g. a dummy pattern. The caller will not wrap this in a dummy coef asn. *)
   full_bor_content : tid -> l -> (Ast.expr, string) result;
   points_to : tid -> l -> vid option -> (asn, string) result;
+  pointee_fbc : (tid -> string (* l *) -> string (* suffix for bound variables *) -> (asn, string) result) option; (* None if this type is not a reference type *)
 }
 
 let simple_fbc loc fbc_name tid l = Ok (CallExpr (loc, fbc_name, [], [], [LitPat tid; LitPat l], Static))
@@ -23,6 +24,7 @@ let emp_ty_interp loc =
     shr = (fun _ _ _ -> Error "Not yet supported");
     full_bor_content = (fun _ _ -> Error "Not yet supported");
     points_to = (fun _ _ _ -> Ok (True loc));
+    pointee_fbc = None;
   }
 
 module Aux = struct

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -41,17 +41,12 @@ pub mod ptr {
     }
 
     impl<T> NonNull<T> {
-        pub fn from<'a>(reference: &'a mut T) -> Self {
+        pub fn from(reference: &mut T) -> Self {
             let r = NonNull {
                 pointer: reference as *mut T,
             };
-            //@ open_full_borrow(_q_a, 'a, <T>.full_borrow_content(_t, reference));
-            //@ open_full_borrow_content::<T>(_t, reference);
             //@ points_to_limits(reference);
-            //@ close_full_borrow_content::<T>(_t, reference);
-            //@ close_full_borrow(<T>.full_borrow_content(_t, reference));
             //@ close ptr::NonNull_own::<T>(_t, r);
-            //@ leak full_borrow(_, _);
             r
         }
 

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -338,9 +338,8 @@ impl<T> Deque<T> {
         //@ close Deque(deque, cons(value, elems));
     }
 
-    pub fn push_front<'a>(&'a mut self, value: T) {
-        //@ open_full_borrow(_q_a, 'a, Deque_full_borrow_content(_t, self));
-        //@ open Deque_full_borrow_content::<T>(_t, self)();
+    pub fn push_front(&mut self, value: T) {
+        //@ open_points_to(self);
         //@ open Deque_own::<T>()(_t, ?deque);
         if (*self).size < 0x7fffffff {
             unsafe {
@@ -355,9 +354,7 @@ impl<T> Deque<T> {
         //@ close elem_own::<T>(_t)(value);
         //@ close foreach(cons(value, elems), elem_own::<T>(_t));
         //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size + 1 });
-        //@ close Deque_full_borrow_content::<T>(_t, self)();
-        //@ close_full_borrow(Deque_full_borrow_content(_t, self));
-        //@ leak full_borrow(_, _);
+        //@ close_points_to(self);
     }
 
     unsafe fn unsafe_push_back(deque: *mut Deque<T>, value: T)
@@ -404,9 +401,8 @@ impl<T> Deque<T> {
         //@ close Deque(deque, append(elems, [value]));
     }
 
-    pub fn push_back<'a>(&'a mut self, value: T) {
-        //@ open_full_borrow(_q_a, 'a, Deque_full_borrow_content(_t, self));
-        //@ open Deque_full_borrow_content::<T>(_t, self)();
+    pub fn push_back(&mut self, value: T) {
+        //@ open_points_to(self);
         //@ open Deque_own::<T>()(_t, ?deque);
         if (*self).size < 0x7fffffff {
             unsafe {
@@ -423,9 +419,7 @@ impl<T> Deque<T> {
         //@ close foreach([value], elem_own::<T>(_t));
         //@ foreach_append(elems, [value]);
         //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size + 1 });
-        //@ close Deque_full_borrow_content::<T>(_t, self)();
-        //@ close_full_borrow(Deque_full_borrow_content(_t, self));
-        //@ leak full_borrow(_, _);
+        //@ close_points_to(self);
     }
 
     unsafe fn unsafe_pop_front(deque: *mut Deque<T>) -> T
@@ -450,13 +444,12 @@ impl<T> Deque<T> {
         result
     }
 
-    pub fn pop_front<'a>(&'a mut self) -> T
-        //@ req thread_token(?_t) &*& [?_q]lifetime_token(?a) &*& full_borrow(a, Deque_full_borrow_content(_t, self));
-        //@ ens thread_token(_t) &*& [_q]lifetime_token(a) &*& <T>.own(_t, result);
+    pub fn pop_front(&mut self) -> T
+        //@ req thread_token(?_t) &*& *self |-> ?deque &*& Deque_own::<T>(_t, deque);
+        //@ ens thread_token(_t) &*& *self |-> ?deque1 &*& Deque_own::<T>(_t, deque1) &*& <T>.own(_t, result);
     {
-        //@ open_full_borrow(_q, a, Deque_full_borrow_content(_t, self));
-        //@ open Deque_full_borrow_content::<T>(_t, self)();
-        //@ open Deque_own::<T>()(_t, ?deque);
+        //@ open_points_to(self);
+        //@ open Deque_own::<T>()(_t, deque);
         if (*self).size == 0 {
             std::process::abort();
         }
@@ -468,9 +461,7 @@ impl<T> Deque<T> {
             //@ open foreach(_, _);
             //@ open elem_own::<T>(_t)(result);
             //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size - 1 });
-            //@ close Deque_full_borrow_content::<T>(_t, self)();
-            //@ close_full_borrow(Deque_full_borrow_content(_t, self));
-            //@ leak full_borrow(_, _);
+            //@ close_points_to(self);
             return result;
         }
     }
@@ -515,9 +506,8 @@ impl<T> Deque<T> {
         return result;
     }
 
-    pub fn pop_back<'a>(&'a mut self) -> T {
-        //@ open_full_borrow(_q_a, 'a, Deque_full_borrow_content(_t, self));
-        //@ open Deque_full_borrow_content::<T>(_t, self)();
+    pub fn pop_back(&mut self) -> T {
+        //@ open_points_to(self);
         //@ open Deque_own::<T>()(_t, ?deque);
         if (*self).size == 0 {
             std::process::abort();
@@ -534,9 +524,7 @@ impl<T> Deque<T> {
             //@ nth_drop(0, length(elems) - 1, elems);
             //@ open elem_own::<T>(_t)(result);
             //@ close Deque_own::<T>()(_t, Deque::<T> { sentinel, size: deque.size - 1 });
-            //@ close Deque_full_borrow_content::<T>(_t, self)();
-            //@ close_full_borrow(Deque_full_borrow_content(_t, self));
-            //@ leak full_borrow(_, _);
+            //@ close_points_to(self);
             return result;
         }
     }


### PR DESCRIPTION
They get a unique name of the form '_N where N is their local def id.

Also: when generating a contract for a safe function, and a parameter of type &mut T has an elided lifetime, and the function's return type has no elided lifetimes, then the full borrow is opened, i.e. instead of requiring the full borrow, we require and ensure the points-to and the OWN of the pointee.
