### PR TITLE
[Rust] Support local decls in ghost code

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -299,6 +299,8 @@ TOOLS_EXCEPT_VFIDE += ../bin/vf-cxx-ast-exporter$(DOTEXE) build-vf-rust-mir-expo
 
 TOOLS = $(TOOLS_EXCEPT_VFIDE) ../bin/vfide$(DOTEXE)
 
+vf: ../bin/verifast$(DOTEXE) ../bin/vfide$(DOTEXE)
+
 ifndef WITHOUT_LABLGTK
 build: $(TOOLS) $(STDLIB) tabhunt
 else

--- a/src/frontend/parser.ml
+++ b/src/frontend/parser.ml
@@ -84,7 +84,7 @@ let rust_keywords = [
 
   "async"; "await"; "dyn";
 
-  "abstract"; "become"; "box"; "do"; "final"; "macro"; "override"; "priv";
+  "abstract"; "become"; (*"box";*) "do"; "final"; "macro"; "override"; "priv";
   "typeof"; "unsized"; "virtual"; "yield";
 
   "try";
@@ -107,10 +107,10 @@ let rust_ghost_keywords = [
   "box_class"; "action"; "handle_pred"; "preserved_by"; "consuming_box_pred"; "consuming_handle_pred"; "perform_action"; "nonghost_callers_only";
   "create_box"; "above"; "below"; "and_handle"; "and_fresh_handle"; "create_handle"; "create_fresh_handle"; "dispose_box"; 
   "produce_lem_ptr_chunk"; "dup_lem_ptr_chunk"; "produce_fn_ptr_chunk";
-  "producing_box_pred"; "producing_handle_pred"; "producing_fresh_handle_pred"; "box"; "handle"; "any"; "split_fraction"; "by"; "merge_fractions";
+  "producing_box_pred"; "producing_handle_pred"; "producing_fresh_handle_pred"; "handle"; "any"; "split_fraction"; "by"; "merge_fractions";
   "unloadable_module"; "decreases"; "forall_"; "import_module"; "require_module"; ".."; "extends"; "permbased";
   "terminates"; "abstract_type"; "fix_auto"; "typeid"; "activating"; "truncating"; "typedef"; "fn_type"; "lem_type";
-  "type_pred_decl"; "type_pred_def"
+  "type_pred_decl"; "type_pred_def"; "let_lft"
 ]
 
 let java_keywords = [

--- a/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
@@ -130,7 +130,7 @@ fn ghost_range_contents_is_block_decls(contents: &str) -> bool {
         || trimmed_contents.starts_with("lem ")
         || trimmed_contents.starts_with("lem_auto ")
         || trimmed_contents.starts_with("lem_auto(")
-        || trimmed_contents.starts_with("let '")
+        || trimmed_contents.starts_with("let_lft ")
 }
 
 /// If a ghost range occurs at the toplevel before the first token in a file,

--- a/src/rust_frontend/vf_mir_translator/rust_parser.ml
+++ b/src/rust_frontend/vf_mir_translator/rust_parser.ml
@@ -483,20 +483,21 @@ and parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause = funct
   ] -> (ftn, [], args, params, openBraceLoc, ss, closeBraceLoc)
 and parse_block_stmt = function%parser
   [ (l, Kwd "{");
+    parse_ghost_decls as ds;
     parse_stmts as ss;
     (closeBraceLoc, Kwd "}")
-  ] -> BlockStmt (l, [], ss, closeBraceLoc, ref [])
+  ] -> BlockStmt (l, ds, ss, closeBraceLoc, ref [])
 and parse_stmts stream = rep parse_stmt stream
 
-let parse_param = function%parser
+and parse_param = function%parser
   [ (_, Ident x); (_, Kwd ":"); parse_type as t ] -> t, x
 | [ (_, Kwd "self"); (_, Kwd ":"); parse_type as t ] -> t, "self"
 
-let parse_struct_field = function%parser
+and parse_struct_field = function%parser
   [ (l, Ident x); (_, Kwd ":"); parse_type as t ] ->
   Field (l, Real, t, x, Instance, Public, false, None)
 
-let parse_pred_paramlist = function%parser
+and parse_pred_paramlist = function%parser
   [ (_, Kwd "(");
     [%let ps = rep_comma parse_param ];
     [%let (ps, inputParamCount) = begin function%parser
@@ -508,10 +509,10 @@ let parse_pred_paramlist = function%parser
     (_, Kwd ")")
   ] -> ps, inputParamCount
 
-let parse_pred_body = function%parser
+and parse_pred_body = function%parser
   [ (_, Kwd "="); parse_asn as p ] -> p
 
-let parse_type_params = function%parser
+and parse_type_params = function%parser
   [ (_, Kwd "<");
     [%let tparams = rep_comma (function%parser
       [ (_, Ident x) ] -> x
@@ -519,7 +520,7 @@ let parse_type_params = function%parser
     (_, Kwd ">") ] -> tparams
 | [ ] -> []
 
-let parse_func_header k = function%parser
+and parse_func_header k = function%parser
   [ (l, Ident g); [%let l, g = parse_simple_path_rest l g]; parse_type_params as tparams; (_, Kwd "("); [%let ps = rep_comma parse_param]; (_, Kwd ")");
     [%let rt = function%parser
       [ (_, Kwd "->"); parse_type as t ] -> Some t
@@ -527,7 +528,7 @@ let parse_func_header k = function%parser
     ]
   ] -> (l, g, tparams, ps, rt)
 
-let parse_func_rest k = function%parser
+and parse_func_rest k = function%parser
   [ [%let (l, g, tparams, ps, rt) = parse_func_header k];
     [%let d = function%parser
       [ (_, Kwd ";");
@@ -541,7 +542,7 @@ let parse_func_rest k = function%parser
     ]
   ] -> d
 
-let rec parse_ctors = function%parser
+and parse_ctors = function%parser
   [ (l, Ident cn);
     [%let ts = function%parser
      | [ (_, Kwd "(");
@@ -556,7 +557,7 @@ and parse_ctors_suffix = function%parser
 | [ (_, Kwd "|"); parse_ctors as cs ] -> cs
 | [ ] -> []
 
-let parse_lemma_keyword = function%parser
+and parse_lemma_keyword = function%parser
   [ (_, Kwd "lem") ] -> Lemma (false, None)
 | [ (_, Kwd "lem_auto");
     [%let trigger = function%parser
@@ -565,7 +566,7 @@ let parse_lemma_keyword = function%parser
     ]
   ] -> Lemma (true, trigger)
 
-let parse_ghost_decl = function%parser
+and parse_ghost_decl = function%parser
 | [ (l, Kwd "inductive"); (li, Ident i); parse_type_params as tparams; (_, Kwd "=");
     [%let cs = function%parser
      | [ parse_ctors as cs ] -> cs
@@ -699,9 +700,9 @@ let parse_ghost_decl = function%parser
   in
   if targ_names <> tparams then raise (ParseException (lrhs, "Right-hand side type arguments must match definition type parameters"));
   [TypePredDef (l, tparams, tp, predName, Left (lrhs, rhs))]
-| [ (l, Kwd "let"); (lx, PrimePrefixedIdent x); (_, Kwd "="); parse_expr as e; (_, Kwd ";") ] -> [TypeWithTypeidDecl (l, x, CallExpr (l, "typeid_of_lft", [], [], [LitPat e], Static))]
+| [ (l, Kwd "let_lft"); (lx, PrimePrefixedIdent x); (_, Kwd "="); parse_expr as e; (_, Kwd ";") ] -> [TypeWithTypeidDecl (l, x, CallExpr (l, "typeid_of_lft", [], [], [LitPat e], Static))]
 
-let parse_ghost_decls stream = List.flatten (rep parse_ghost_decl stream)
+and parse_ghost_decls stream = List.flatten (rep parse_ghost_decl stream)
 
 let parse_ghost_decl_block = function%parser
   [ (_, Kwd "/*@"); parse_ghost_decls as ds; (_, Kwd "@*/") ] -> ds

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -240,7 +240,7 @@ impl Tree {
                     //@ if q < 1 { close [1 - q]hidden_lifetime_token(k1); }
                     //@ close_lifetime_intersection_token(q, k, k1);
                     {
-                        //@ let 'b = kk1;
+                        //@ let_lft 'b = kk1;
                         visitor.visit/*@::<V, 'b> @*/((*x).data);
                     }
                     //@ if q < 1 { open [1 - q]hidden_lifetime_token(k1); }


### PR DESCRIPTION
This simplifies applying open_full_borrow_strong.

Also:
- Change the syntax of local lifetime declarations from 'let 'a = ...;' to 'let_lft 'a = ...;'
- Allow using 'box' as an identifier
- Add 'make vf' target: makes ../bin/verifast and ../bin/vfide
