### PR TITLE
Single-field structs have no padding

### DIFF
--- a/bin/rust/rust_belt/lifetime_logic.rsspec
+++ b/bin/rust/rust_belt/lifetime_logic.rsspec
@@ -155,6 +155,22 @@ lem close_full_borrow_strong(k1: lifetime_t, P: pred(), Q: pred());
     req close_full_borrow_token_strong(k1, P, ?q, ?k) &*& is_full_borrow_convert_strong(?f, ?Ctx, Q, k1, P) &*& Ctx() &*& Q();
     ens full_borrow(k1, Q) &*& [q]lifetime_token(k) &*& is_full_borrow_convert_strong(f, Ctx, Q, k1, P);
 
+pred close_full_borrow_token_strong_(k: lifetime_t, P: pred(), q: real);
+
+lem open_full_borrow_strong_(k: lifetime_t, P: pred());
+    nonghost_callers_only
+    req full_borrow(k, P) &*& [?q]lifetime_token(k);
+    ens P() &*& close_full_borrow_token_strong_(k, P, q);
+
+lem_type restore_full_borrow_(Ctx: pred(), Q: pred(), P: pred()) = lem();
+    req Ctx() &*& Q(); // Empty mask
+    ens P();
+
+lem close_full_borrow_strong_();
+    nonghost_callers_only
+    req close_full_borrow_token_strong_(?k, ?P, ?q) &*& is_restore_full_borrow_(?proof, ?Ctx, ?Q, P) &*& Ctx() &*& Q();
+    ens full_borrow(k, Q) &*& [q]lifetime_token(k) &*& is_restore_full_borrow_(proof, Ctx, Q, P);
+
 // LftL-bor-unnest
 pred_ctor full_borrow_(k: lifetime_t, P: pred())(;) = full_borrow(k, P);
 

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -6710,8 +6710,17 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     flatmap
       begin
         function
-          (sn, (_, tparams, Some (_, fmap, _), _, _)) ->
+          (sn, (lsn, tparams, Some (_, fmap, _), padding_symb_opt, _)) ->
           let targs = tparams_as_targs tparams in
+          begin match padding_symb_opt, fmap with
+          | Some symb, [_] ->
+            (* Single-field structs have no padding *)
+            [("struct_" ^ sn ^ "_padding", []),
+             ([], lsn, tparams, [sn, PtrType (StructType (sn, targs))], symb, Some 1,
+              EmpAsn lsn)]
+          | _ -> []
+          end
+          @
           flatmap
             begin
               function

--- a/tests/rust/safe_abstraction/box.rs
+++ b/tests/rust/safe_abstraction/box.rs
@@ -1,0 +1,37 @@
+pub struct Box<T> {
+    ptr: *mut T
+}
+
+/*@
+
+pred<T> <Box<T>>.own(t, box) = (<T>.full_borrow_content(t, box.ptr))() &*& std::alloc::alloc_block(box.ptr as *u8, std::alloc::Layout::new_::<T>());
+
+@*/
+
+impl<T> Box<T> {
+
+    pub fn deref_mut<'a>(&'a mut self) -> &'a mut T {
+        unsafe {
+            //@ open_full_borrow_strong_('a, Box_full_borrow_content(_t, self));
+            //@ open Box_full_borrow_content::<T>(_t, self)();
+            //@ open Box_own::<T>(_t, ?box);
+            let r = &mut *self.ptr;
+            /*@
+            {
+                pred Ctx() = (*self).ptr |-> r &*& std::alloc::alloc_block(r as *u8, std::alloc::Layout::new_::<T>());
+                produce_lem_ptr_chunk restore_full_borrow_(Ctx, <T>.full_borrow_content(_t, r), Box_full_borrow_content(_t, self))() {
+                    open Ctx();
+                    close Box_own::<T>(_t, box);
+                    close Box_full_borrow_content::<T>(_t, self)();
+                } {
+                    close Ctx();
+                    close_full_borrow_strong_();
+                }
+            }
+            @*/
+            r
+        }
+    }
+
+}
+

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -42,6 +42,7 @@ cd purely_unsafe
   verifast -target LP64 -c -extern ../unverified/platform atomics_example.rs
 cd ..
 cd safe_abstraction
+  verifast -c box.rs
   verifast -c full_bor_primitive_types.rs
   verifast -c shared_primitive_types.rs
   verifast -c deque_i32.rs


### PR DESCRIPTION
(I'm not aware of any such official guarantee, but at least for Rust, I guess it follows from Rust's claim of offering the ability to build zero-cost abstractions.)

Also:
- [Rust] Add simplified version of open_full_borrow_strong
- [Rust] Add box.rs example (just deref_mut for now)
