### PR TITLE
Allow patterns as arguments in expression calls

### DIFF
--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -375,7 +375,7 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
         [ Symbol "expr-call-expr" ]
         [
           "expr", sexpr_of_expr expr;
-          "args", sexpr_of_list sexpr_of_expr args
+          "args", sexpr_of_list sexpr_of_pat args
         ]
     | WFunPtrCall (_, callee, ftn_opt, exprs) ->
       build_list

--- a/src/explorer/explorer.ml
+++ b/src/explorer/explorer.ml
@@ -312,7 +312,7 @@ let _ =
       | ReadArray(_, array_expr, index_expr) -> string_of_expr array_expr ^ "[" ^ string_of_expr index_expr ^ "]" 
       | Deref(_, expr_in) -> "*" ^ string_of_expr expr_in
       | CallExpr(_, name, _, _, args, _) -> name ^ "(" ^ string_of_pat_list args ^ ")"
-      | ExprCallExpr(_, callee_expr, args_expr) -> string_of_expr callee_expr ^ "(" ^ string_of_expr_list args_expr ^ ")"
+      | ExprCallExpr(_, callee_expr, args_expr) -> string_of_expr callee_expr ^ "(" ^ string_of_pat_list args_expr ^ ")"
       | IfExpr(_, cond_expr, then_expr, else_expr) -> "(" ^ string_of_expr cond_expr ^") ? (" ^ string_of_expr then_expr ^ ") : (" ^ string_of_expr else_expr ^ ")"
       | CastExpr(_, type_cast, expr_in) -> "(" ^ string_of_type_expr type_cast ^ ")" ^ string_of_expr expr_in 
       | SizeofExpr(_, TypeExpr type_sizeof) -> "sizeof(" ^ string_of_type_expr type_sizeof ^ ")"
@@ -625,11 +625,11 @@ let _ =
               | ExprCallExpr(_, callee_expr, args_expr) ->
                 begin
                   let pattern_inside = if (exactMacthOnly) then false, []
-                    else combine_or (check_expr_for_pattern callee_expr pattern false) (check_expr_list_for_pattern args_expr pattern)
+                    else combine_or (check_expr_for_pattern callee_expr pattern false) (check_pat_list_for_pattern args_expr pattern)
                   in
                   match pattern with
-                    | ExprCallExpr(_, pattern_callee_expr, pattern_args_expr) -> 
-                      let res_exact_match = combine_and (check_expr_for_pattern callee_expr pattern_callee_expr true) (check_expr_list_for_pattern_list args_expr pattern_args_expr) in
+                    | ExprCallExpr(_, pattern_callee_expr, pattern_args_expr) when List.length args_expr = List.length pattern_args_expr ->
+                      let res_exact_match = combine_and (check_expr_for_pattern callee_expr pattern_callee_expr true) (check_pat_list_equal_list args_expr pattern_args_expr) in
                       combine_or pattern_inside res_exact_match
                     | _ -> pattern_inside
                 end

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -407,7 +407,7 @@ and
   | ExprCallExpr of (* Call whose callee is an expression instead of a plain identifier *)
       loc *
       expr *
-      expr list
+      pat list
   | WFunPtrCall of loc * expr * string option (* function type name *) * expr list
   | WPureFunCall of loc * string * type_ list * expr list
   | WPureFunValueCall of loc * expr * expr list
@@ -1287,7 +1287,7 @@ let expr_fold_open iter state e =
   | Deref (l, e0) -> iter state e0
   | WDeref (l, e0, tp) -> iter state e0
   | CallExpr (l, g, targes, pats0, pats, mb) -> let state = iterpats state pats0 in let state = iterpats state pats in state
-  | ExprCallExpr (l, e, es) -> iters state (e::es)
+  | ExprCallExpr (l, e, es) -> iterpats (iter state e) es
   | WPureFunCall (l, g, targs, args) -> iters state args
   | WPureFunValueCall (l, e, args) -> iters state (e::args)
   | WFunCall (l, g, targs, args, _) -> iters state args

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -337,7 +337,7 @@ and of_expr = function
   C ("ExprCallExpr", [
     of_loc l;
     of_expr ef;
-    of_list of_expr args
+    of_list of_pat args
   ])
 | WFunPtrCall (l, ef, ftn_opt, args) ->
   C ("WFunPtrCall", [

--- a/src/frontend/parser.ml
+++ b/src/frontend/parser.ml
@@ -1109,7 +1109,7 @@ and
           Some ([ReturnStmt (l, Some (call g [call iargs (List.map (fun (t, x) -> Var (l, x)) ps)]))], l), false, []);
         Func (l, Fixpoint, tparams, Some rt, gdef_curried, [PureFuncTypeExpr (l, [iargsType; rt]), g; iargsType, "__args"], false, None, None, false,
           Some ([SwitchStmt (l, Var (l, "__args"), [SwitchStmtClause (l, call iargs (List.map (fun (t, x) -> Var (l, x)) ps),
-            [ReturnStmt (l, Some (call gdef ([ExprCallExpr (l, Var (l, g_uncurry), [Var (l, g)])] @ List.map (fun (t, x) -> Var (l, x)) ps)))])])], l), false, []);
+            [ReturnStmt (l, Some (call gdef ([ExprCallExpr (l, Var (l, g_uncurry), [LitPat (Var (l, g))])] @ List.map (fun (t, x) -> Var (l, x)) ps)))])])], l), false, []);
         Func (l, Fixpoint, tparams, Some (ManifestTypeExpr (l, intType)), gmeasure, [iargsType, "__args"], false, None, None, false,
           Some ([SwitchStmt (l, Var (l, "__args"), [SwitchStmtClause (l, call iargs (List.map (fun (t, x) -> Var (l, x)) ps),
             [ReturnStmt (l, Some measure)])])], l), false, []);
@@ -1121,7 +1121,7 @@ and
             IfStmt (l, Operation (l, Neq, [call g (List.map (fun (t, x) -> Var (l, x)) ps); bodyExpr]), [
               ExprStmt (call "fix_unfold" [Var (l, gdef_curried); Var (l, gmeasure); call iargs (List.map (fun (t, x) -> Var (l, x)) ps)]);
               Open (l, None, "exists", [], [], [CtorPat (l, "pair", [CtorPat (l, "pair", [VarPat (l, "f1__"); VarPat (l, "f2__")]); CtorPat (l, iargs, List.map (fun (t, x) -> VarPat (l, x ^ "0")) ps)])], None);
-              Assert (l, (MatchAsn (l, call "pair" [ExprCallExpr (l, Var (l, g_uncurry), [Var (l, "f1_")]); ExprCallExpr (l, Var (l, g_uncurry), [Var (l, "f2_")])],
+              Assert (l, (MatchAsn (l, call "pair" [ExprCallExpr (l, Var (l, g_uncurry), [LitPat (Var (l, "f1_"))]); ExprCallExpr (l, Var (l, g_uncurry), [LitPat (Var (l, "f2_"))])],
                 CtorPat (l, "pair", [VarPat (l, g ^ "__1"); VarPat (l, g ^ "__2")]))));
               Assert (l, Operation (l, Eq, [
                 call gdef ([Var (l, g ^ "__1")] @ List.map (fun (t, x) -> Var (l, x ^ "0")) ps);
@@ -2803,9 +2803,9 @@ and
 | [ (l, Kwd "--"); 
     [%l e = parse_expr_suffix_rest (AssignOpExpr (l, e0, Sub, IntLit (l, unit_big_int, true, false, NoLSuffix), true))] ] -> e
 | [ (l, Kwd "("); 
-    [%l es = rep_comma parse_expr]; 
+    [%l es = rep_comma parse_pattern]; 
     (_, Kwd ")"); 
-    [%l e = parse_expr_suffix_rest (match e0 with Read(l', e0', f') -> CallExpr (l', f', [], [], LitPat(e0'):: (List.map (fun e -> LitPat(e)) es), Instance) | _ -> ExprCallExpr (l, e0, es))]
+    [%l e = parse_expr_suffix_rest (match e0 with Read(l', e0', f') -> CallExpr (l', f', [], [], LitPat e0'::es, Instance) | _ -> ExprCallExpr (l, e0, es))]
   ] -> e
 | [ ] -> e0
 and

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -1604,7 +1604,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                   (Ast.ExprCallExpr
                      ( loc,
                        TypePredExpr (loc, IdentTypeExpr (loc, None, name), "own"),
-                       [ t; v ] )));
+                       [ LitPat t; LitPat v ] )));
             shr =
               (fun k t l ->
                 Ok
@@ -1615,7 +1615,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                          ( loc,
                            TypePredExpr
                              (loc, IdentTypeExpr (loc, None, name), "share"),
-                           [ k; t; l ] ) )));
+                           [ LitPat k; LitPat t; LitPat l ] ) )));
             full_bor_content =
               (fun tid l ->
                 Ok
@@ -1625,7 +1625,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                          ( loc,
                            IdentTypeExpr (loc, None, name),
                            "full_borrow_content" ),
-                       [ tid; l ] )));
+                       [ LitPat tid; LitPat l ] )));
             points_to =
               (fun t l vid ->
                 let rhs =

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -4575,6 +4575,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let tp = instantiate_type tpenv tp in
       (WFunCall (l, "#inductive_projection", [t], [w; i1; i2], Static), tp, None)
     | ExprCallExpr (l, e, es) ->
+      let es = List.map (function LitPat e -> e | _ -> static_error l "Patterns are not supported here" None) es in
       let (w, t, _) = check e in
       begin match (t, es) with
         (PureFuncType (_, _), _) -> check_pure_fun_value_call l w t es
@@ -6501,7 +6502,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         let a =
           match e with
           | CallExpr (l, g, targs, pats0, pats, binding) when binding <> Instance -> PredAsn (l, g, targs, pats0, pats, binding)
-          | ExprCallExpr (l, e, args) -> PredExprAsn (l, e, List.map (fun e -> LitPat e) args)
+          | ExprCallExpr (l, e, args) -> PredExprAsn (l, e, args)
           | CallExpr (l, g, [], pats0, LitPat e::pats, Instance) ->
             let index =
               match pats0 with

--- a/tests/rust/safe_abstraction/box.rs
+++ b/tests/rust/safe_abstraction/box.rs
@@ -14,7 +14,7 @@ impl<T> Box<T> {
         unsafe {
             //@ open_full_borrow_strong_('a, Box_full_borrow_content(_t, self));
             //@ open Box_full_borrow_content::<T>(_t, self)();
-            //@ open Box_own::<T>(_t, ?box);
+            //@ open <Box<T>>.own(_t, ?box);
             let r = &mut *self.ptr;
             /*@
             {


### PR DESCRIPTION
Allows E(?x) or E(_) where E is an arbitrary expression.
