### PR TITLE
[Rust] Bump Rust toolchain to nightly-2024-11-23

### DIFF
--- a/src/rust_frontend/rust_fe.ml
+++ b/src/rust_frontend/rust_fe.ml
@@ -97,7 +97,7 @@ module Make (Args : RUST_FE_ARGS) = struct
   let run_vf_mir_exporter (rustc_args : string list) (rs_file_path : string) =
     try
       (*** TODO @Nima: Get these names from build system *)
-      let tchain_name = "nightly-2024-06-10" in
+      let tchain_name = "nightly-2024-11-23" in
       let* tchain_root = RustTChain.find_tchain_root tchain_name in
       let tchain_lib, rustc_driver_prefix =
         match Vfconfig.platform with

--- a/src/rust_frontend/vf_mir_exporter/rust-toolchain.toml
+++ b/src/rust_frontend/vf_mir_exporter/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-10"
+channel = "nightly-2024-11-23"
 components = ["rustc-dev", "llvm-tools-preview"]

--- a/src/rust_frontend/vf_mir_exporter/src/main.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_private)]
+
 fn init_tracing() {
     // A builder for `FmtSubscriber`.
     let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -2054,7 +2054,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                  there is a problem with extending the implementation for clean-up paths *)
               | "std::ptr::mut_ptr::<impl *mut T>::is_null" -> (
                   match (substs, args_cpn) with
-                  | ( [ Mir.GenArgType gen_arg_ty_info; Mir.GenArgConst ],
+                  | ( [ Mir.GenArgType gen_arg_ty_info ],
                       [ arg_cpn ] ) ->
                       let* tmp_rvalue_binders, [ arg ] =
                         translate_operands [ (arg_cpn, fn_loc) ]
@@ -2081,7 +2081,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               | "std::ptr::const_ptr::<impl *const T>::offset"
               | "std::ptr::mut_ptr::<impl *mut T>::offset" -> (
                   match (substs, args_cpn) with
-                  | ( [ Mir.GenArgType gen_arg_ty_info; Mir.GenArgConst ],
+                  | ( [ Mir.GenArgType gen_arg_ty_info ],
                       [ arg1_cpn; arg2_cpn ] ) ->
                       let* tmp_rvalue_binders, [ arg1; arg2 ] =
                         translate_operands
@@ -2098,7 +2098,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               | "std::ptr::const_ptr::<impl *const T>::offset_from"
               | "std::ptr::mut_ptr::<impl *mut T>::offset_from" -> (
                   match (substs, args_cpn) with
-                  | ( [ Mir.GenArgType gen_arg_ty_info; Mir.GenArgConst ],
+                  | ( [ Mir.GenArgType gen_arg_ty_info ],
                       [ arg1_cpn; arg2_cpn ] ) ->
                       let* tmp_rvalue_binders, [ arg1; arg2 ] =
                         translate_operands
@@ -2121,7 +2121,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               | "std::ptr::const_ptr::<impl *const T>::add"
               | "std::ptr::mut_ptr::<impl *mut T>::add" -> (
                   match (substs, args_cpn) with
-                  | ( [ Mir.GenArgType gen_arg_ty_info; Mir.GenArgConst ],
+                  | ( [ Mir.GenArgType gen_arg_ty_info ],
                       [ arg1_cpn; arg2_cpn ] ) ->
                       let* tmp_rvalue_binders, [ arg1; arg2 ] =
                         translate_operands
@@ -2148,7 +2148,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               | "std::ptr::const_ptr::<impl *const T>::sub"
               | "std::ptr::mut_ptr::<impl *mut T>::sub" -> (
                   match (substs, args_cpn) with
-                  | ( [ Mir.GenArgType gen_arg_ty_info; Mir.GenArgConst ],
+                  | ( [ Mir.GenArgType gen_arg_ty_info ],
                       [ arg1_cpn; arg2_cpn ] ) ->
                       let* tmp_rvalue_binders, [ arg1; arg2 ] =
                         translate_operands

--- a/tests/rust/purely_unsafe/account_value.rs
+++ b/tests/rust/purely_unsafe/account_value.rs
@@ -51,8 +51,8 @@ impl Account {
 fn main1() {
     unsafe {
         let mut account = Account::new();
-        Account::deposit(std::ptr::addr_of_mut!(account), 1000);
-        assert(Account::get_balance(std::ptr::addr_of_mut!(account)) == 1000);
+        Account::deposit(&raw mut account, 1000);
+        assert(Account::get_balance(&raw mut account) == 1000);
     }
 }
 

--- a/tests/rust/purely_unsafe/deque.rs
+++ b/tests/rust/purely_unsafe/deque.rs
@@ -122,7 +122,7 @@ impl<T> Deque<T> {
         }
         //@ close_struct(new_node);
         (*new_node).prev = (*deque).sentinel;
-        std::ptr::write(std::ptr::addr_of_mut!((*new_node).value), value);
+        std::ptr::write(&raw mut (*new_node).value, value);
         //@ close Node_value(new_node, _);
         //@ let sentinel = (*deque).sentinel;
         //@ let first = (*sentinel).next;
@@ -144,7 +144,7 @@ impl<T> Deque<T> {
         //@ close_struct(new_node);
         //@ let sentinel = (*deque).sentinel;
         (*new_node).prev = (*(*deque).sentinel).prev;
-        std::ptr::write(std::ptr::addr_of_mut!((*new_node).value), value);
+        std::ptr::write(&raw mut (*new_node).value, value);
         //@ close Node_value(new_node, _);
         (*new_node).next = (*deque).sentinel;
         /*@
@@ -176,7 +176,7 @@ impl<T> Deque<T> {
         let node = (*(*deque).sentinel).next;
         //@ open Nodes(_, _, _, _, _);
         //@ open Node_value(node, _);
-        let result = std::ptr::read(std::ptr::addr_of!((*node).value));
+        let result = std::ptr::read(&raw mut (*node).value);
         //@ close Node_value(node, _);
         (*(*node).prev).next = (*node).next;
         //@ open Nodes(_, _, _, _, _);
@@ -196,7 +196,7 @@ impl<T> Deque<T> {
         //@ Nodes_split_last(first);
         let node = (*(*deque).sentinel).prev;
         //@ open Node_value(node, _);
-        let result = std::ptr::read(std::ptr::addr_of!((*node).value));
+        let result = std::ptr::read(&raw const (*node).value);
         //@ close Node_value(node, _);
         /*@
         if 2 <= length(elems) {

--- a/tests/rust/purely_unsafe/mt_account_transfer.rs
+++ b/tests/rust/purely_unsafe/mt_account_transfer.rs
@@ -61,12 +61,12 @@ fn main() {
             std::alloc::handle_alloc_error(layout);
         }
         //@ close_struct(accounts);
-        std::ptr::write(std::ptr::addr_of_mut!((*accounts).balance1), 2000);
-        std::ptr::write(std::ptr::addr_of_mut!((*accounts).balance2), 0);
+        std::ptr::write(&raw mut (*accounts).balance1, 2000);
+        std::ptr::write(&raw mut (*accounts).balance2, 0);
         //@ close Accounts_inv(accounts)();
         //@ close exists(Accounts_inv(accounts));
         let mutex = simple_mutex::SimpleMutex_new();
-        std::ptr::write(std::ptr::addr_of_mut!((*accounts).mutex), mutex);
+        std::ptr::write(&raw mut (*accounts).mutex, mutex);
         //@ produce_fn_ptr_chunk platform::threading::thread_run(transfer)(transfer_pre)(data) { call(); }
         platform::threading::fork(transfer, accounts as *mut u8);
         simple_mutex::SimpleMutex_acquire(mutex);

--- a/tests/rust/purely_unsafe/point_value.rs
+++ b/tests/rust/purely_unsafe/point_value.rs
@@ -51,8 +51,8 @@ impl Point {
 fn main1() {
     unsafe {
         let mut point = Point::new();
-        Point::set_x(std::ptr::addr_of_mut!(point), 1000);
-        assert(Point::get_x(std::ptr::addr_of_mut!(point)) == 1000);
+        Point::set_x(&raw mut point, 1000);
+        assert(Point::get_x(&raw mut point) == 1000);
     }
 }
 

--- a/tests/rust/rust-toolchain.toml
+++ b/tests/rust/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-06-10"
+channel = "nightly-2024-11-23"

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -323,7 +323,7 @@ impl<T> Deque<T> {
         //@ close_struct(new_node);
         //@ open Deque(_, _);
         (*new_node).prev = (*deque).sentinel;
-        std::ptr::write(std::ptr::addr_of_mut!((*new_node).value), value);
+        std::ptr::write(&raw mut (*new_node).value, value);
         //@ let sentinel = (*deque).sentinel;
         //@ let first = (*sentinel).next;
         (*new_node).next = (*(*deque).sentinel).next;
@@ -367,7 +367,7 @@ impl<T> Deque<T> {
         //@ open Deque(_, _);
         //@ let sentinel = (*deque).sentinel;
         (*new_node).prev = (*(*deque).sentinel).prev;
-        std::ptr::write(std::ptr::addr_of_mut!((*new_node).value), value);
+        std::ptr::write(&raw mut (*new_node).value, value);
         (*new_node).next = (*deque).sentinel;
         //@ assert Deque__(sentinel, ?nodes);
         /*@


### PR DESCRIPTION
Also, uses the new '&raw const/mut $expr' syntax instead of
'std::ptr::addr_of!($expr)'/'std::ptr::addr_of_mut!($expr)'.
