### PR TITLE
[Rust] Check variance

### DIFF
--- a/bin/rust/rust_belt/general.rsspec
+++ b/bin/rust/rust_belt/general.rsspec
@@ -205,4 +205,12 @@ lem_auto lft_of_typeid_of_lft(k: lifetime_t);
     req true;
     ens lft_of(typeid_of_lft(k)) == k;
 
+fix is_subtype_of<T0, T1>() -> bool; // T0 is a subtype of T1
+
+fix upcast<t0, t1>(x: t0) -> t1; // Cast a value of type t0 to a supertype t1 of t0
+
+lem own_mono<T0, T1>(t: thread_id_t, v: T0);
+    req type_interp::<T0>() &*& type_interp::<T1>() &*& <T0>.own(t, v) &*& is_subtype_of::<T0, T1>() == true;
+    ens type_interp::<T0>() &*& type_interp::<T1>() &*& <T1>.own(t, upcast::<T0, T1>(v));
+
 @*/

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -48,13 +48,21 @@ mod ptr {
     struct NonNull<T>;
     
     /*@
+    
     lem close_NonNull_own<T>(t: thread_id_t, v: NonNull<T>);
         req NonNull_ptr(v) as usize != 0;
         ens (NonNull_own::<T>())(t, v);
+        
     lem open_NonNull_own<T>(t: thread_id_t, v: NonNull<T>);
         req [_](NonNull_own::<T>())(t, v);
         ens NonNull_ptr(v) as usize != 0;
+        
     fix NonNull_ptr<_T>(v: NonNull<_T>) -> *_T;
+    
+    lem NonNull_upcast<T0, T1>(v: NonNull<T0>);
+        req true;
+        ens NonNull_ptr::<T1>(upcast(v)) == NonNull_ptr::<T0>(v) as *_;
+    
     @*/
 
     impl<T> NonNull<T> {

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -517,6 +517,7 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
             "t2", sexpr_of_prover_type t2;
             "e", sexpr_of_expr e
           ]
+    | Unbox (e, t) -> build_list [ Symbol "expr-unbox" ] [ "e", sexpr_of_expr e; "t", sexpr_of_type_ t ]
     | ArrayTypeExpr' (_, e) ->
         build_list
           [ Symbol "expr-array-type" ]

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -498,6 +498,7 @@ and
   | GenericExpr of loc * expr * (type_expr * expr) list * expr option (* default clause *) (* C11 generic selection (keyword '_Generic') *)
   | AddressOf of loc * expr
   | ProverTypeConversion of prover_type * prover_type * expr  (* Generated during type checking in the presence of type parameters, to get the prover types right *)
+  | Unbox of expr * type_ (* Generated during type checking; Unbox (e, t) converts the value of e, which is of prover type Inductive, to the prover type of t *)
   | ArrayTypeExpr' of loc * expr (* horrible hack --- for well-formed programs, this exists only during parsing *)
   | AssignExpr of loc * expr * expr
   | AssignOpExpr of loc * expr * operator * expr * bool (* true = return value of lhs before operation *)
@@ -1119,6 +1120,7 @@ let rec expr_loc e =
   | WAssignOpExpr (l, lhs, x, rhs, postOp) -> l
   | CommaExpr (l, e1, e2) -> l
   | ProverTypeConversion (t1, t2, e) -> expr_loc e
+  | Unbox (e, t) -> expr_loc e
   | InstanceOfExpr(l, e, tp) -> l
   | SuperMethodCall(l, _, _) -> l
   | WSuperMethodCall(l, _, _, _, _) -> l
@@ -1347,6 +1349,7 @@ let expr_fold_open iter state e =
     end
   | AddressOf (l, e0) -> iter state e0
   | ProverTypeConversion (pt, pt0, e0) -> iter state e0
+  | Unbox (e, t) -> iter state e
   | ArrayTypeExpr' (l, e) -> iter state e
   | AssignExpr (l, lhs, rhs) -> iter (iter state lhs) rhs
   | AssignOpExpr (l, lhs, op, rhs, post) -> iter (iter state lhs) rhs

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -484,6 +484,7 @@ and of_expr = function
     of_prover_type ptt;
     of_expr e
   ])
+| Unbox (e, t) -> C ("Unbox", [of_expr e; of_type t])
 | ArrayTypeExpr' (l, e) -> C ("ArrayTypeExpr'", [of_loc l; of_expr e])
 | AssignExpr (l, el, er) ->
   C ("AssignExpr", [

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -146,6 +146,13 @@ struct Hir {
     }
 }
 
+enum Variance {
+    covariant @0;
+    invariant @1;
+    contravariant @2;
+    bivariant @3;
+}
+
 struct Ty {
 
     struct ConstKind {
@@ -232,6 +239,7 @@ struct Ty {
         vis @4: Visibility;
         isLocal @5: Bool;
         hirGenerics @6: Hir.Generics;
+        variances @10: List(Variance); # One for each generic lifetime or type parameter
         predicates @7: List(Predicate);
         implementsDrop @8: Bool;
     }

--- a/src/rust_frontend/vf_mir_translator/rust_parser.ml
+++ b/src/rust_frontend/vf_mir_translator/rust_parser.ml
@@ -684,7 +684,7 @@ and parse_ghost_decl = function%parser
      | [ ] -> false
     ]
   ] -> [FuncTypeDecl (l, Real, rt, ftn, [], ftps, ps, (pre, post, terminates))]
-| [ (l, Kwd "lem_type"); (lftn, Ident ftn); (_, Kwd "("); [%let ftps = rep_comma parse_param]; (_, Kwd ")"); (_, Kwd "=");
+| [ (l, Kwd "lem_type"); (lftn, Ident ftn); parse_type_params as tparams; (_, Kwd "("); [%let ftps = rep_comma parse_param]; (_, Kwd ")"); (_, Kwd "=");
   (_, Kwd "lem"); (_, Kwd "("); [%let ps = rep_comma parse_param]; (_, Kwd ")"); 
   [%let rt = function%parser
     [ (_, Kwd "->"); parse_type as t ] -> Some t
@@ -693,7 +693,7 @@ and parse_ghost_decl = function%parser
   (_, Kwd ";");
   (_, Kwd "req"); parse_asn as pre; (_, Kwd ";");
   (_, Kwd "ens"); parse_asn as post; (_, Kwd ";")
-] -> [FuncTypeDecl (l, Ghost, rt, ftn, [], ftps, ps, (pre, post, false))]
+] -> [FuncTypeDecl (l, Ghost, rt, ftn, tparams, ftps, ps, (pre, post, false))]
 | [ (l, Kwd "abstract_type"); (_, Ident tn); (_, Kwd ";") ] -> [AbstractTypeDecl (l, tn)]
 | [ (l, Kwd "type_pred_decl"); (_, Kwd "<"); (_, Kwd "Self"); (_, Kwd ">"); (_, Kwd "."); (_, Ident predName); (_, Kwd ":"); parse_type as te; (_, Kwd ";") ] ->
   [TypePredDecl (l, te, "Self", predName)]

--- a/src/rust_frontend/vf_mir_translator/vf_mir_capnp_alias.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_capnp_alias.ml
@@ -24,6 +24,7 @@ module AnnotationRd = VfMirStub.Reader.Annotation
 module UnsafetyRd = VfMirStub.Reader.Unsafety
 module IdentRd = VfMirStub.Reader.Ident
 module VisibilityRd = VfMirStub.Reader.Visibility
+module VarianceRd = VfMirStub.Reader.Variance
 
 (* Hir *)
 module HirRd = VfMirStub.Reader.Hir

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1337,6 +1337,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       List.iter (function (te, e) -> expr_mark_addr_taken e locals) cases;
       begin match default with None -> () | Some e -> expr_mark_addr_taken e locals end
     | ProverTypeConversion(_, _, e) ->  expr_mark_addr_taken e locals
+    | Unbox (e, _) -> expr_mark_addr_taken e locals
     | ArrayTypeExpr'(_, e) ->  expr_mark_addr_taken e locals
     | AssignExpr(_, e1, e2) ->  expr_mark_addr_taken e1 locals;  expr_mark_addr_taken e2 locals
     | AssignOpExpr(_, e1, _, e2, _) -> expr_mark_addr_taken e1 locals;  expr_mark_addr_taken e2 locals
@@ -1502,6 +1503,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       in
       iter e
     | ProverTypeConversion(_, _, e) -> expr_address_taken e
+    | Unbox (e, _) -> expr_address_taken e
     | ArrayTypeExpr'(_, e) -> expr_address_taken e
     | AssignExpr(_, e1, e2) -> (expr_address_taken e1) @ (expr_address_taken e2)
     | AssignOpExpr(_, e1, _, e2, _) -> (expr_address_taken e1) @ (expr_address_taken e2)

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -1,5 +1,14 @@
 /*@
 pred<T> <ptr::NonNull<T>>.own(t, nonNull;) = nonNull.pointer as usize != 0;
+
+lem ptr::NonNull_own_mono<T0, T1>()
+    req type_interp::<T0>() &*& type_interp::<T1>() &*& ptr::NonNull_own::<T0>(?t, ?v) &*& is_subtype_of::<T0, T1>() == true;
+    ens type_interp::<T0>() &*& type_interp::<T1>() &*& ptr::NonNull_own::<T1>(t, ptr::NonNull::<T1> { pointer: v.pointer as *_ });
+{
+    open ptr::NonNull_own::<T0>(t, v);
+    close ptr::NonNull_own::<T1>(t, ptr::NonNull::<T1> { pointer: v.pointer as *_ });
+}
+
 pred_ctor ptr::NonNull_frac_bc<T>(t: thread_id_t, l: *ptr::NonNull<T>)(;) = (*l).pointer |-> ?p &*& struct_ptr::NonNull_padding(l) &*& ptr::NonNull_own(t, ptr::NonNull::<T> { pointer: p });
 pred<T> <ptr::NonNull<T>>.share(k, t, l) =
     frac_borrow(k, ptr::NonNull_frac_bc(t, l));

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -28,6 +28,13 @@ pred<T> <Arc<T>>.own(t, arc) = [_]std::ptr::NonNull_own(default_tid, arc.ptr) &*
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*& ticket(dlft_pred(dk), gid, ?frac) &*& [frac]dlft_pred(dk)(gid, false) &*&
     [_](<T>.share)(dk, default_tid, &(*ptr).data) &*& pointer_within_limits(&(*ptr).data) == true &*& is_Send(typeid(T)) == true;
 
+lem Arc_own_mono<T0, T1>()
+    req type_interp::<T0>() &*& type_interp::<T1>() &*& Arc_own::<T0>(?t, ?v) &*& is_subtype_of::<T0, T1>() == true;
+    ens type_interp::<T0>() &*& type_interp::<T1>() &*& Arc_own::<T1>(t, Arc::<T1> { ptr: upcast(v.ptr) });
+{
+    assume(false);
+}
+
 pred_ctor Arc_frac_bc<T>(l: *Arc<T>, nnp: std::ptr::NonNull<ArcInner<T>>)(;) = (*l).ptr |-> nnp;
 pred_ctor ticket_(dk: lifetime_t, gid: isize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);
 

--- a/tests/rust/safe_abstraction/generic_pair.rs
+++ b/tests/rust/safe_abstraction/generic_pair.rs
@@ -7,6 +7,17 @@ pub struct Pair<A, B> {
 
 pred<A, B> <Pair<A, B>>.own(t, pair) = <A>.own(t, pair.fst) &*& <B>.own(t, pair.snd);
 
+lem Pair_own_mono<A0, A1, B0, B1>()
+    req type_interp::<A0>() &*& type_interp::<A1>() &*& type_interp::<B0>() &*& type_interp::<B1>() &*& Pair_own::<A0, B0>(?t, ?v) &*& is_subtype_of::<A0, A1>() == true &*& is_subtype_of::<B0, B1>() == true;
+    ens type_interp::<A0>() &*& type_interp::<A1>() &*& type_interp::<B0>() &*& type_interp::<B1>() &*& Pair_own::<A1, B1>(t, Pair::<A1, B1> { fst: upcast(v.fst), snd: upcast(v.snd) });
+{
+    open Pair_own::<A0, B0>(t, v);
+    Pair_upcast::<A0, A1, B0, B1>(v);
+    own_mono::<A0, A1>(t, v.fst);
+    own_mono::<B0, B1>(t, v.snd);
+    close Pair_own::<A1, B1>(t, upcast(v));
+}
+
 lem Pair_drop<A, B>()
     req Pair_own::<A, B>(?t, ?pair);
     ens <A>.own(t, pair.fst) &*& <B>.own(t, pair.snd);

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -139,6 +139,17 @@ pred<'a, T> <MutexGuard<'a, T>>.own(t, mutexGuard) =
     &*& sys::locks::SysMutex_locked(&(*mutexGuard.lock).inner, full_borrow_(klong, <T>.full_borrow_content(t0, &(*mutexGuard.lock).data)), t)
     &*& full_borrow(klong, <T>.full_borrow_content(t0, &(*mutexGuard.lock).data));
 
+lem MutexGuard_own_mono<'a0, 'a1, T>()
+    req type_interp::<T>() &*& MutexGuard_own::<'a0, T>(?t, ?v) &*& lifetime_inclusion('a1, 'a0) == true;
+    ens type_interp::<T>() &*& MutexGuard_own::<'a1, T>(t, MutexGuard::<'a1, T> { lock: v.lock as *_ });
+{
+    open MutexGuard_own::<'a0, T>(t, v);
+    assert [_]exists_np(?klong);
+    lifetime_inclusion_trans('a1, 'a0, klong);
+    frac_borrow_mono('a0, 'a1, Mutex_frac_borrow_content(klong, v.lock));
+    close MutexGuard_own::<'a1, T>(t, v);
+}
+
 pred_ctor MutexGuard_fbc_rest<'a, T>(klong: lifetime_t, t: thread_id_t, l: *MutexGuard<'a, T>, lock: *Mutex<T>)() =
     (*l).lock |-> lock &*& lifetime_inclusion('a, klong) == true &*& struct_MutexGuard_padding(l)
     &*& [_]frac_borrow('a, Mutex_frac_borrow_content(klong, lock))

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -38,6 +38,13 @@ pred<T> <Rc<T>>.own(t, rc) =
     [_](<T>.share(dk, t, &(*ptr).value)) &*&
     pointer_within_limits(&(*ptr).value) == true;
 
+lem Rc_own_mono<T0, T1>()
+    req type_interp::<T0>() &*& type_interp::<T1>() &*& Rc_own::<T0>(?t, ?v) &*& is_subtype_of::<T0, T1>() == true;
+    ens type_interp::<T0>() &*& type_interp::<T1>() &*& Rc_own::<T1>(t, Rc::<T1> { ptr: upcast(v.ptr) });
+{
+    assume(false);
+}
+
 pred_ctor Rc_frac_bc<T>(l: *Rc<T>, nnp: std::ptr::NonNull<RcBox<T>>)(;) = (*l).ptr |-> nnp;
 
 pred_ctor ticket_(dk: lifetime_t, gid: usize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);


### PR DESCRIPTION
For each struct S for which the user defines a custom `<S>.own` predicate, and that has non-invariant generic parameters, a proof obligation S_own_mono is now generated, requiring the user to show that the type interpretation satisfies the inferred variance.

Also:
- Generates an `S_upcast` lemma defining upcast::<S<T0...>, S<T1...>>(v)
- Improves VeriFast type inference for pure functions with a generic return type (such as `upcast`)

TODO:
- Verify Rc_own_mono and Arc_own_mono
- Update the S_share_mono proof obligation to also check monotonicity of <S>.share with respect to S's type parameters.
