### PR TITLE
[Rust] Nested fns: improve crash msg

### DIFF
--- a/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
@@ -203,7 +203,7 @@ pub fn preprocess(
                         cs.next();
                         output.push('{');
                         if next_block_is_fn_body {
-                            assert!(fn_body_brace_depth == -1);
+                            assert!(fn_body_brace_depth == -1, "{}:{}: nested functions are not yet supported", start_of_block.line, start_of_block.column);
                             fn_body_brace_depth = brace_depth;
                             next_block_is_fn_body = false;
                         }


### PR DESCRIPTION
Causes a more helpful message to appear in the Rust frontend crash report when the preprocessor crashes on a nested function.
