### PR TITLE
Make const vars read-only

### DIFF
--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -332,6 +332,7 @@ type type_expr = (* ?type_expr *)
   | PredTypeExpr of loc * type_expr list * int option (* if None, not necessarily precise; if Some n, precise with n input parameters *)
   | PureFuncTypeExpr of loc * type_expr list   (* Potentially uncurried *)
   | LValueRefTypeExpr of loc * type_expr
+  | ConstTypeExpr of loc * type_expr
 and
   operator =  (* ?operator *)
   | Add | Sub | PtrDiff | Le | Ge | Lt | Gt | Eq | Neq | And | Or | Xor | Not | Mul | Div | Mod | BitNot | BitAnd | BitXor | BitOr | ShiftLeft | ShiftRight
@@ -674,7 +675,7 @@ and
       stmt
   | DeclStmt of (* enkel declaratie *)
       loc *
-      (loc * type_expr option * string * expr option * (bool ref (* indicates whether address is taken *) * string list ref option ref (* pointer to enclosing block's list of variables whose address is taken *))) list
+      (loc * type_expr option * string * expr option * (bool ref (* indicates whether address is taken *) * (string * bool (*is_const_var*)) list ref option ref (* pointer to enclosing block's list of variables whose address is taken *))) list
   | ExprStmt of expr
   | IfStmt of (* if  regel-conditie-branch1-branch2  *)
       loc *
@@ -716,7 +717,7 @@ and
       decl list *
       stmt list *
       loc *
-      string list ref
+      (string * bool (*is_const_var*)) list ref
   | PerformActionStmt of
       loc *
       bool ref (* in non-pure context *) *
@@ -1047,6 +1048,7 @@ let type_expr_loc t =
   | PredTypeExpr(l, te, _) -> l
   | PureFuncTypeExpr (l, tes) -> l
   | FuncTypeExpr (l, _, _) -> l
+  | ConstTypeExpr (l, te) -> l
 
 let string_of_func_kind f=
   match f with
@@ -1202,6 +1204,7 @@ let type_expr_fold_open f state te =
   | PredTypeExpr (l, paramTps, inputParamCount) -> List.fold_left f state paramTps
   | PureFuncTypeExpr (l, tps) -> List.fold_left f state tps
   | LValueRefTypeExpr (l, tp) -> f state tp
+  | ConstTypeExpr (l, tp) -> f state tp
 
 let stmt_fold_open f state s =
   match s with

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -214,6 +214,11 @@ let rec of_type_expr = function
     of_loc l;
     of_type_expr tp
   ])
+| ConstTypeExpr (l, tp) ->
+  C ("ConstTypeExpr", [
+    of_loc l;
+    of_type_expr tp
+  ])
 and of_operator = function
   MinValue t -> C ("MinValue", [of_type t])
 | MaxValue t -> C ("MaxValue", [of_type t])
@@ -742,7 +747,7 @@ and of_stmt = function
         of_option of_expr init;
         T [
           of_ref b addressTaken;
-          of_ref (of_option (of_ref (of_list s))) addressTakenList
+          of_ref (of_option (of_ref (of_list (fun (x, isConstVar) -> T [s x; b isConstVar])))) addressTakenList
         ]
       ]
     end ds
@@ -799,7 +804,7 @@ and of_stmt = function
     of_list of_decl ds;
     of_list of_stmt ss;
     of_loc closeBraceLoc;
-    of_ref (of_list s) addressTaken
+    of_ref (of_list (fun (x, isConstVar) -> T [s x; b isConstVar])) addressTaken
   ])
 | PerformActionStmt (_, _, _, _, _, _, _, _, _, _, _, _) -> failwith "TODO"
 | SplitFractionStmt (_, _, _, _, _) -> failwith "TODO"

--- a/src/frontend/parser.ml
+++ b/src/frontend/parser.ml
@@ -1408,8 +1408,8 @@ and
     parse_primary_type as t0 
   ] -> t0
 | [ (l, Kwd "const"); 
-    parse_primary_type as t0 
-  ] -> t0
+    parse_primary_type as t0
+  ] -> ConstTypeExpr (l, t0)
 | [ (l, Kwd "register"); 
     parse_primary_type as t0 
   ] -> t0
@@ -1529,7 +1529,7 @@ and
     [%l t = parse_type_suffix t0] 
   ] -> t
 | [ (l, Kwd "const"); 
-    [%l t = parse_type_suffix t0] 
+    [%l t = parse_type_suffix (ConstTypeExpr (l, t0))] 
   ] -> t
 | [ (l, Kwd "["); 
     (_, Kwd "]"); 

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -2129,6 +2129,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       in
       iter ts
     | LValueRefTypeExpr (l, te) -> RefType (check te)
+    | ConstTypeExpr (l, te) -> check te
     in
     check te
   

--- a/tests/const_vars.c
+++ b/tests/const_vars.c
@@ -1,0 +1,35 @@
+void ptr_set(char **p, char *msg)
+//@ requires *p |-> _;
+//@ ensures *p |-> msg;
+{
+  *p = msg;
+}
+
+void char_set(char *a)
+//@ requires character(a, _);
+//@ ensures character(a, 'b');
+{
+  a[0] = 'b';
+}
+
+void test()
+//@ requires true;
+//@ ensures true;
+{
+  char *const p = 0;
+  set_ptr(&p, "Hello"); //~should_fail
+}
+
+int main(void)
+//@ requires true;
+//@ ensures true;
+{
+  const char *p = 0;
+  const char z = 0;
+
+  ptr_set(&p, "Hello");
+  char_set((char *)&z); //~should_fail
+  assert(z == 'b'); //~allow_dead_code
+
+  return 0; //~allow_dead_code
+}

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -467,6 +467,7 @@ cd tutorial_solutions
   verifast_both -target 32bit students.c
 cd ..
 cd tests
+  verifast -c -allow_should_fail const_vars.c
   verifast -c -allow_should_fail issue601.c
   verifast -c issue536.c
   verifast -c continue.c


### PR DESCRIPTION
VeriFast now produces only a fractional points-to chunk for a `const`-typed local variable.

Fixes #366
