### PR TITLE
[Rust] Generate init_ref_S proof obligation

### DIFF
--- a/bin/rust/aliasing.rsspec
+++ b/bin/rust/aliasing.rsspec
@@ -1,0 +1,93 @@
+// See https://github.com/btj/vf-rust-aliasing/tree/master/README.md
+// VeriFast aims to soundly (but not necessarily completely) enforce the Tree Borrows aliasing restrictions model by Neven Villani and Ralf Jung.
+// The current design is highly incomplete (e.g., it does not support two-phase borrows).
+
+/*@
+
+fix is_shared_ref_provenance(prov: pointer_provenance) -> bool;
+fix is_shared_ref(x: *_) -> bool { is_shared_ref_provenance((x as pointer).provenance) }
+
+fix ref_origin_provenance(prov: pointer_provenance) -> pointer_provenance;
+fix ref_origin<t>(p: *t) -> *t { pointer_ctor(ref_origin_provenance((p as pointer).provenance), (p as pointer).address) as *t }
+
+lem_auto(ptr_provenance_min_addr(ref_origin_provenance(prov))) ref_origin_min_addr(prov: pointer_provenance);
+    req true;
+    ens ptr_provenance_min_addr(ref_origin_provenance(prov)) == ptr_provenance_min_addr(prov);
+
+lem_auto(ptr_provenance_max_addr(ref_origin_provenance(prov))) ref_origin_max_addr(prov: pointer_provenance);
+    req true;
+    ens ptr_provenance_max_addr(ref_origin_provenance(prov)) == ptr_provenance_max_addr(prov);
+
+lem_auto(ref_origin(ref_origin(p))) ref_origin_ref_origin(p: *_);
+    req true;
+    ens ref_origin(ref_origin(p)) == ref_origin(p);
+
+pred ref_mut_end_token<T>(p: *T; x: *T);
+
+pred ref_init_perm<T>(p: *T; x: *T);
+pred ref_padding_init_perm<T>(p: *T; x: *T);
+
+lem_auto ref_init_perm_inv<T>();
+    req ref_init_perm::<T>(?p, ?x);
+    ens ref_init_perm::<T>(p, x) &*& ref_origin(p) == ref_origin(x);
+
+pred ref_end_token<T>(p: *T; x: *T, frac: real);
+pred ref_padding_end_token<T>(p: *T; x: *T, frac: real);
+
+pred ref_initialized<T>(p: *T;);
+pred ref_padding_initialized<T>(p: *T;);
+
+pred_ctor ref_initialized_<T>(p: *T)(;) = ref_initialized(p);
+pred_ctor ref_padding_initialized_<T>(p: *T)(;) = ref_padding_initialized(p);
+
+@*/
+
+fn create_ref_mut<T>(x: *T) -> *T;
+//@ req *x |-> ?v;
+//@ ens *result |-> v &*& ref_mut_end_token(result, x);
+
+fn reborrow_ref_mut_implicit<T>(x: *T) -> *T;
+//@ req true;
+//@ ens result == x;
+
+/*@
+
+lem end_ref_mut<T>(p: *T);
+    req ref_mut_end_token(p, ?x) &*& *p |-> ?v;
+    ens *x |-> v;
+
+lem end_ref_mut_<t>();
+    req ref_mut_end_token::<t>(?p, ?x) &*& *p |-> ?v;
+    ens *x |-> v;
+
+pred ref_precreated_token<T>(x: *T, p: *T);
+
+lem precreate_ref<T>(x: *T) -> *T;
+   req true;
+   ens ref_precreated_token(x, result) &*& ref_init_perm(result, x);
+
+@*/
+
+fn create_ref<T>(x: *T) -> *T;
+//@ req ref_precreated_token(x, ?p) &*& [?f]ref_initialized(p);
+//@ ens [f]ref_initialized(p) &*& result == p;
+
+fn reborrow_ref<T>(x: *T) -> *T;
+//@ req [?f]ref_initialized(x);
+//@ ens [f]ref_initialized(x) &*& result == x;
+
+fn reborrow_ref_UnsafeCell(x: *_) -> *_;
+//@ req true;
+//@ ens result == x;
+
+fn create_slice_ref<T>(x: slice_ref<'static, T>) -> slice_ref<'static, T>;
+//@ req true; // TODO
+//@ ens result == x;
+
+fn reborrow_slice_ref<T>(x: slice_ref<'static, T>) -> slice_ref<'static, T>;
+//@ req true; // TODO
+//@ ens result == x;
+
+fn create_str_ref(x: str_ref<'static>) -> str_ref<'static>;
+//@ req true; // TODO
+//@ ens result == x;

--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -1,8 +1,9 @@
-include!{"rust_belt/general.rsspec"}
 include!{"prelude_core.rsspec"}
+include!{"aliasing.rsspec"}
 include!{"ghost_cells.rsspec"}
 include!{"counting.rsspec"}
 include!{"mask.rsspec"}
+include!{"rust_belt/general.rsspec"}
 include!{"rust_belt/lifetime_logic.rsspec"}
 include!{"rust_belt/lem_aux.rsspec"}
 

--- a/bin/rust/prelude_core.rsspec
+++ b/bin/rust/prelude_core.rsspec
@@ -8,6 +8,10 @@ lem assume(b: bool);
     req true;
     ens b;
 
+lem note(b: bool);
+    req b;
+    ens b;
+
 pred exists<t>(x: t;) = true;
 pred exists_np<t>(x: t) = true;
 

--- a/bin/rust/rust_belt/general.rsspec
+++ b/bin/rust/rust_belt/general.rsspec
@@ -194,6 +194,15 @@ lem share_full_borrow_m<T>(k: lifetime_t, t: thread_id_t, l: *_);
     req type_interp::<T>() &*& atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& full_borrow(k, (<T>.full_borrow_content)(t, l)) &*& [?q]lifetime_token(k);
     ens type_interp::<T>() &*& atomic_mask(mask) &*& [_](<T>.share)(k, t, l) &*& [q]lifetime_token(k);
 
+lem init_ref_share<T>(k: lifetime_t, t: thread_id_t, p: *T);
+    nonghost_callers_only
+    req type_interp::<T>() &*& ref_init_perm(p, ?x) &*& [_](<T>.share)(k, t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& [q]lifetime_token(k) &*& [_](<T>.share)(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+
+lem init_ref_share_m<T>(k: lifetime_t, t: thread_id_t, p: *T);
+    req type_interp::<T>() &*& atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& ref_init_perm(p, ?x) &*& [_](<T>.share)(k, t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& atomic_mask(mask) &*& [q]lifetime_token(k) &*& [_](<T>.share)(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+
 fix is_Send(type_id: *_) -> bool;
 
 lem Send::send<T>(t0: thread_id_t, t1: thread_id_t, v: T);

--- a/bin/rust/rust_belt/lifetime_logic.rsspec
+++ b/bin/rust/rust_belt/lifetime_logic.rsspec
@@ -287,13 +287,6 @@ lem frac_borrow_implies(k: lifetime_t, P: pred(;), Q: pred(;));
     req [_]frac_borrow(k, P) &*& is_implies_frac(?f, P, Q) &*& is_implies_frac(?f1, Q, P);
     ens [_]frac_borrow(k, Q) &*& is_implies_frac(f, P, Q) &*& is_implies_frac(f1, Q, P);
 
-pred_ctor sep_(P: pred(;), Q: pred(;))(;) = P() &*& Q();
-
-// Not in Rustbelt!
-lem frac_borrow_split(k: lifetime_t, P: pred(;), Q: pred(;));
-    req [_]frac_borrow(k, sep_(P, Q));
-    ens [_]frac_borrow(k, P) &*& [_]frac_borrow(k, Q);
-
 // LftL-fract-acc-atomic
 pred close_frac_borrow_token_atomic(b: bool, q: real, P: pred(;), k: lifetime_t);
 
@@ -309,6 +302,40 @@ lem close_frac_borrow_atomic(P: pred(;), k: lifetime_t);
 lem frac_borrow_lft_incl(k: lifetime_t, q: real, k1: lifetime_t);
     req [_]frac_borrow(k, lifetime_token_(q, k1));
     ens lifetime_inclusion(k, k1) == true;
+
+// Not in RustBelt; TODO: check soundness!
+
+pred_ctor sep_(P: pred(;), Q: pred(;))(;) = P() &*& Q();
+
+lem frac_borrow_split(k: lifetime_t, P: pred(;), Q: pred(;));
+    req [_]frac_borrow(k, sep_(P, Q));
+    ens [_]frac_borrow(k, P) &*& [_]frac_borrow(k, Q);
+
+lem frac_borrow_sep(k: lifetime_t, P: pred(;), Q: pred(;));
+    req [_]frac_borrow(k, P) &*& [_]frac_borrow(k, Q);
+    ens [_]frac_borrow(k, sep_(P, Q));
+
+pred_ctor scaledp(coef: real, P: pred(;))(;) = [coef]P();
+
+lem frac_borrow_implies_scaled(k: lifetime_t, coef: real, P: pred(;));
+    req [_]frac_borrow(k, scaledp(coef, P));
+    ens [_]frac_borrow(k, P);
+
+pred close_frac_borrow_token_strong(k1: lifetime_t, P: pred(;), q: real, k: lifetime_t, f: real);
+
+lem open_frac_borrow_strong(k: lifetime_t, P: pred(;), q: real) -> lifetime_t;
+    nonghost_callers_only
+    req [_]frac_borrow(k, P) &*& [q]lifetime_token(k);
+    ens lifetime_inclusion(k, result) == true &*& [?f]P() &*& close_frac_borrow_token_strong(result, P, q, k, f);
+
+lem_type frac_borrow_convert_strong(Ctx: pred(), Q: pred(), k1: lifetime_t, f: real, P: pred()) = lem();
+    req Ctx() &*& Q() &*& [_]lifetime_dead_token(k1); // Empty mask
+    ens [f]P();
+
+lem close_frac_borrow_strong(k1: lifetime_t, P: pred(;), Q: pred());
+    nonghost_callers_only
+    req close_frac_borrow_token_strong(k1, P, ?q, ?k, ?f) &*& is_frac_borrow_convert_strong(?c, ?Ctx, Q, k1, f, P) &*& Ctx() &*& Q();
+    ens full_borrow(k1, Q) &*& [q]lifetime_token(k) &*& is_frac_borrow_convert_strong(c, Ctx, Q, k1, f, P);
 
 // Mask preserving view shifts - mask aware versions. See the documentation about Iris view shifts in general.h
 // LftL-incl
@@ -406,5 +433,30 @@ lem open_frac_borrow_m(k: lifetime_t, P: pred(;), q_lft: real);
 lem close_frac_borrow_m(q_p: real, P: pred(;));
     req atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& [q_p]P() &*& close_frac_borrow_token(q_p, P, ?q_lft, ?k);
     ens atomic_mask(mask) &*& [q_lft]lifetime_token(k);
+
+// The following do not exist in RustBelt; TODO: check soundness!
+
+lem open_frac_borrow_strong_m(k: lifetime_t, P: pred(;), q: real) -> lifetime_t;
+    req atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& [_]frac_borrow(k, P) &*& [q]lifetime_token(k);
+    ens atomic_mask(mask) &*& lifetime_inclusion(k, result) == true &*& [?f]P() &*& close_frac_borrow_token_strong(result, P, q, k, f);
+
+lem close_frac_borrow_strong_m();
+    req atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& close_frac_borrow_token_strong(?k1, ?P, ?q, ?k, ?f) &*& is_frac_borrow_convert_strong(?c, ?Ctx, ?Q, k1, f, P) &*& Ctx() &*& Q();
+    ens atomic_mask(mask) &*& full_borrow(k1, Q) &*& [q]lifetime_token(k) &*& is_frac_borrow_convert_strong(c, Ctx, Q, k1, f, P);
+
+// Lemmas for proving init_ref_S proof obligations. Not in RustBelt; TODO: check soundness!
+pred close_frac_borrow_for_init_ref_lemma_token(fr: real, q: real, k: lifetime_t, P: pred(;));
+
+lem open_frac_borrow_for_init_ref_lemma(P: pred(;), q: real);
+    req atomic_mask(Nlft) &*& [_]frac_borrow(?k, P) &*& [q]lifetime_token(k);
+    ens atomic_mask(Nlft) &*& [?fr]P() &*& close_frac_borrow_for_init_ref_lemma_token(fr, q, k, P);
+
+lem_type close_frac_borrow_for_init_ref_lemma_premise<T>(Ctx: pred(), fr: real, Q: pred(;), p: *T, P: pred(;)) = lem();
+    req Ctx() &*& [fr/2]Q() &*& ref_initialized::<T>(p);
+    ens [fr]P();
+
+lem close_frac_borrow_for_init_ref_lemma<T>();
+    req atomic_mask(Nlft) &*& close_frac_borrow_for_init_ref_lemma_token(?fr, ?q, ?k, ?P) &*& is_close_frac_borrow_for_init_ref_lemma_premise::<T>(?prem, ?Ctx, fr, ?Q, ?p, P) &*& Ctx() &*& [fr/2]Q() &*& ref_initialized::<T>(p);
+    ens atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]frac_borrow(k, Q) &*& [_]frac_borrow(k, ref_initialized_::<T>(p)) &*& is_close_frac_borrow_for_init_ref_lemma_premise::<T>(prem, Ctx, fr, Q, p, P);
 
 @*/

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -26,6 +26,18 @@ mod rt {
 
 mod num {
 
+    /*@
+    
+    lem init_ref_usize(p: *usize, coef: real);
+        req ref_init_perm::<usize>(p, ?x) &*& [?f](*x |-> ?v) &*& 0 < coef &*& coef < 1;
+        ens ref_initialized(p) &*& [coef*f](*p |-> v) &*& [(1 - coef)*f](*x |-> v) &*& ref_end_token(p, x, coef*f);
+    
+    lem end_ref_usize(p: *usize);
+        req ref_initialized(p) &*& ref_end_token(p, ?x, ?f) &*& [f](*p |-> ?v);
+        ens [f](*x |-> v);
+    
+    @*/
+
     impl usize {
     
         fn checked_sub(self: usize, other: usize) -> std::option::Option<usize>;
@@ -45,6 +57,10 @@ mod marker {
     lem close_PhantomData_own<T>(t: thread_id_t, marker: PhantomData<T>);
         req true;
         ens <PhantomData<T>>.own(t, marker);
+    
+    lem close_ref_initialized_PhantomData<T>(marker: *PhantomData<T>, f: real);
+        req true;
+        ens [f]ref_initialized::<PhantomData<T>>(marker);
     
     @*/
     
@@ -128,6 +144,14 @@ mod ptr {
     lem NonNull_upcast<T0, T1>(v: NonNull<T0>);
         req true;
         ens NonNull_ptr::<T1>(upcast(v)) == NonNull_ptr::<T0>(v) as *_;
+    
+    lem init_ref_NonNull<T>(p: *NonNull<T>, coef: real);
+        req ref_init_perm(p, ?x) &*& [?f](*x |-> ?v) &*& 0 < coef &*& coef < 1;
+        ens ref_initialized(p) &*& [(1 - coef)*f](*x |-> v) &*& [coef*f](*p |-> v) &*& ref_end_token(p, x, coef*f);
+    
+    lem end_ref_NonNull<T>(p: *NonNull<T>);
+        req ref_initialized(p) &*& ref_end_token(p, ?x, ?f) &*& [f](*p |-> ?v);
+        ens [f](*x |-> v);
     
     @*/
 
@@ -217,6 +241,20 @@ mod alloc {
     lem open_Allocator_own<A>(alloc: A);
         req <A>.own(?t, alloc);
         ens Allocator::<A>(t, alloc, _);
+    
+    fix Allocator_full_borrow_content_<A>(t: thread_id_t, l: *A, alloc_id: any) -> pred();
+    
+    lem close_Allocator_full_borrow_content_<A>(t: thread_id_t, l: *A);
+        req *l |-> ?alloc &*& Allocator::<A>(t, alloc, ?alloc_id);
+        ens (Allocator_full_borrow_content_::<A>(t, l, alloc_id))();
+    
+    lem open_Allocator_full_borrow_content_<A>(t: thread_id_t, l: *A, alloc_id: any);
+        req (Allocator_full_borrow_content_::<A>(t, l, alloc_id))();
+        ens *l |-> ?alloc &*& Allocator::<A>(t, alloc, alloc_id);
+    
+    lem share_Allocator_full_borrow_content_<A>(k: lifetime_t, t: thread_id_t, l: *A, alloc_id: any);
+        req type_interp::<A>() &*& atomic_mask(Nlft) &*& full_borrow(k, Allocator_full_borrow_content_::<A>(t, l, alloc_id)) &*& [?q]lifetime_token(k);
+        ens type_interp::<A>() &*& atomic_mask(Nlft) &*& [_](<A>.share(k, t, l)) &*& [q]lifetime_token(k);
     
     pred share_allocator_end_token<A>(l: *A, alloc_id: any);
     
@@ -369,6 +407,45 @@ mod option {
         None,
         Some(T),
     }
+    
+    /*@
+    
+    fix Option_Some_0_offset<T>() -> usize;
+    fix Option_Some_0_ptr<T>(ptr: *Option<T>) -> *T { field_ptr(ptr as pointer, typeid(T), Option_Some_0_offset::<T>()) as *T }
+    
+    pred Option_Some<T>(l: *Option<T>;); // Represents ownership of the discriminant
+    
+    lem open_points_to_Option_Some<T>(l: *Option<T>);
+        req [?f](*l |-> Option::Some(?v0));
+        ens [f]Option_Some(l) &*& [f](*Option_Some_0_ptr(l) |-> v0);
+    
+    lem close_points_to_Option_Some<T>(l: *Option<T>);
+        req [?f]Option_Some(l) &*& [f](*Option_Some_0_ptr(l) |-> ?v0);
+        ens [f](*l |-> Option::Some(v0));
+    
+    lem init_ref_Option_None<T>(p: *Option<T>, coef: real);
+        req ref_init_perm::<Option<T>>(p, ?x) &*& [?f](*x |-> Option::None) &*& 0 < coef &*& coef < 1;
+        ens ref_initialized::<Option<T>>(p) &*& ref_end_token(p, x, coef*f) &*& [(1-coef)*f](*x |-> Option::None) &*& [coef*f](*p |-> Option::None);
+    
+    pred init_ref_Option_Some_token<T>(p: *Option<T>, x: *Option<T>, frac: real);
+    
+    lem open_ref_init_perm_Option_Some<T>(p: *Option<T>);
+        req ref_init_perm::<Option<T>>(p, ?x) &*& [?f]Option_Some::<T>(x);
+        ens init_ref_Option_Some_token::<T>(p, x, f) &*& ref_init_perm::<T>(Option_Some_0_ptr(p), Option_Some_0_ptr(x));
+    
+    lem init_ref_Option_Some<T>(p: *Option<T>, coef: real);
+        req init_ref_Option_Some_token::<T>(p, ?x, ?f) &*& ref_initialized::<T>(Option_Some_0_ptr(p)) &*& 0 < coef &*& coef < 1;
+        ens ref_initialized::<Option<T>>(p) &*& [(1-coef)*f]Option_Some::<T>(x) &*& [coef*f]Option_Some::<T>(p) &*& ref_end_token(p, x, coef*f);
+    
+    lem end_ref_Option_None<T>(p: *Option<T>);
+        req ref_initialized::<Option<T>>(p) &*& ref_end_token(p, ?x, ?f) &*& [f](*p |-> Option::None);
+        ens [f](*x |-> Option::None);
+    
+    lem end_ref_Option_Some<T>(p: *Option<T>);
+        req ref_initialized::<Option<T>>(p) &*& ref_end_token(p, ?x, ?f) &*& [f]Option_Some::<T>(p);
+        ens [f]Option_Some::<T>(x) &*& ref_initialized::<T>(Option_Some_0_ptr(p));
+    
+    @*/
     
     impl<T> Option<T> {
     

--- a/src/rust_frontend/vf_mir_translator/ast_to_src.ml
+++ b/src/rust_frontend/vf_mir_translator/ast_to_src.ml
@@ -7,6 +7,7 @@ let rec string_of_type_expr = function
 | StructTypeExpr (l, Some sn, None, [], targs) -> Printf.sprintf "%s%s" sn (string_of_type_targs targs)
 | ConstructedTypeExpr (l, tn, targs) -> Printf.sprintf "%s%s" tn (string_of_type_targs targs)
 | RustRefTypeExpr (l, lft, mut, tp) -> Printf.sprintf "&%s%s %s" (string_of_type_expr lft) (match mut with Mutable -> " mut" | Shared -> "") (string_of_type_expr tp)
+| PtrTypeExpr (l, tp) -> Printf.sprintf "*%s" (string_of_type_expr tp)
 | te -> failwith (Printf.sprintf "string_of_type_expr: %s" (Ocaml_expr_formatter.string_of_ocaml_expr true (Ocaml_expr_of_ast.of_type_expr te)))
 and string_of_type_targs = function
   [] -> ""

--- a/src/rust_frontend/vf_mir_translator/rust_parser.ml
+++ b/src/rust_frontend/vf_mir_translator/rust_parser.ml
@@ -496,13 +496,13 @@ let rec parse_stmt = function%parser
 and parse_match_stmt_arm = function%parser
   [ parse_expr as pat; (l, Kwd "=>"); parse_block_stmt as s ] -> SwitchStmtClause (l, pat, [s])
 and parse_produce_lemma_function_pointer_chunk_stmt_function_type_clause = function%parser
-  [ [%let (li, ftn) = parse_simple_path];
+  [ [%let (li, ftn) = parse_simple_path]; [%let targs = function%parser [ parse_type_args as targs ] -> targs | [ ] -> []];
     (_, Kwd "("); [%let args = rep_comma parse_expr]; (_, Kwd ")");
     (_, Kwd "("); [%let params = rep_comma (function%parser [ (l, Ident x) ] -> (l, x))]; (_, Kwd ")");
     (openBraceLoc, Kwd "{");
     parse_stmts as ss;
     (closeBraceLoc, Kwd "}")
-  ] -> (ftn, [], args, params, openBraceLoc, ss, closeBraceLoc)
+  ] -> (ftn, targs, args, params, openBraceLoc, ss, closeBraceLoc)
 and parse_block_stmt = function%parser
   [ (l, Kwd "{");
     parse_ghost_decls as ds;

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -286,6 +286,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           begin match resolve Real (pn,ilist) l ftn functypemap with
             None -> static_error l "No such function type" None
           | Some (ftn, (lft, gh, fttparams, rt, ftxmap, xmap, pre, post, terminates, ft_predfammaps, ft_typeid)) ->
+            reportUseSite DeclKind_FuncType lft l;
             begin match stmt_ghostness with
               Real -> if gh <> Real || (ftxmap = [] && fttparams = []) then static_error l "A produce_function_pointer_chunk statement may be used only for parameterized and type-parameterized function types." None
             | Ghost -> if gh <> Ghost then static_error l "Lemma function pointer type expected." None

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -42,6 +42,14 @@ lem ptr::NonNull_share_full<T>(k: lifetime_t, t: thread_id_t, l: *ptr::NonNull<T
     assert [?qf]frac_borrow(k, ptr::NonNull_frac_bc(t, l));
     close [qf]<ptr::NonNull<T>>.share(k, t, l);
 }
+
+lem init_ref_ptr::NonNull<T>(p: *ptr::NonNull<T>)
+    req type_interp::<T>() &*& atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]ptr::NonNull_share::<T>(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]ptr::NonNull_share::<T>(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 pub mod ptr {

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -109,6 +109,13 @@ lem Arc_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Arc<T>)
     leak Arc_share(k, t, l);
 }
 
+lem init_ref_Arc<T>(p: *Arc<T>)
+    req type_interp::<T>() &*& is_Send(typeid(T)) == true &*& atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]Arc_share::<T>(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]Arc_share::<T>(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 unsafe impl<T: Sync + Send> Send for Arc<T> {}

--- a/tests/rust/safe_abstraction/arc_u32.rs
+++ b/tests/rust/safe_abstraction/arc_u32.rs
@@ -103,6 +103,14 @@ lem ArcU32_share_full(k: lifetime_t, t: thread_id_t, l: *ArcU32)
     close ArcU32_share(k, t, l);
     leak ArcU32_share(k, t, l);
 }
+
+lem init_ref_ArcU32(p: *ArcU32)
+    req atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]ArcU32_share(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]ArcU32_share(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 unsafe impl Send for ArcU32 {}

--- a/tests/rust/safe_abstraction/cell.rs
+++ b/tests/rust/safe_abstraction/cell.rs
@@ -65,6 +65,14 @@ lem Cell_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Cell<T>)
   close Cell_share::<T>()(k, t, l);
   leak Cell_share::<T>()(k, t, l);
 }
+
+lem init_ref_Cell<T>(p: *Cell<T>)
+    req type_interp::<T>() &*& atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]Cell_share::<T>(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]Cell_share::<T>(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false); // TODO
+}
+
 @*/
 
 impl<T> Cell<T> {

--- a/tests/rust/safe_abstraction/cell_u32.rs
+++ b/tests/rust/safe_abstraction/cell_u32.rs
@@ -56,6 +56,14 @@ lem CellU32_share_full(k: lifetime_t, t: thread_id_t, l: *CellU32)
   close <CellU32>.share(k, t, l);
   leak <CellU32>.share(k, t, l);
 }
+
+lem init_ref_CellU32(p: *CellU32)
+    req atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]CellU32_share(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]CellU32_share(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 impl CellU32 {

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -282,6 +282,13 @@ lem Deque_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Deque
     close [q]Deque_share::<T>()(k1, t, l);
 }
 
+lem init_ref_Deque<T>(p: *Deque<T>)
+    req type_interp::<T>() &*& atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]Deque_share::<T>(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]Deque_share::<T>(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 impl<T> Deque<T> {

--- a/tests/rust/safe_abstraction/deque_i32.rs
+++ b/tests/rust/safe_abstraction/deque_i32.rs
@@ -114,6 +114,14 @@ lem Deque_share_full(k: lifetime_t, t: thread_id_t, l: *Deque)
     assert [?q_f]frac_borrow(_, _);
     close [q_f]Deque_share(k, t, l);
 }
+
+lem init_ref_Deque(p: *Deque)
+    req atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]Deque_share(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]Deque_share(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 impl Deque {

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -108,6 +108,13 @@ lem Mutex_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Mutex<T>)
     }
 }
 
+lem init_ref_Mutex<T>(p: *Mutex<T>)
+    req type_interp::<T>() &*& is_Send(typeid(T)) == true &*& atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]Mutex_share::<T>(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]Mutex_share::<T>(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 unsafe impl<T: Send> Send for Mutex<T> {}

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -99,6 +99,13 @@ lem MutexU32_share_full(k: lifetime_t, t: thread_id_t, l: *MutexU32)
     }
 }
 
+lem init_ref_MutexU32(p: *MutexU32)
+    req atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]MutexU32_share(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]MutexU32_share(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 unsafe impl Send for MutexU32 {}

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -129,6 +129,13 @@ lem Rc_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Rc<T>)
     close [df]Rc_share::<T>(k, t, l);
 }
 
+lem init_ref_Rc<T>(p: *Rc<T>)
+    req type_interp::<T>() &*& atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]Rc_share::<T>(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens type_interp::<T>() &*& atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]Rc_share::<T>(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 
 impl<T> Rc<T> {

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -105,6 +105,14 @@ lem RcU32_share_full(k: lifetime_t, t: thread_id_t, l: *RcU32)
     leak exists(nnp);
     close [df]RcU32_share(k, t, l);
 }
+
+lem init_ref_RcU32(p: *RcU32)
+    req atomic_mask(Nlft) &*& ref_init_perm(p, ?x) &*& [_]RcU32_share(?k, ?t, x) &*& [?q]lifetime_token(k);
+    ens atomic_mask(Nlft) &*& [q]lifetime_token(k) &*& [_]RcU32_share(k, t, p) &*& [_]frac_borrow(k, ref_initialized_(p));
+{
+    assume(false);
+}
+
 @*/
 pub struct RcU32 {
     ptr: NonNull<RcBoxU32>,


### PR DESCRIPTION
This proof obligation proves that memory referred to by &S references created by unverified typechecked clients is immutable for the lifetime of the shared reference (except for the parts that are under an UnsafeCell).

Proved it for linked_list.rs and generic_pair.rs.

TODO: Prove this proof obligations for the other examples
