### PR TITLE
[Rust] Freeze pointee memory on shared ref creation

### DIFF
--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -6,6 +6,7 @@ include!{"mask.rsspec"}
 include!{"rust_belt/general.rsspec"}
 include!{"rust_belt/lifetime_logic.rsspec"}
 include!{"rust_belt/lem_aux.rsspec"}
+include!{"rust_belt/aliasing.rsspec"}
 
 union std_empty_ {}
 struct std_tuple_0_ {}

--- a/bin/rust/rust_belt/aliasing.rsspec
+++ b/bin/rust/rust_belt/aliasing.rsspec
@@ -1,0 +1,7 @@
+fn reborrow_ref_mut<T>(x: *T) -> *T;
+//@ req thread_token(?t) &*& full_borrow(?k, <T>.full_borrow_content(t, x)) &*& [?q]lifetime_token(k);
+//@ ens thread_token(t) &*& full_borrow(k, <T>.full_borrow_content(t, result)) &*& [q]lifetime_token(k) &*& ref_origin(result) == result;
+
+fn reborrow_ref_implicit<T>(x: *T) -> *T;
+//@ req [_]frac_borrow(?k, ref_initialized_(x)) &*& [?q]lifetime_token(k);
+//@ ens [q]lifetime_token(k) &*& result == x;

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -266,6 +266,16 @@ mod alloc {
         req share_allocator_end_token::<A>(?l, ?alloc_id) &*& Allocator::<&'a A>(?t, _, alloc_id);
         ens *l |-> ?alloc &*& Allocator::<A>(t, alloc, alloc_id);
     
+    pred ref_Allocator_end_token<A>(p: *A, x: *A, alloc_id: any);
+    
+    lem init_ref_Allocator<'a, A>(p: *A);
+        req ref_init_perm(p, ?x) &*& *x |-> ?alloc &*& Allocator(?t, alloc, ?alloc_id);
+        ens ref_initialized(p) &*& Allocator::<&'a A>(t, p, alloc_id) &*& ref_Allocator_end_token(p, x, alloc_id);
+    
+    lem end_ref_Allocator<'a, A>();
+        req ref_Allocator_end_token::<A>(?p, ?x, ?alloc_id) &*& ref_initialized(p) &*& Allocator::<&'a A>(?t, _, alloc_id);
+        ens *x |-> ?alloc &*& Allocator::<A>(t, alloc, alloc_id);
+    
     pred share_allocator_at_lifetime_end_token<A>(t: thread_id_t, l: *A, alloc_id: any, k: lifetime_t);
     
     lem share_allocator_at_lifetime<'a, A>(l: *A);
@@ -277,6 +287,18 @@ mod alloc {
         nonghost_callers_only
         req share_allocator_at_lifetime_end_token::<A>(?t, ?l, ?alloc_id, ?k) &*& [_]lifetime_dead_token(k);
         ens *l |-> ?alloc &*& Allocator::<A>(t, alloc, alloc_id);
+    
+    pred ref_Allocator_end_token_at_lifetime<A>(t: thread_id_t, p: *A, x: *A, alloc_id: any, k: lifetime_t);
+    
+    lem init_ref_Allocator_at_lifetime<'a, A>(p: *A);
+        nonghost_callers_only
+        req ref_init_perm(p, ?x) &*& *x |-> ?alloc &*& Allocator(?t, alloc, ?alloc_id);
+        ens ref_initialized(p) &*& Allocator::<&'a A>(t, p, alloc_id) &*& ref_Allocator_end_token_at_lifetime(t, p, x, alloc_id, 'a);
+    
+    lem end_ref_Allocator_at_lifetime<A>();
+        nonghost_callers_only
+        req ref_Allocator_end_token_at_lifetime::<A>(?t, ?p, ?x, ?alloc_id, ?k) &*& [_]lifetime_dead_token(k) &*& ref_initialized(p);
+        ens *x |-> ?alloc &*& Allocator::<A>(t, alloc, alloc_id);
     
     @*/
 

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -458,7 +458,7 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let ts = List.map (fun (t, (tp0, tp)) -> prover_convert_term t tp0 tp) (zip2 ts (zip2 domain declared_paramtypes)) in
           let produce_post env' =
             let tpenv = zip2 tparams targs in
-            let env'' = env' @ zip2 (xs1@xs2) ts @ typeid_env_of_tpenv l env tpenv in
+            let env'' = env' @ zip2 (xs1@xs2) ts @ typeid_env_of_tpenv l typeid_env tpenv in
             with_context PushSubcontext $. fun () ->
             with_context (Executing (h, env'', l, "Applying autolemma")) $. fun () ->
             produce_asn_core_with_post typeid_env tpenv h [] env'' post real_unit size_first size_all true $. fun h_ _ _ _ ->

--- a/src/frontend/verifast0.ml
+++ b/src/frontend/verifast0.ml
@@ -320,6 +320,7 @@ type _ vfparam =
 | Vfparam_extern_specs: string list vfparam
 | Vfparam_externs: string list vfparam
 | Vfparam_skip_specless_fns: bool vfparam (* Skip verification of functions for which the user did not provide a precondition and postcondition. This is the default behavior for C, C++ and Java but not for Rust. *)
+| Vfparam_ignore_ref_creation: bool vfparam
 
 let cast_vfarg: type t1 t2. t1 vfparam -> t1 -> t2 vfparam -> t2 option = fun p0 a0 p ->
   (* if Obj.magic p0 = Obj.magic p then Some (Obj.magic a0) else None *)
@@ -341,6 +342,7 @@ let cast_vfarg: type t1 t2. t1 vfparam -> t1 -> t2 vfparam -> t2 option = fun p0
   | Vfparam_extern_specs, Vfparam_extern_specs -> Some a0
   | Vfparam_externs, Vfparam_externs -> Some a0
   | Vfparam_skip_specless_fns, Vfparam_skip_specless_fns -> Some a0
+  | Vfparam_ignore_ref_creation, Vfparam_ignore_ref_creation -> Some a0
   | _ -> None
 
 type _ vfparam_info =
@@ -371,6 +373,7 @@ let vfparam_info_of: type a. a vfparam -> a vfparam_info = function
 | Vfparam_extern_specs -> string_list_param
 | Vfparam_externs -> string_list_param
 | Vfparam_skip_specless_fns -> BoolParam
+| Vfparam_ignore_ref_creation -> BoolParam
 
 let default_vfarg: type ta. ta vfparam -> ta = fun p ->
   match vfparam_info_of p with
@@ -402,6 +405,7 @@ let vfparams = [
   "extern", (Vfparam Vfparam_externs, "`-extern path/to/externCrate` is equivalent to `-rustc_arg --extern -rustc_arg externCrate=path/to/externCrate/target/debug/libexternCrate.rlib -rustc_arg -L -rustc_arg dependency=path/to/externCrate/target/debug/deps -extern_spec externCrate=path/to/externCrate/spec/lib.rsspec`");
   "target", (Vfparam Vfparam_data_model, "Target platform of the program being verified. Determines the size of pointer and integer types. Supported targets: " ^ String.concat ", " (List.map fst data_models));
   "skip_specless_fns", (Vfparam Vfparam_skip_specless_fns, "Skip verification of functions for which the user did not provide a precondition and postcondition. This is the default behavior for C, C++ and Java but not for Rust.");
+  "ignore_ref_creation", (Vfparam Vfparam_ignore_ref_creation, "In Rust, treat &E or &mut E like &raw E. This is unsound!");
 ]
 
 type vfbinding = Vfbinding: 'a vfparam * 'a -> vfbinding
@@ -466,6 +470,7 @@ type options = {
   option_use_java_frontend : bool;
   option_enforce_annotations : bool;
   option_report_skipped_stmts: bool; (* Report statements in functions or methods that have no contract. *)
+  option_allow_ignore_ref_creation: bool;
 } (* ?options *)
 
 (* Region: verify_program_core: the toplevel function *)

--- a/src/rust_frontend/rust_fe.ml
+++ b/src/rust_frontend/rust_fe.ml
@@ -5,6 +5,8 @@ module type RUST_FE_ARGS = sig
   val report_macro_call : Ast.loc0 -> Ast.loc0 -> unit
   val verbose_flags : string list
   val skip_specless_fns : bool
+  val allow_ignore_ref_creation : bool
+  val ignore_ref_creation : bool
 end
 
 module Make (Args : RUST_FE_ARGS) = struct
@@ -228,7 +230,7 @@ module Make (Args : RUST_FE_ARGS) = struct
       if pointerWidth <> 8 * (1 lsl data_model.ptr_width) then
         raise (Parser.CompilationError (Printf.sprintf "C target %s does not match rustc target %s; specify a matching C target using the -target command-line option" data_model_name targetTriple));
       (!Stats.stats)#set_success_qualifier (Printf.sprintf "target: %s (%s)" targetTriple data_model_name);
-      VfMirTr.translate_vf_mir extern_specs vf_mir_rd Args.report_should_fail Args.skip_specless_fns
+      VfMirTr.translate_vf_mir extern_specs vf_mir_rd Args.report_should_fail Args.skip_specless_fns Args.allow_ignore_ref_creation Args.ignore_ref_creation
     | Error einfo ->
         let gen_emsg = "Rust frontend failed to generate VF MIR: " in
         let desc =

--- a/src/rust_frontend/rust_fe.mli
+++ b/src/rust_frontend/rust_fe.mli
@@ -6,6 +6,8 @@ module type RUST_FE_ARGS =
     val report_macro_call : Ast.loc0 -> Ast.loc0 -> unit
     val verbose_flags : string list
     val skip_specless_fns : bool
+    val allow_ignore_ref_creation : bool
+    val ignore_ref_creation : bool
   end
 module Make :
   functor (_ : RUST_FE_ARGS) ->

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -413,6 +413,14 @@ struct Body {
         sourceInfo @3: SourceInfo;
     }
 
+    struct PlaceKind {
+        union {
+            mutableRef @0: Void;
+            sharedRef @1: Void;
+            other @2: Void;
+        }
+    }
+
     struct Place {
         struct PlaceElement {
             struct FieldData {
@@ -430,6 +438,7 @@ struct Body {
         local @0: LocalDeclId;
         localIsMutable @2: Bool;
         projection @1: List(PlaceElement);
+        kind @3: PlaceKind;
     }
 
     struct Scalar {
@@ -555,7 +564,9 @@ struct Body {
                 }
                 region @0: Ty.Region;
                 borKind @1: BorrowKind;
+                placeTy @3: Ty;
                 place @2: Place;
+                isImplicit @4: Bool;
             }
 
             struct CastData {

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -527,6 +527,9 @@ mod vf_mir_builder {
         visitor.submodules
     }
 
+    #[derive(Clone, Copy)]
+    enum PlaceKind { MutableRef, SharedRef, Other }
+
     enum EncKind<'tcx, 'a> {
         Body(&'a mir::Body<'tcx>),
         Adt,
@@ -1832,7 +1835,7 @@ mod vf_mir_builder {
             let src_info_cpn = statement_cpn.reborrow().init_source_info();
             Self::encode_source_info(tcx, &statement.source_info, src_info_cpn);
             let kind_cpn = statement_cpn.init_kind();
-            Self::encode_statement_kind(tcx, enc_ctx, &statement.kind, kind_cpn);
+            Self::encode_statement_kind(tcx, enc_ctx, statement.source_info.span, &statement.kind, kind_cpn);
         }
 
         fn encode_source_info(
@@ -1849,6 +1852,7 @@ mod vf_mir_builder {
         fn encode_statement_kind(
             tcx: TyCtxt<'tcx>,
             enc_ctx: &mut EncCtx<'tcx, 'a>,
+            span: rustc_span::Span,
             statement_kind: &mir::StatementKind<'tcx>,
             mut statement_kind_cpn: statement_kind_cpn::Builder<'_>,
         ) {
@@ -1858,7 +1862,7 @@ mod vf_mir_builder {
                     let lhs_place_cpn = assign_data_cpn.reborrow().init_lhs_place();
                     Self::encode_place(enc_ctx, lhs_place, lhs_place_cpn);
                     let rhs_rvalue_cpn = assign_data_cpn.init_rhs_rvalue();
-                    Self::encode_rvalue(tcx, enc_ctx, rhs_rval, rhs_rvalue_cpn);
+                    Self::encode_rvalue(tcx, enc_ctx, span, rhs_rval, rhs_rvalue_cpn);
                 }
                 mir::StatementKind::Nop => statement_kind_cpn.set_nop(()),
                 // Todo @Nima: For now we do not support many statements and treat them as Nop
@@ -1869,6 +1873,7 @@ mod vf_mir_builder {
         fn encode_rvalue(
             tcx: TyCtxt<'tcx>,
             enc_ctx: &mut EncCtx<'tcx, 'a>,
+            span: rustc_span::Span,
             rvalue: &mir::Rvalue<'tcx>,
             rvalue_cpn: rvalue_cpn::Builder<'_>,
         ) {
@@ -1883,12 +1888,18 @@ mod vf_mir_builder {
                 // &x or &mut x
                 mir::Rvalue::Ref(region, bor_kind, place) => {
                     let mut ref_data_cpn = rvalue_cpn.init_ref();
+                    let place_ty = place.ty(&enc_ctx.body().local_decls, tcx);
+                    let place_ty_cpn = ref_data_cpn.reborrow().init_place_ty();
+                    Self::encode_ty(tcx, enc_ctx, place_ty.ty, place_ty_cpn);
                     let region_cpn = ref_data_cpn.reborrow().init_region();
                     Self::encode_region(*region, region_cpn);
                     let bor_kind_cpn = ref_data_cpn.reborrow().init_bor_kind();
                     Self::encode_borrow_kind(bor_kind, bor_kind_cpn);
-                    let place_cpn = ref_data_cpn.init_place();
+                    let place_cpn = ref_data_cpn.reborrow().init_place();
                     Self::encode_place(enc_ctx, place, place_cpn);
+                    let source_text = enc_ctx.tcx.sess.source_map().span_to_snippet(span).unwrap();
+                    let is_identifier = source_text.chars().all(|c| c.is_alphanumeric() || c == '_');
+                    ref_data_cpn.set_is_implicit(is_identifier);
                 }
                 mir::Rvalue::ThreadLocalRef(def_id) => todo!(),
                 mir::Rvalue::RawPtr(mutability, place) => {
@@ -2512,11 +2523,19 @@ mod vf_mir_builder {
             let decl = &enc_ctx.body().local_decls()[place.local];
             place_cpn.set_local_is_mutable(decl.mutability == mir::Mutability::Mut);
 
-            let mut pty = PlaceTy::from_ty(decl.ty);
-            place_cpn.fill_projection(place.projection, |place_elm_cpn, place_elm| {
-                Self::encode_place_element(enc_ctx, pty.ty, &place_elm, place_elm_cpn);
+            let local = &enc_ctx.body().local_decls()[place.local];
+            let mut pty = PlaceTy::from_ty(local.ty);
+            let mut kind = PlaceKind::Other;
+            place_cpn.reborrow().fill_projection(place.projection, |place_elm_cpn, place_elm| {
+                kind = Self::encode_place_element(enc_ctx, pty.ty, &place_elm, place_elm_cpn, kind);
                 pty = pty.projection_ty(enc_ctx.tcx, place_elm);
             });
+            let mut kind_cpn = place_cpn.init_kind();
+            match kind {
+                PlaceKind::MutableRef => kind_cpn.set_mutable_ref(()),
+                PlaceKind::SharedRef => kind_cpn.set_shared_ref(()),
+                PlaceKind::Other => kind_cpn.set_other(()),
+            }
         }
 
         fn encode_place_element(
@@ -2524,13 +2543,24 @@ mod vf_mir_builder {
             ty: ty::Ty<'tcx>,
             place_elm: &mir::PlaceElem<'tcx>,
             mut place_elm_cpn: place_element_cpn::Builder<'_>,
-        ) {
+            place_kind: PlaceKind
+        ) -> PlaceKind {
             debug!(
                 "Encoding place element {:?} Projecting from {:?}",
                 place_elm, ty
             );
             match place_elm {
-                mir::ProjectionElem::Deref => place_elm_cpn.set_deref(()),
+                mir::ProjectionElem::Deref => {
+                    place_elm_cpn.set_deref(());
+                    match ty.kind() {
+                        ty::TyKind::Ref(_, _, mutability) =>
+                            match mutability {
+                                ty::Mutability::Not => PlaceKind::SharedRef,
+                                ty::Mutability::Mut => PlaceKind::MutableRef,
+                            },
+                        _ => PlaceKind::Other,
+                    }
+                }
                 mir::ProjectionElem::Field(field, fty) => {
                     let mut field_data_cpn = place_elm_cpn.init_field();
                     field_data_cpn.set_index(field.as_u32());
@@ -2549,9 +2579,11 @@ mod vf_mir_builder {
                     /* Todo @Nima: When `encode_ty` becomes a method of `EncCtx` there would not be
                      * such strange arguments `enc_ctx.tcx` and `enc_tcx`
                      */
+                    PlaceKind::Other
                 }
                 mir::ProjectionElem::Downcast(symbol, variant_idx) => {
                     place_elm_cpn.set_downcast(variant_idx.as_u32());
+                    PlaceKind::Other
                 }
                 _ => todo!(),
             }

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -3921,6 +3921,8 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             let report_macro_call = reportMacroCall
             let verbose_flags = verbose_flags
             let skip_specless_fns = Vfbindings.get Vfparam_skip_specless_fns vfbindings
+            let allow_ignore_ref_creation = allow_ignore_ref_creation
+            let ignore_ref_creation = Vfbindings.get Vfparam_ignore_ref_creation vfbindings
           end
         )
         in

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -74,6 +74,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     option_use_java_frontend=use_java_frontend;
     option_enforce_annotations=enforce_annotations;
     option_report_skipped_stmts=report_skipped_stmts;
+    option_allow_ignore_ref_creation=allow_ignore_ref_creation;
   } = options
 
   let disable_overflow_check = Vfbindings.get Vfparam_disable_overflow_check vfbindings

--- a/src/vfconsole/vfconsole.ml
+++ b/src/vfconsole/vfconsole.ml
@@ -465,6 +465,7 @@ let _ =
   let emitHighlightedSourceFiles = ref false in
   let dumpPerLineStmtExecCounts = ref false in
   let allowDeadCode = ref false in
+  let allowIgnoreRefCreation = ref false in
   let readOptionsFromSourceFile = ref false in
   let exports: string list ref = ref [] in
   let outputSExpressions : string option ref = ref None in
@@ -524,6 +525,7 @@ let _ =
             ; "-focus", String (fun path_loc -> let [path; loc_string] = String.split_on_char ':' path_loc in focus := Some (path, int_of_string loc_string)), "-focus myfile.c:123 causes VeriFast to verify only the function/method/constructor/destructor at the specified source line"
             ; "-break_at_node", String (fun path -> targetPath := Some (path |> String.split_on_char ',' |> List.map int_of_string)), "Break when symbolic execution reaches the specified node in the execution tree."
             ; "-allow_should_fail", Set allowShouldFail, "Allow '//~' annotations that specify the line should fail."
+            ; "-allow_ignore_ref_creation", Set allowIgnoreRefCreation, "Allow //~ignore_ref_creation directives."
             ; "-emit_vfmanifest", Set emitManifest, " "
             ; "-check_vfmanifest", Set checkManifest, " "
             ; "-emit_dll_vfmanifest", Set emitDllManifest, " "
@@ -573,6 +575,7 @@ let _ =
           option_verbose_flags = !verbose_flags;
           option_vfbindings = vfbindings;
           option_allow_should_fail = !allowShouldFail;
+          option_allow_ignore_ref_creation = !allowIgnoreRefCreation;
           option_emit_manifest = !emitManifest;
           option_check_manifest = !checkManifest;
           option_vroots = !vroots;

--- a/src/vfide/vfide.ml
+++ b/src/vfide/vfide.ml
@@ -1684,6 +1684,7 @@ let show_ide initialPath prover codeFont traceFont vfbindings layout javaFronten
                 option_use_java_frontend = !useJavaFrontend;
                 option_enforce_annotations = enforceAnnotations;
                 option_allow_should_fail = true;
+                option_allow_ignore_ref_creation = true;
                 option_emit_manifest = false;
                 option_check_manifest = false;
                 option_vroots = [crt_vroot default_bindir];

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 /*@
 pred<T> <ptr::NonNull<T>>.own(t, nonNull;) = nonNull.pointer as usize != 0;
 

--- a/tests/rust/purely_unsafe/atomics_example.rs
+++ b/tests/rust/purely_unsafe/atomics_example.rs
@@ -1,4 +1,4 @@
-// verifast_options{extern:../unverified/platform}
+// verifast_options{ignore_ref_creation extern:../unverified/platform}
 
 use std::{ptr::null_mut, sync::atomic::{AtomicUsize, Ordering::SeqCst}};
 

--- a/tests/rust/purely_unsafe/httpd.rs
+++ b/tests/rust/purely_unsafe/httpd.rs
@@ -1,4 +1,4 @@
-// verifast_options{extern:../unverified/platform}
+// verifast_options{ignore_ref_creation extern:../unverified/platform}
 
 use std::io::Write;
 //@ use std::alloc::{alloc_block, Layout};

--- a/tests/rust/purely_unsafe/httpd_mt.rs
+++ b/tests/rust/purely_unsafe/httpd_mt.rs
@@ -1,4 +1,4 @@
-// verifast_options{extern:../unverified/platform}
+// verifast_options{ignore_ref_creation extern:../unverified/platform}
 
 use std::io::Write;
 

--- a/tests/rust/purely_unsafe/httpd_vec.rs
+++ b/tests/rust/purely_unsafe/httpd_vec.rs
@@ -1,4 +1,4 @@
-// verifast_options{extern:../unverified/platform}
+// verifast_options{ignore_ref_creation extern:../unverified/platform}
 
 use std::io::Write;
 

--- a/tests/rust/purely_unsafe/str.rs
+++ b/tests/rust/purely_unsafe/str.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 unsafe fn is_hi<'a>(text: &'a str) -> bool
 //@ req [?f]text.ptr[..text.len] |-> ?cs;
 //@ ens [f]text.ptr[..text.len] |-> cs &*& result == (cs == ['H', 'i']);

--- a/tests/rust/purely_unsafe/vec_test.rs
+++ b/tests/rust/purely_unsafe/vec_test.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 unsafe fn assert(b: bool)
 //@ req b;
 //@ ens true;

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 use std::process::abort;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/rust/safe_abstraction/arc_u32.rs
+++ b/tests/rust/safe_abstraction/arc_u32.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 use std::process::abort;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/rust/safe_abstraction/cell.rs
+++ b/tests/rust/safe_abstraction/cell.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 #![allow(dead_code)]
 
 pub struct Cell<T> {

--- a/tests/rust/safe_abstraction/cell_u32.rs
+++ b/tests/rust/safe_abstraction/cell_u32.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 #![allow(dead_code)]
 
 pub struct CellU32 {

--- a/tests/rust/safe_abstraction/deque.rs
+++ b/tests/rust/safe_abstraction/deque.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 /*@
 
 lem foreach_unappend<a>(xs1: list<a>, xs2: list<a>, p: pred(a))

--- a/tests/rust/safe_abstraction/generic_pair.rs
+++ b/tests/rust/safe_abstraction/generic_pair.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 pub struct Pair<A, B> {
     fst: A,
     snd: B

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -1,4 +1,4 @@
-// verifast_options{extern:../unverified/sys}
+// verifast_options{ignore_ref_creation extern:../unverified/sys}
 
 #![feature(negative_impls)]
 #![allow(dead_code)]

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -1,4 +1,4 @@
-// verifast_options{extern:../unverified/sys}
+// verifast_options{ignore_ref_creation extern:../unverified/sys}
 
 #![feature(negative_impls)]
 #![allow(dead_code)]

--- a/tests/rust/safe_abstraction/rc.rs
+++ b/tests/rust/safe_abstraction/rc.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 #![feature(negative_impls)]
 
 use std::{cell::UnsafeCell, process::abort, ptr::NonNull};

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 #![feature(negative_impls)]
 use std::{cell::UnsafeCell, process::abort, ptr::NonNull};
 /*@

--- a/tests/rust/safe_abstraction/tparam_own.rs
+++ b/tests/rust/safe_abstraction/tparam_own.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 fn replace<'a, T>(r: &'a mut T, v: T) -> T {
     unsafe {
         //@ open_full_borrow(_q_a, 'a, (<T>.full_borrow_content)(_t, r));

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -1,3 +1,5 @@
+// verifast_options{ignore_ref_creation}
+
 /*@
 
 lem_auto bitand_zero(y: usize)

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -17,7 +17,7 @@ cd unverified
   cd ..
 cd ..
 begin_parallel
-verifast -c nonnull.rs
+verifast -c -ignore_ref_creation nonnull.rs
 cd purely_unsafe
   verifast -c -allow_should_fail -allow_dead_code nonmut_let_immut.rs
   verifast -c struct_exprs.rs
@@ -39,33 +39,33 @@ cd purely_unsafe
   verifast -c pred_fam.rs
   verifast -c tree3.rs
   verifast -c generic_structs.rs
-  verifast -c str.rs
-  verifast -prover z3v4.5 -target LP64 -c -extern ../unverified/platform httpd.rs
-  verifast -prover z3v4.5 -target LP64 -c -extern ../unverified/platform httpd_vec.rs
+  verifast -c -ignore_ref_creation str.rs
+  verifast -prover z3v4.5 -target LP64 -c -ignore_ref_creation -extern ../unverified/platform httpd.rs
+  verifast -prover z3v4.5 -target LP64 -c -ignore_ref_creation -extern ../unverified/platform httpd_vec.rs
   verifast -prover z3v4.5 -c -extern ../unverified/platform mt_account_transfer.rs
-  verifast -prover z3v4.5 -target LP64 -c -extern ../unverified/platform httpd_mt.rs
+  verifast -prover z3v4.5 -target LP64 -c -ignore_ref_creation -extern ../unverified/platform httpd_mt.rs
   verifast -c my_option.rs
-  verifast -c vec_test.rs
-  verifast -target LP64 -c -extern ../unverified/platform atomics_example.rs
+  verifast -c -ignore_ref_creation vec_test.rs
+  verifast -target LP64 -c -ignore_ref_creation -extern ../unverified/platform atomics_example.rs
 cd ..
 cd safe_abstraction
   verifast -c box.rs
   verifast -c full_bor_primitive_types.rs
   verifast -c shared_primitive_types.rs
   verifast -c deque_i32.rs
-  verifast -c deque.rs
-  verifast -c cell_u32.rs
-  verifast -c cell.rs
-  verifast -c tree.rs
+  verifast -c -ignore_ref_creation deque.rs
+  verifast -c -ignore_ref_creation cell_u32.rs
+  verifast -c -ignore_ref_creation cell.rs
+  verifast -c -ignore_ref_creation tree.rs
   verifast -c -allow_should_fail -allow_dead_code drop_test.rs
-  verifast -c tparam_own.rs
-  verifast -c generic_pair.rs
-  verifast -c -extern ../unverified/sys mutex_u32.rs
-  verifast -c -extern ../unverified/sys mutex.rs
-  verifast -c rc_u32.rs
-  verifast -c rc.rs
-  verifast -c arc_u32.rs
-  verifast -c arc.rs
+  verifast -c -ignore_ref_creation tparam_own.rs
+  verifast -c -ignore_ref_creation generic_pair.rs
+  verifast -c -ignore_ref_creation -extern ../unverified/sys mutex_u32.rs
+  verifast -c -ignore_ref_creation -extern ../unverified/sys mutex.rs
+  verifast -c -ignore_ref_creation rc_u32.rs
+  verifast -c -ignore_ref_creation rc.rs
+  verifast -c -ignore_ref_creation arc_u32.rs
+  verifast -c -ignore_ref_creation arc.rs
   begin_sequential
     verifast -c -apply_quick_fix proof_obligs_quick_fix_test_result.rs proof_obligs_quick_fix_test.rs
     verifast -c proof_obligs_quick_fix_test_result.rs


### PR DESCRIPTION
Until a shared reference is ended, the memory it points to is immutable.

To postpone dealing with this, specify -ignore_ref_creation on the command line or put //~ignore_ref_creation on the line that creates the ref.
