### PR TITLE
Fixpoint function parameter requires clauses

### DIFF
--- a/bin/list.gh
+++ b/bin/list.gh
@@ -219,7 +219,7 @@ lemma void foreach_append<t>(list<t> xs, list<t> ys);
     requires foreach(xs, ?p) &*& foreach(ys, p);
     ensures foreach(append(xs, ys), p);
 
-fixpoint list<b> map<a, b>(fixpoint(a, b) f, list<a> xs) {
+fixpoint list<b> map<a, b>(fixpoint(a x, b) requires x < xs f, list<a> xs) {
     switch (xs) {
         case nil: return nil;
         case cons(x, xs0): return cons(f(x), map(f, xs0));

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -152,10 +152,11 @@ let rec sexpr_of_type_expr : type_expr -> sexpression = function
       build_list
         [ Symbol "type-pred-expr" ]
         [ "types", sexpr_of_list sexpr_of_type_expr targs; "precise", sexpr_of_option sexpr_of_int p ]
-  | PureFuncTypeExpr (_, exprs) ->
+  | PureFuncTypeExpr (_, params, requires_opt) ->
       build_list
         [ Symbol "type-expr-pure-func" ]
-        [ "type-exprs", sexpr_of_list sexpr_of_type_expr exprs ]
+        [ "type-exprs", sexpr_of_list (fun (tp, x_opt) -> List [sexpr_of_type_expr tp; sexpr_of_option (fun (l, x) -> Symbol x) x_opt]) params;
+          "requires", sexpr_of_option (fun e -> Symbol "(omitted)") requires_opt ]
   | LValueRefTypeExpr (_, te) -> 
       List [ Symbol "type-expr-lvalue-ref"; sexpr_of_type_expr te ]
 

--- a/src/explorer/explorer.ml
+++ b/src/explorer/explorer.ml
@@ -283,7 +283,7 @@ let _ =
         | IdentTypeExpr(_, _, name) -> name
         | ConstructedTypeExpr(_, name, type_expr_list) -> name ^ "<" ^ string_of_type_expr_list type_expr_list ^ ">"
         | PredTypeExpr(_, type_expr_list, _) -> string_of_type_expr_list type_expr_list
-        | PureFuncTypeExpr(_, type_expr_list) -> string_of_type_expr_list type_expr_list
+        | PureFuncTypeExpr(_, params, _) -> string_of_type_expr_list (List.map fst params)
     and string_of_type_expr_list (type_expr_list: type_expr list) : string =
       match type_expr_list with
         | [] -> ""
@@ -496,10 +496,10 @@ let _ =
                 | PredTypeExpr(_, pattern_type_expr_list, _) -> check_type_expr_equal_list type_expr_list pattern_type_expr_list
                 | _ -> false
             end
-          | PureFuncTypeExpr(_, type_expr_list) ->
+          | PureFuncTypeExpr(_, params, _) ->
             begin
               match pattern_type_expr with
-                | PureFuncTypeExpr(_, pattern_type_expr_list) -> check_type_expr_equal_list type_expr_list pattern_type_expr_list
+                | PureFuncTypeExpr(_, pattern_params, _) -> check_type_expr_equal_list (List.map fst params) (List.map fst pattern_params)
                 | _ -> false
             end
       and check_type_expr_equal_list (type_expr_list: type_expr list) (pattern_type_expr_list: type_expr list) : bool =

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -334,7 +334,7 @@ type type_expr = (* ?type_expr *)
   | IdentTypeExpr of loc * string option (* package name *) * string
   | ConstructedTypeExpr of loc * string * type_expr list  (* A type of the form x<T1, T2, ...> *)
   | PredTypeExpr of loc * type_expr list * int option (* if None, not necessarily precise; if Some n, precise with n input parameters *)
-  | PureFuncTypeExpr of loc * type_expr list   (* Potentially uncurried *)
+  | PureFuncTypeExpr of loc * (type_expr * (loc * string) option) list * expr (* 'requires' clause *) option   (* Potentially uncurried *)
   | LValueRefTypeExpr of loc * type_expr
   | ConstTypeExpr of loc * type_expr
 and
@@ -1050,7 +1050,7 @@ let type_expr_loc t =
   | RustRefTypeExpr (l, _, _, _) -> l
   | ArrayTypeExpr(l, te) -> l
   | PredTypeExpr(l, te, _) -> l
-  | PureFuncTypeExpr (l, tes) -> l
+  | PureFuncTypeExpr (l, tes, _) -> l
   | FuncTypeExpr (l, _, _) -> l
   | ConstTypeExpr (l, te) -> l
 
@@ -1206,7 +1206,7 @@ let type_expr_fold_open f state te =
   | IdentTypeExpr (l, pn, x) -> state
   | ConstructedTypeExpr (l, x, targs) -> List.fold_left f state targs
   | PredTypeExpr (l, paramTps, inputParamCount) -> List.fold_left f state paramTps
-  | PureFuncTypeExpr (l, tps) -> List.fold_left f state tps
+  | PureFuncTypeExpr (l, tps, _) -> List.fold_left (fun state (tp, _) -> f state tp) state tps
   | LValueRefTypeExpr (l, tp) -> f state tp
   | ConstTypeExpr (l, tp) -> f state tp
 

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -204,10 +204,11 @@ let rec of_type_expr = function
     of_list of_type_expr argTps;
     of_option i inputParamCount
   ])
-| PureFuncTypeExpr (l, tps) ->
+| PureFuncTypeExpr (l, ps, requires_opt) ->
   C ("PureFuncTypeExpr", [
     of_loc l;
-    of_list of_type_expr tps
+    of_list (fun (tp, x_opt) -> T [of_type_expr tp; of_option (fun (l, x) -> T [of_loc l; s x]) x_opt]) ps;
+    of_option of_expr requires_opt
   ])
 | LValueRefTypeExpr (l, tp) ->
   C ("LValueRefTypeExpr", [

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -3821,7 +3821,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       ), 
       (
         structmap1, unionmap1, enummap1, globalmap1, modulemap1, importmodulemap1, 
-        inductivemap1, purefuncmap1, predctormap1, struct_accessor_map1, malloc_block_pred_map1, new_block_pred_map1, 
+        inductivemap1, purefuncmap1, purefuncparamrequiresmap1, predctormap1, struct_accessor_map1, malloc_block_pred_map1, new_block_pred_map1, 
         field_pred_map1, predfammap1, predinstmap1, typedefmap1, functypemap1, 
         funcmap1, boxmap, classmap1, interfmap1, classterms1, interfaceterms1, 
         abstract_types_map1, cxx_ctor_map1, cxx_dtor_map1, bases_constructed_map1, cxx_vtype_map1, cxx_inst_pred_map1,

--- a/tests/fixpoint_param_requires_clauses/bad_map1.c
+++ b/tests/fixpoint_param_requires_clauses/bad_map1.c
@@ -1,0 +1,10 @@
+/*@
+
+fixpoint list<b> map1<a, b>(fixpoint(a x, b) requires x < xs f, list<a> xs) {
+    switch (xs) {
+        case nil: return cons(f(default_value), nil); //~should_fail
+        case cons(h, t): return cons(f(h), map1(f, t));
+    }
+}
+
+@*/

--- a/tests/fixpoint_param_requires_clauses/bad_map2.c
+++ b/tests/fixpoint_param_requires_clauses/bad_map2.c
@@ -1,0 +1,17 @@
+/*@
+
+fixpoint list<b> map0<a, b>(fixpoint(a x, b) f, list<a> xs) {
+    switch (xs) {
+        case nil: return cons(f(default_value), nil);
+        case cons(h, t): return cons(f(h), map(f, t));
+    }
+}
+
+fixpoint list<b> map1<a, b>(fixpoint(a x, b) requires x < xs f, list<a> xs) {
+    switch (xs) {
+        case nil: return nil;
+        case cons(h, t): return cons(f(h), map0(f, t)); //~should_fail
+    }
+}
+
+@*/

--- a/tests/fixpoint_param_requires_clauses/bad_map3.c
+++ b/tests/fixpoint_param_requires_clauses/bad_map3.c
@@ -1,0 +1,10 @@
+/*@
+
+fixpoint list<b> map1<a, b>(fixpoint(a x, b) requires x < xs f, list<a> xs) {
+    switch (xs) {
+        case nil: return nil;
+        case cons(h, t): return map1(f, xs); //~should_fail
+    }
+}
+
+@*/

--- a/tests/fixpoint_param_requires_clauses/positive_test.c
+++ b/tests/fixpoint_param_requires_clauses/positive_test.c
@@ -1,0 +1,14 @@
+/*@
+
+inductive nodeIn = parentIn(list<nodeIn>) | leafIn;
+
+inductive nodeOut = parentOut(list<nodeOut>) | leafOut;
+
+fixpoint nodeOut getOut(nodeIn n) {
+    switch(n) {
+        case parentIn(l): return parentOut(map(getOut, l));
+        case leafIn: return leafOut;
+    }
+}
+
+@*/

--- a/testsuite.mysh
+++ b/testsuite.mysh
@@ -468,6 +468,10 @@ cd tutorial_solutions
 cd ..
 cd tests
   verifast -c -allow_should_fail const_vars.c
+  cd fixpoint_param_requires_clauses
+    verifast -c positive_test.c
+    verifast -c -allow_should_fail bad_map1.c bad_map2.c bad_map3.c
+  cd ..
   verifast -c -allow_should_fail issue601.c
   verifast -c issue536.c
   verifast -c continue.c


### PR DESCRIPTION
Enables recursion through higher-order functions (e.g. a fixpoint function passing itself as an argument to 'map').

Fixes #639
