### PR TITLE
[Rust] Support hidden locals

### DIFF
--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -3621,26 +3621,23 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
              let y = x + 2;
              ``
              The third `x` refers to the first x but the code might be confusing for the user *)
+          (*
           Ast.static_error loc
             (Printf.sprintf
                "This function shadows local variable name '%s'; this is not \
                 yet supported in VeriFast"
                surf_name)
             None
-      (*
-          let internal_name =
-            TrName.tag_internal surf_name ^ string_of_int !counter
-          in
-          if !counter = Int.max_int then
-            failwith "Shadowed var name counter ovf"
-          else
-            let _ = counter := succ !counter in
-            let env_entry_opt : VF0.var_debug_info option =
-              Some { internal_name; surf_name }
-            in
-            let trs_entry : var_id_trs_entry = { id; internal_name } in
-            (env_entry_opt, trs_entry, surf_names_set)
           *)
+          counter := succ !counter;
+          let internal_name =
+            (*TrName.tag_internal*) surf_name ^ "_" ^ string_of_int !counter
+          in
+          let env_entry_opt : VF0.var_debug_info option =
+            (*Some { internal_name; surf_name }*) None
+          in
+          let trs_entry : var_id_trs_entry = { id; internal_name } in
+          (env_entry_opt, trs_entry, surf_names_set)
     in
     let f_aux (env_map, trs_map, surf_names_set)
         ({ internal; surf_name } : Mir.var_debug_info) =

--- a/tests/rust/hidden_locals.rs
+++ b/tests/rust/hidden_locals.rs
@@ -1,0 +1,14 @@
+fn main() {
+    unsafe {
+        let mut x = 10;
+        x += 1;
+        {
+            let x = 20;
+            //@ assert x == 11 && x_1 == 20;
+            let x = 30;
+            //@ assert x == 11 && x_1 == 20 && x_2 == 30;
+        }
+        x += 1;
+        //@ assert x == 12;
+    }
+}

--- a/tests/rust/safe_abstraction/linked_list.rs
+++ b/tests/rust/safe_abstraction/linked_list.rs
@@ -992,28 +992,28 @@ impl<T, A: Allocator> LinkedList<T, A> {
             //@ open_points_to(self);
             (*node.as_ptr()).next = self.head;
             (*node.as_ptr()).prev = None;
-            let node_ = Some(node);
+            let node = Some(node);
 
             //@ open Nodes(_, _, _, _, _, _);
             match self.head {
                 None => {
                     //@ close Nodes::<T>(alloc_id, None, None, None, None, nil);
-                    self.tail = node_
+                    self.tail = node
                 }
                 // Not creating new mutable (unique!) references overlapping `element`.
                 Some(head) => {
-                    (*head.as_ptr()).prev = node_;
-                    //@ close Nodes(alloc_id, self0.head, node_, self0.tail, None, nodes);
+                    (*head.as_ptr()).prev = node;
+                    //@ close Nodes(alloc_id, self0.head, node_1, self0.tail, None, nodes);
                 }
             }
 
-            self.head = node_;
+            self.head = node;
             //@ assume(self0.len < usize::MAX);
             self.len += 1;
             //@ close_points_to(self);
             //@ assert *self |-> ?self1;
             //@ points_to_limits(&(*NonNull_ptr(node)).element);
-            //@ close Nodes(alloc_id, node_, None, self1.tail, None, cons(node, nodes));
+            //@ close Nodes(alloc_id, node_1, None, self1.tail, None, cons(node, nodes));
             //@ close elem_fbc::<T>(t)(node);
             //@ close foreach(cons(node, nodes), elem_fbc::<T>(t));
             //@ close <LinkedList<T, A>>.own(t, self1);
@@ -1058,18 +1058,18 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 //@ let alloc_ref = precreate_ref(&(*self).alloc);
                 //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
                 self.head = (*node.as_ptr()).next;
-                let node_ = Box::from_raw_in(node.as_ptr(), &self.alloc);
+                let node = Box::from_raw_in(node.as_ptr(), &self.alloc);
 
                 //@ open Nodes(_, ?next, _, ?tail, _, _);
-                match self.head {
-                    None => self.tail = None,
-                    // Not creating new mutable (unique!) references overlapping `element`.
-                    Some(head) => (*head.as_ptr()).prev = None,
-                }
+            match self.head {
+                None => self.tail = None,
+                // Not creating new mutable (unique!) references overlapping `element`.
+                Some(head) => (*head.as_ptr()).prev = None,
+            }
                 //@ close Nodes(alloc_id, next, None, (*self).tail, None, _);
 
-                self.len -= 1;
-                Some(node_)
+            self.len -= 1;
+                Some(node)
             }
         }
     }
@@ -1086,15 +1086,15 @@ impl<T, A: Allocator> LinkedList<T, A> {
         unsafe {
             (*node.as_ptr()).next = None;
             (*node.as_ptr()).prev = self.tail;
-            let node_ = Some(node);
+            let node = Some(node);
 
             match self.tail {
-                None => self.head = node_,
+                None => self.head = node,
                 // Not creating new mutable (unique!) references overlapping `element`.
-                Some(tail) => (*tail.as_ptr()).next = node_,
+                Some(tail) => (*tail.as_ptr()).next = node,
             }
 
-            self.tail = node_;
+            self.tail = node;
             self.len += 1;
         }
     }
@@ -1107,17 +1107,17 @@ impl<T, A: Allocator> LinkedList<T, A> {
         match self.tail {
             None => None,
             Some(node) => unsafe {
-                let node_ = Box::from_raw_in(node.as_ptr(), &self.alloc);
-                self.tail = node_.prev;
+                let node = Box::from_raw_in(node.as_ptr(), &self.alloc);
+                self.tail = node.prev;
 
-                match self.tail {
-                    None => self.head = None,
-                    // Not creating new mutable (unique!) references overlapping `element`.
-                    Some(tail) => (*tail.as_ptr()).next = None,
-                }
+            match self.tail {
+                None => self.head = None,
+                // Not creating new mutable (unique!) references overlapping `element`.
+                Some(tail) => (*tail.as_ptr()).next = None,
+            }
 
-                self.len -= 1;
-                Some(node_)
+            self.len -= 1;
+                Some(node)
             }
         }
     }
@@ -1151,15 +1151,15 @@ impl<T, A: Allocator> LinkedList<T, A> {
         (*self).len |-> length(nodes1) + length(nodes2);
     @*/
     {
-        let node_ = unsafe { node.as_mut() }; // this one is ours now, we can create an &mut.
+        let node = unsafe { node.as_mut() }; // this one is ours now, we can create an &mut.
 
         // Not creating new mutable (unique!) references overlapping `element`.
-        match node_.prev {
+        match node.prev {
             Some(prev) => unsafe {
                 //@ Nodes_last_lemma(head);
                 //@ Nodes_split_off_last(head);
                 //@ assert Nodes(_, head, None, ?pprev, prev_, ?nodes10);
-                (*prev.as_ptr()).next = node_.next;
+                (*prev.as_ptr()).next = node.next;
                 //@ open Nodes(alloc_id, next_, Some(node), tail, None, nodes2);
                 //@ close Nodes(alloc_id, next_, Some(node), tail, None, nodes2);
                 //@ close Nodes::<T>(alloc_id, next_, prev_, prev_, next_, []);
@@ -1171,21 +1171,21 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 //@ Nodes_last_lemma(head);
                 //@ open Nodes(alloc_id, head, _, _, _, nodes1);
                 //@ close Nodes(alloc_id, next_, None, None, next_, []);
-                self.head = node_.next
+                self.head = node.next
             }
         };
 
-        match node_.next {
+        match node.next {
             Some(next) => unsafe {
                 //@ open Nodes(alloc_id, next_, Some(node), tail, None, nodes2);
-                (*next.as_ptr()).prev = node_.prev;
+                (*next.as_ptr()).prev = node.prev;
                 //@ close Nodes(alloc_id, next_, prev_, tail, None, nodes2);
             },
             // this node is the tail node
             None => {
                 //@ open Nodes(alloc_id, next_, Some(node), _, _, nodes2);
                 //@ close Nodes(alloc_id, next_, prev_, prev_, next_, []);
-                self.tail = node_.prev;
+                self.tail = node.prev;
                 
             }
         };
@@ -1207,16 +1207,16 @@ impl<T, A: Allocator> LinkedList<T, A> {
     ) {
         // This method takes care not to create multiple mutable references to whole nodes at the same time,
         // to maintain validity of aliasing pointers into `element`.
-        if let Some(mut existing_prev_) = existing_prev {
+        if let Some(mut existing_prev) = existing_prev {
             unsafe {
-                existing_prev_.as_mut().next = Some(splice_start);
+                existing_prev.as_mut().next = Some(splice_start);
             }
         } else {
             self.head = Some(splice_start);
         }
-        if let Some(mut existing_next_) = existing_next {
+        if let Some(mut existing_next) = existing_next {
             unsafe {
-                existing_next_.as_mut().prev = Some(splice_end);
+                existing_next.as_mut().prev = Some(splice_end);
             }
         } else {
             self.tail = Some(splice_end);
@@ -1318,14 +1318,14 @@ impl<T, A: Allocator> LinkedList<T, A> {
     {
         // The split node is the new tail node of the first part and owns
         // the head of the second part.
-        if let Some(mut split_node_) = split_node {
+        if let Some(mut split_node) = split_node {
             //@ Nodes_last_lemma(head0);
             //@ Nodes_split_off_last(head0);
             //@ assert Nodes(alloc_id, head0, None, ?prev0, split_node, ?nodes10);
             let second_part_head;
             let second_part_tail;
             unsafe {
-                second_part_head = split_node_.as_mut().next.take();
+                second_part_head = split_node.as_mut().next.take();
             }
             //@ open Nodes(_, next0, split_node, tail0, None, nodes2);
             if let Some(mut head) = second_part_head {
@@ -1351,10 +1351,10 @@ impl<T, A: Allocator> LinkedList<T, A> {
             //@ std::alloc::end_ref_Allocator::<'static, A>();
 
             // Fix the tail ptr of the first part
-            self.tail = Some(split_node_);
+            self.tail = Some(split_node);
             self.len = at;
             //@ close Nodes::<T>(alloc_id, None, split_node, split_node, None, []);
-            //@ close Nodes::<T>(alloc_id, split_node, prev0, split_node, None, [split_node_]);
+            //@ close Nodes::<T>(alloc_id, split_node, prev0, split_node, None, [split_node_1]);
             //@ Nodes_append(head0);
             //@ close_points_to(self);
             //@ close <LinkedList<T, A>>.own(t, *self);
@@ -1819,11 +1819,11 @@ impl<T, A: Allocator> LinkedList<T, A> {
             //@ let_lft 'a = k;
             //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
             let ll = LinkedList {
-                head: self.head.take(),
-                tail: self.tail.take(),
+            head: self.head.take(),
+            tail: self.tail.take(),
                 len: mem::replace(&mut self.len, 0), //mem::take(&mut self.len),
-                alloc: &self.alloc,
-                marker: PhantomData,
+            alloc: &self.alloc,
+            marker: PhantomData,
             };
             //@ close <LinkedList<T, &'a A>>.own(t, ll);
             drop/*@::<LinkedList<T, &'a A>> @*/(ll);
@@ -1993,11 +1993,11 @@ impl<T, A: Allocator> LinkedList<T, A> {
             //@ open <LinkedList<T, A>>.own(t, ll0);
             //@ let alloc_ref = precreate_ref(&(*self).alloc);
             //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
-            let node = Box::new_in(Node::new(elt), &self.alloc);
+        let node = Box::new_in(Node::new(elt), &self.alloc);
             let node_ptr = NonNull::new_unchecked(Box::leak(node) as *mut Node<T>); //NonNull::from(Box::leak(node));
             //@ std::alloc::end_ref_Allocator::<'static, A>();
             //@ close_points_to(self);
-            // SAFETY: node_ptr is a unique pointer to a node we boxed with self.alloc and leaked
+        // SAFETY: node_ptr is a unique pointer to a node we boxed with self.alloc and leaked
             self.push_front_node(node_ptr);
         }
     }
@@ -2065,9 +2065,9 @@ impl<T, A: Allocator> LinkedList<T, A> {
     #[rustc_confusables("push", "append")]
     pub fn push_back(&mut self, elt: T) {
         unsafe {
-            let node = Box::new_in(Node::new(elt), &self.alloc);
-            let node_ptr = NonNull::from(Box::leak(node));
-            // SAFETY: node_ptr is a unique pointer to a node we boxed with self.alloc and leaked
+        let node = Box::new_in(Node::new(elt), &self.alloc);
+        let node_ptr = NonNull::from(Box::leak(node));
+        // SAFETY: node_ptr is a unique pointer to a node we boxed with self.alloc and leaked
             self.push_back_node(node_ptr);
         }
     }
@@ -2135,8 +2135,8 @@ impl<T, A: Allocator> LinkedList<T, A> {
             //@ open_points_to(self);
             let len = self.len;
             //@ assert (*self).head |-> ?head &*& (*self).tail |-> ?tail &*& Nodes(?alloc_id, _, _, _, _, _);
-            assert!(at <= len, "Cannot split off at a nonexistent index");
-            if at == 0 {
+        assert!(at <= len, "Cannot split off at a nonexistent index");
+        if at == 0 {
                 //@ let alloc_ref = precreate_ref(&(*self).alloc);
                 //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
                 let alloc1 = clone_allocator(&self.alloc);
@@ -2146,7 +2146,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 //@ assert *self |-> ?self1;
                 //@ close <LinkedList<T, A>>.own(t, self1);
                 return mem::replace(self, Self::new_in(alloc1));
-            } else if at == len {
+        } else if at == len {
                 //@ let alloc_ref = precreate_ref(&(*self).alloc);
                 //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
                 let alloc2 = clone_allocator(&self.alloc);
@@ -2156,14 +2156,14 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 //@ assert *self |-> ?self1;
                 //@ close <LinkedList<T, A>>.own(t, self1);
                 return Self::new_in(alloc2);
-            }
+        }
 
-            // Below, we iterate towards the `i-1`th node, either from the start or the end,
-            // depending on which would be faster.
+        // Below, we iterate towards the `i-1`th node, either from the start or the end,
+        // depending on which would be faster.
             let mut iter;
             let mut i;
             //@ assert Nodes(alloc_id, head, None, tail, None, ?nodes);
-            let split_node = if at - 1 <= len - 1 - (at - 1) {
+        let split_node = if at - 1 <= len - 1 - (at - 1) {
                 iter = self.head;
                 i = 0;
                 //@ close Nodes(alloc_id, head, None, None, head, []);
@@ -2196,8 +2196,8 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 //@ append_assoc(nodes1, [iter_], tail(nodes2));
                 //@ foreach_unappend(append(nodes1, [iter_]), tail(nodes2), elem_fbc::<T>(t));
                 iter
-            } else {
-                // better off starting from the end
+        } else {
+            // better off starting from the end
                 iter = self.tail;
                 i = 0;
                 //@ close Nodes(alloc_id, None, iter, iter, None, []);
@@ -2221,8 +2221,8 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 }
                 //@ foreach_unappend(nodes1, nodes2, elem_fbc::<T>(t));
                 iter
-            };
-            unsafe { self.split_off_after_node(split_node, at) }
+        };
+        unsafe { self.split_off_after_node(split_node, at) }
         }
     }
 
@@ -2412,7 +2412,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
         // avoid borrow issues.
         let it = self.head;
         let old_len = self.len;
-        
+
         //@ let ghost_cell_id = create_ghost_cell::<pair<Option<NonNull<Node<T>>>, usize>>(pair(it, 0));
 
         /*@
@@ -2446,7 +2446,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     }
 }
 
-struct DropGuard<'a, T, A: Allocator>(&'a mut LinkedList<T, A>);
+        struct DropGuard<'a, T, A: Allocator>(&'a mut LinkedList<T, A>);
 
 /*@
 
@@ -2462,14 +2462,14 @@ lem DropGuard_own_mono<'a0, 'a1, T, A>()
 
 @*/
 
-impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
-    fn drop(&mut self) {
+        impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
+            fn drop(&mut self) {
         unsafe {
-            // Continue the same loop we do below. This only runs when a destructor has
-            // panicked. If another one panics this will abort.
-            while self.0.pop_front_node().is_some() {}
+                // Continue the same loop we do below. This only runs when a destructor has
+                // panicked. If another one panics this will abort.
+                while self.0.pop_front_node().is_some() {}
+            }
         }
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -2487,8 +2487,8 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for LinkedList<T, A> {
     @*/
     {
         unsafe {
-            // Wrap self so that if a destructor panics, we can try to keep looping
-            let guard = DropGuard(self);
+        // Wrap self so that if a destructor panics, we can try to keep looping
+        let guard = DropGuard(self);
             //@ open_full_borrow_content(t, self);
             loop {
                 //@ inv thread_token(t) &*& *self |-> ?self0 &*& <LinkedList<T, A>>.own(t, self0) &*& [1/2]guard.0 |-> self &*& [1/2]element |-> _;
@@ -2500,7 +2500,7 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for LinkedList<T, A> {
                 }
             }
             //@ close <DropGuard<'static, T, A>>.own(t, guard);
-            mem::forget(guard);
+        mem::forget(guard);
             //@ let head = (*self).head;
             //@ match head { Option::None => {} Option::Some(head_) => { std::ptr::close_NonNull_own::<Node<T>>(t, head_); } }
             //@ close <std::option::Option<NonNull<Node<T>>>>.own(t, head);
@@ -2535,14 +2535,14 @@ impl<'a, T> Iterator for Iter<'a, T> {
                     //@ close std::option::Option_own::<&'a T>(t, Option::None);
                     None
                 }
-                Some(node_) => unsafe {
+                Some(node) => unsafe {
                     //@ open <Iter<'a, T>>.own(t, self0);
                     //@ open exists(Iter_info(?alloc_id, ?head0, ?prev, ?next, ?tail0, ?nodes_before, ?nodes, ?nodes_after, ?prevs_before, ?prevs, ?prevs_after, ?nexts_before, ?nexts, ?nexts_after));
                     //@ open_frac_borrow('a, Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after), q);
                     //@ open [?f]Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after)();
                     //@ open Nodes1::<T>(alloc_id, self0.head, prev, self0.tail, next, nodes, prevs, nexts);
-                    // Need an unbound lifetime to get 'a
-                    let node = node_.as_ptr(); //&*node_.as_ptr();
+                // Need an unbound lifetime to get 'a
+                    let node = node.as_ptr(); //&*node_.as_ptr();
                     let len = self.len;
                     //@ produce_limits(len);
                     self.len = len - 1;
@@ -2552,32 +2552,32 @@ impl<'a, T> Iterator for Iter<'a, T> {
                     //@ close [f]Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after)();
                     //@ close_frac_borrow(f, Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after));
                     /*@
-                    produce_lem_ptr_chunk implies_frac(Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after), Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node_]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after))() {
+                    produce_lem_ptr_chunk implies_frac(Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after), Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after))() {
                         open [?f1]Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after)();
                         open Nodes1::<T>(alloc_id, self0.head, prev, self0.tail, next, nodes, prevs, nexts);
                         close [f1]Nodes1::<T>(alloc_id, self1.head, self0.head, self0.head, self1.head, [], [], []);
-                        assert self0.head == Option::Some(node_) &*& [f1](*NonNull_ptr(node_)).next |-> self1.head;
-                        close [f1]Nodes1::<T>(alloc_id, self0.head, prev, self0.head, self1.head, [node_], [prev], [self1.head]);
+                        assert self0.head == Option::Some(node) &*& [f1](*NonNull_ptr(node)).next |-> self1.head;
+                        close [f1]Nodes1::<T>(alloc_id, self0.head, prev, self0.head, self1.head, [node], [prev], [self1.head]);
                         Nodes1_append::<T>(head0);
-                        close [f1]Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node_]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after)();
+                        close [f1]Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after)();
                     } {
-                        produce_lem_ptr_chunk implies_frac(Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node_]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after), Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after))() {
-                            open [?f1]Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node_]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after)();
-                            Nodes1_split::<T>(nodes_before, [node_], prevs_before, [prev], nexts_before, [self1.head]);
-                            open Nodes1::<T>(alloc_id, _, _, _, _, [node_], [prev], [self1.head]);
+                        produce_lem_ptr_chunk implies_frac(Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after), Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after))() {
+                            open [?f1]Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after)();
+                            Nodes1_split::<T>(nodes_before, [node], prevs_before, [prev], nexts_before, [self1.head]);
+                            open Nodes1::<T>(alloc_id, _, _, _, _, [node], [prev], [self1.head]);
                             open Nodes1::<T>(alloc_id, self1.head, _, _, _, [], [], []);
                             close [f1]Nodes1::<T>(alloc_id, self0.head, prev, self0.tail, next, nodes, prevs, nexts);
                             close [f1]Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after)();
                         } {
-                            frac_borrow_implies('a, Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after), Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node_]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after));
+                            frac_borrow_implies('a, Iter_frac_borrow_content::<T>(alloc_id, head0, self0.head, prev, self0.tail, next, tail0, nodes_before, nodes, nodes_after, prevs_before, prevs, prevs_after, nexts_before, nexts, nexts_after), Iter_frac_borrow_content::<T>(alloc_id, head0, self1.head, self0.head, self1.tail, next, tail0, append(nodes_before, [node]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after));
                         }
                     }
                     @*/
-                    //@ close exists(Iter_info(alloc_id, head0, self0.head, next, tail0, append(nodes_before, [node_]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after));
+                    //@ close exists(Iter_info(alloc_id, head0, self0.head, next, tail0, append(nodes_before, [node]), tail(nodes), nodes_after, append(prevs_before, [prev]), tail(prevs), prevs_after, append(nexts_before, [self1.head]), tail(nexts), nexts_after));
                     //@ open foreach(_, _);
                     //@ close <Iter<'a, T>>.own(t, *self);
-                    //@ open elem_share::<T>('a, t)(node_);
-                    //@ let elem_ref = precreate_ref(&(*node).element);
+                    //@ open elem_share::<T>('a, t)(node);
+                    //@ let elem_ref = precreate_ref(&(*node_1).element);
                     //@ produce_type_interp::<T>();
                     //@ init_ref_share::<T>('a, t, elem_ref);
                     //@ leak type_interp::<T>();
@@ -3356,7 +3356,7 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
                 //@ let current1 = (*self).current;
                 //@ open foreach(nodes2, elem_fbc::<T>(t1));
                 //@ open elem_fbc::<T>(t1)(unlinked_node);
-                self.list.unlink_node(unlinked_node);
+            self.list.unlink_node(unlinked_node);
                 /*@
                 if t1 != t {
                     std::alloc::Allocator_send(t, (*self0.list).alloc);
@@ -3364,8 +3364,8 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
                 @*/
                 //@ let alloc_ref = precreate_ref(&(*self0.list).alloc);
                 //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
-                let unlinked_node_ = Box::from_raw_in(unlinked_node.as_ptr(), &self.list.alloc);
-                let r = Some(Box::into_inner(unlinked_node_).element); // Some(unlinked_node_.element)
+                let unlinked_node = Box::from_raw_in(unlinked_node.as_ptr(), &self.list.alloc);
+                let r = Some(Box::into_inner(unlinked_node).element); // Some(unlinked_node_.element)
                 //@ std::alloc::end_ref_Allocator::<'static, A>();
                 //@ ghost_cell_mutate(ghost_cell_id, pair(self0.index, current1));
                 /*@
@@ -3676,15 +3676,15 @@ where
                     //@ assert Allocator::<A>(t, ?alloc, _);
                     //@ open Nodes(?alloc_id, self1.it, ?prev, ?tail, None, ?nodes2);
                     self.it = (*node.as_ptr()).next; //node.as_ref().next;
-                    self.idx += 1;
+                self.idx += 1;
                     //@ ghost_cell_mutate(ghost_cell_id, pair((*self).it, (*self).idx));
-                    
+
                     //@ open foreach(nodes2, elem_fbc::<T>(t));
                     //@ open elem_fbc::<T>(t)(node);
 
                     if call_pred(&mut self.pred, &mut node.as_mut().element) {
-                        // `unlink_node` is okay with aliasing `element` references.
-                        self.list.unlink_node(node);
+                    // `unlink_node` is okay with aliasing `element` references.
+                    self.list.unlink_node(node);
                         //@ let alloc_ref = precreate_ref(&(*(*self).list).alloc);                        
                         //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
                         let r = Some(Box::into_inner(Box::from_raw_in(node.as_ptr(), &self.list.alloc)).element);
@@ -3705,8 +3705,8 @@ where
                     //@ close ExtractIf_fbc::<T, A>(t, self1.list, ghost_cell_id, self1.old_len)();
                     //@ close_full_borrow(ExtractIf_fbc(t, self1.list, ghost_cell_id, self1.old_len));
                     //@ close <ExtractIf<'a, T, F, A>>.own(t, *self);
-                }
             }
+        }
         }
         //@ close <std::option::Option<T>>.own(t, None);
         None
@@ -3940,17 +3940,17 @@ impl<T, const N: usize> From<[T; N]> for LinkedList<T> {
 // Ensure that `LinkedList` and its read-only iterators are covariant in their type parameters.
 #[allow(dead_code)]
 fn assert_covariance_a<'a>(x: LinkedList<&'static str>) -> LinkedList<&'a str> {
-    x
-}
+        x
+    }
 
 #[allow(dead_code)]
 fn assert_covariance_b<'i, 'a>(x: Iter<'i, &'static str>) -> Iter<'i, &'a str> {
-    x
-}
+        x
+    }
 
 #[allow(dead_code)]
 fn assert_covariance_c<'a>(x: IntoIter<&'static str>) -> IntoIter<&'a str> {
-    x
+        x
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -10,6 +10,7 @@ verifast -allow_should_fail -allow_assume preprocessor_test_crlf_bom.rs
 verifast -allow_should_fail pred_arg_lft.rs
 verifast -allow_should_fail -allow_dead_code lemma_without_body.rs
 verifast -allow_should_fail -allow_dead_code assume_stmt.rs
+verifast hidden_locals.rs
 begin_sequential
 cd unverified
   cd platform


### PR DESCRIPTION
More generally enables verification of Rust functions where multiple local variables have the same name.

If, in a Rust function, multiple local variables have the same name X, the corresponding variables after translation are called X, X_1, X_2, etc.

TODO:
- In cases where the variables have nonoverlapping scopes, avoid changing the names.
- TODO: Perhaps ensure that each variable currently called X in the Rust program is also accessible as X in annotations. (For example: a hidden variable X might be accessible as X and as X_0 while not hidden and only as X_0 while hidden.) (A possible approach to achieve this might be by adding support for 'local variable aliases' in the VeriFast engine.)
