### PR TITLE
Refactoring: explicitly bind postcond result var

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -394,14 +394,14 @@ mysh: ../bin/mysh$(DOTEXE)
 .PHONY: mysh
 
 _build/default/rustc_verifast/rustc_verifast.exe: .FORCE
-	@echo " DUNE " $@
+	@echo "  DUNE " $@
 	dune build rustc_verifast/rustc_verifast.exe
 
 ../bin/rustc-verifast$(DOTEXE): _build/default/rustc_verifast/rustc_verifast.exe
 	if [ ! -e $@ -o $< -nt $@ ]; then cp -f $< $@; fi
 
 _build/default/cargo_verifast/cargo_verifast.exe: .FORCE
-	@echo " DUNE " $@
+	@echo "  DUNE " $@
 	dune build cargo_verifast/cargo_verifast.exe
 
 ../bin/cargo-verifast$(DOTEXE): _build/default/cargo_verifast/cargo_verifast.exe

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -658,10 +658,11 @@ let rec sexpr_of_expr (expr : expr) : sexpression =
             "pat", sexpr_of_pat pat;
             "asn", sexpr_of_expr asn
           ]
-    | EnsuresAsn (loc, asn) ->
+    | EnsuresAsn (loc, result_var, asn) ->
         build_list
           [ Symbol "expr-ensures-asn" ]
-          [ "asn", sexpr_of_expr asn ]
+          [ "asn", sexpr_of_expr asn;
+            "result-var", Symbol result_var ]
     | MatchAsn (loc, asn, pat) ->
         build_list
           [ Symbol "expr-match-asn" ]
@@ -966,8 +967,9 @@ and sexpr_of_decl (decl : decl) : sexpression =
       let contract =
         match contract with
           | None -> []
-          | Some (pre, post) -> [ "precondition", sexpr_of_pred pre
-                                ; "postcondition", sexpr_of_pred post ]
+          | Some (pre, (result_var, post)) ->
+            [ "precondition", sexpr_of_pred pre
+            ; "postcondition", List [ Symbol result_var; sexpr_of_pred post ] ]
       in
       let kw = List.concat [ [ "kind", sexpr_of_func_kind kind
                              ; "type-parameters", List (List.map symbol tparams )

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -601,8 +601,8 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | CoefAsn (l, coef', body) ->
       evalpat true ghostenv env coef' RealType RealType $. fun ghostenv env coef' ->
       produce_asn_core_with_post typeid_env tpenv h ghostenv env body (real_mul l coef coef') size_first size_all assuming cont_with_post
-    | EnsuresAsn (l, body) ->
-      cont_with_post h ghostenv env (Some body)
+    | EnsuresAsn (l, result_var, body) ->
+      cont_with_post h ghostenv env (Some (result_var, body))
     | WPredExprAsn (l, e, pts, inputParamCount, pats) ->
       let symb = eval None env e in
       let pts' = instantiate_types tpenv pts in
@@ -1455,8 +1455,8 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     | CoefAsn (l, coefpat, WPointsTo (_, e, tp, kind, rhs)) -> points_to l (SrcPat coefpat) e tp kind (SrcPat rhs)
     | CoefAsn (l, coefpat, WPredAsn (_, g, is_global_predref, targs, pat0, pats)) -> pred_asn l (SrcPat coefpat) g is_global_predref targs (srcpats pat0) (srcpats pats)
     | CoefAsn (l, coefpat, WInstPredAsn (_, e_opt, st, cfin, tn, g, index, pats)) -> inst_call_pred l (SrcPat coefpat) e_opt st tn g index pats
-    | EnsuresAsn (l, body) ->
-      cont_with_post [] h ghostenv env env' None (Some body)
+    | EnsuresAsn (l, result_var, body) ->
+      cont_with_post [] h ghostenv env env' None (Some (result_var, body))
     | WPredExprAsn (l, e, pts, inputParamCount, pats) -> pred_expr_asn l real_unit_pat e pts inputParamCount pats
     | CoefAsn (l, coefpat, WPredExprAsn (_, e, pts, inputParamCount, pats)) -> pred_expr_asn l (SrcPat coefpat) e pts inputParamCount pats
     )

--- a/src/cxx_frontend/decl_translator.ml
+++ b/src/cxx_frontend/decl_translator.ml
@@ -82,7 +82,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
         params,
         ng_callers_only,
         ft,
-        pre_post,
+        Option.map (fun (pre, post) -> (pre, ("result", post))) pre_post,
         terminates,
         body_opt,
         false,
@@ -230,7 +230,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
         params,
         ng_callers_only,
         ft,
-        pre_post,
+        Option.map (fun (pre, post) -> (pre, ("result", post))) pre_post,
         terminates,
         body_opt,
         is_virtual,
@@ -371,7 +371,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
     let l, type_desc = type_get decl |> Node_translator.decompose in
     match R.Type.get type_desc with
     | R.Type.FunctionProto fp ->
-        let return_type, (ft_type_params, ft_params, params), contract =
+        let return_type, (ft_type_params, ft_params, params), (pre, post, terminates) =
           transl_function_proto_type l fp
         in
         Ast.FuncTypeDecl
@@ -382,7 +382,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
             ft_type_params,
             ft_params,
             params,
-            contract )
+            (pre, ("result", post), terminates) )
     | _ ->
         let ty = Type_translator.translate_decomposed l type_desc in
         Ast.TypedefDecl (loc, ty, name, [])
@@ -415,7 +415,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
           params,
           ng_callers_only,
           ft,
-          pre_post,
+          Option.map (fun (pre, post) -> (pre, ("result", post))) pre_post,
           terminates,
           body_opt,
           false,

--- a/src/explorer/explorer.ml
+++ b/src/explorer/explorer.ml
@@ -124,9 +124,9 @@ let _ =
             begin 
               match contract_opt with
                 | None -> parse_decl_list tail
-                | Some contract -> let (_, postcond) = contract in (loc, name, postcond) :: parse_decl_list tail
+                | Some contract -> let (_, (_, postcond)) = contract in (loc, name, postcond) :: parse_decl_list tail
             end
-          | FuncTypeDecl(loc, _, _, name, _, _, _, (_, postcond, _)) -> (loc, name, postcond) :: parse_decl_list tail
+          | FuncTypeDecl(loc, _, _, name, _, _, _, (_, (_, postcond), _)) -> (loc, name, postcond) :: parse_decl_list tail
           | _ -> parse_decl_list tail
     in
 
@@ -152,7 +152,7 @@ let _ =
                           begin 
                             match contract_opt with
                               | Some contract -> 
-                                let (_, postcond) = contract in 
+                                let (_, (_, postcond)) = contract in 
                                 postcond
                           end
                     end

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -599,7 +599,7 @@ and
       loc *
       pat *
       asn
-  | EnsuresAsn of loc * asn
+  | EnsuresAsn of loc * string (* result variable *) * asn
   | MatchAsn of loc * expr * pat
   | WMatchAsn of loc * expr * pat * type_
   | LetTypeAsn of loc * string * type_ * asn (* `let_type U = T in A` means A with type T substituted for type parameter U *)
@@ -916,7 +916,7 @@ and
       (type_expr * string) list *  (* parameters *)
       bool (* nonghost_callers_only *) *
       (string * type_expr list * (loc * string) list) option (* implemented function type, with function type type arguments and function type arguments *) *
-      (asn * asn) option *  (* contract *)
+      (asn * (string (* result variable *) * asn)) option *  (* contract *)
       bool *  (* terminates *)
       (stmt list * loc (* Close brace *)) option *  (* body *)
       bool * (* virtual *)
@@ -958,7 +958,7 @@ and
       string list * (* type parameters *)
       (type_expr * string) list *
       (type_expr * string) list *
-      (asn * asn * bool) (* precondition, postcondition, terminates *)
+      (asn * (string (* result variable *) * asn) * bool) (* precondition, postcondition, terminates *)
   | BoxClassDecl of
       loc *
       string *
@@ -1144,7 +1144,7 @@ let rec expr_loc e =
   | EmpAsn l -> l
   | ForallAsn (l, tp, i, e) -> l
   | CoefAsn (l, coef, body) -> l
-  | EnsuresAsn (l, body) -> l
+  | EnsuresAsn (l, result_var, body) -> l
   | CxxNew (l, _, _)
   | WCxxNew (l, _, _) -> l
   | CxxDelete (l, _) -> l
@@ -1393,7 +1393,7 @@ let expr_fold_open iter state e =
   | EmpAsn l -> state
   | ForallAsn (l, tp, i, e) -> iter state e
   | CoefAsn (l, coef, body) -> iter (iterpat state coef) body
-  | EnsuresAsn (l, body) -> iter state body
+  | EnsuresAsn (l, result_var, body) -> iter state body
   | _ -> static_error (expr_loc e) "This expression form is not allowed in this position." None
 
 (* Postfix fold *)

--- a/src/rust_frontend/vf_mir_translator/ast_to_src.ml
+++ b/src/rust_frontend/vf_mir_translator/ast_to_src.ml
@@ -69,5 +69,5 @@ let rec string_of_asn = function
 
 let string_of_decl (d: decl) =
   match d with
-  | Func (l, Lemma (false, None), tparams, rt, f, ps, nonghost_callers_only, None, Some (pre, post), false, None, false, []) ->
+  | Func (l, Lemma (false, None), tparams, rt, f, ps, nonghost_callers_only, None, Some (pre, (result_var, post)), false, None, false, []) ->
     Printf.sprintf "lem %s%s(%s)%s\n    req %s;\n    ens %s;\n{\n    assume(false);\n}" f (string_of_tparams tparams) (string_of_params ps) (string_of_ret rt) (string_of_asn pre) (string_of_asn post)

--- a/src/rust_frontend/vf_mir_translator/rust_parser.ml
+++ b/src/rust_frontend/vf_mir_translator/rust_parser.ml
@@ -431,7 +431,7 @@ let parse_spec_clauses = function%parser
   in
   let pre_post, cs =
     match cs with
-      RequiresClause pre::EnsuresClause post::cs -> Some (pre, post), cs
+      RequiresClause pre::EnsuresClause post::cs -> Some (pre, ("result", post)), cs
     | _ -> None, cs
   in
   let terminates, cs =
@@ -739,7 +739,7 @@ and parse_ghost_decl = function%parser
        [ (_, Kwd "terminates"); (_, Kwd ";") ] -> true
      | [ ] -> false
     ]
-  ] -> [FuncTypeDecl (l, Real, rt, ftn, tparams, ftps, ps, (pre, post, terminates))]
+  ] -> [FuncTypeDecl (l, Real, rt, ftn, tparams, ftps, ps, (pre, ("result", post), terminates))]
 | [ (l, Kwd "lem_type"); (lftn, Ident ftn); parse_type_params as tparams; (_, Kwd "("); [%let ftps = rep_comma parse_param]; (_, Kwd ")"); (_, Kwd "=");
   (_, Kwd "lem"); (_, Kwd "("); [%let ps = rep_comma parse_param]; (_, Kwd ")"); 
   [%let rt = function%parser
@@ -749,7 +749,7 @@ and parse_ghost_decl = function%parser
   (_, Kwd ";");
   (_, Kwd "req"); parse_asn as pre; (_, Kwd ";");
   (_, Kwd "ens"); parse_asn as post; (_, Kwd ";")
-] -> [FuncTypeDecl (l, Ghost, rt, ftn, tparams, ftps, ps, (pre, post, false))]
+] -> [FuncTypeDecl (l, Ghost, rt, ftn, tparams, ftps, ps, (pre, ("result", post), false))]
 | [ (l, Kwd "abstract_type"); (_, Ident tn); (_, Kwd ";") ] -> [AbstractTypeDecl (l, tn)]
 | [ (l, Kwd "type_pred_decl"); (_, Kwd "<"); (_, Kwd "Self"); (_, Kwd ">"); (_, Kwd "."); (_, Ident predName); (_, Kwd ":"); parse_type as te; (_, Kwd ";") ] ->
   [TypePredDecl (l, te, "Self", predName)]

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -3329,7 +3329,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
         false (*nonghost_callers_only*),
         None
         (*implemented function type, with function type type arguments and function type arguments*),
-        Some (pre, post) (*contract*),
+        Some (pre, ("result", post)) (*contract*),
         false (*terminates*),
         None (*body*),
         false (*virtual*),
@@ -3471,7 +3471,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
       (*might be just True*)
     in
     let post_asn = Sep (contract_loc, post_na_token, post_asn) in
-    Ok (pre_asn, post_asn)
+    Ok (pre_asn, ("result", post_asn))
 
   let gen_drop_contract adt_defs self_ty self_ty_targs self_lft_args limpl =
     let outlives_preds = [] in
@@ -3625,7 +3625,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                        [ LitPat (Var (limpl, "self")) ],
                        Static )) )))
     in
-    Ok (pre, post)
+    Ok (pre, ("result", post))
 
   (** makes the mappings used for substituting the MIR level local declaration ids with names closer to variables surface name *)
   let make_var_id_name_maps (loc : Ast.loc) (vdis : Mir.var_debug_info list) =
@@ -3784,13 +3784,13 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                  (loc, arg_name, ty_info))
         in
         let result = (loc, output) in
-        let* pre, post =
+        let* contract =
           gen_contract adt_defs loc
             (List.map TrName.lft_name_without_apostrophe
                (lifetime_params_get_list required_fn_cpn))
             [] [] [] params result
         in
-        Ok ((false, None, Some (pre, post), false), false))
+        Ok ((false, None, Some contract, false), false))
     in
     if assume_correct then Ast.static_error loc "assume_correct does not make sense on trait required functions" None;
     let decl =
@@ -4362,7 +4362,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
         false (*nonghost_callers_only*),
         None
         (*implemented function type, with function type type arguments and function type arguments*),
-        Some (pre, post) (*contract*),
+        Some (pre, ("result", post)) (*contract*),
         false (*terminates*),
         None (*body*),
         false (*virtual*),
@@ -4568,7 +4568,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
             false (*nonghost_callers_only*),
             None
             (*implemented function type, with function type type arguments and function type arguments*),
-            Some (pre, post) (*contract*),
+            Some (pre, ("result", post)) (*contract*),
             false (*terminates*),
             None (*body*),
             false (*virtual*),
@@ -4593,7 +4593,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
             false (*nonghost_callers_only*),
             None
             (*implemented function type, with function type type arguments and function type arguments*),
-            Some (EmpAsn adt_def_loc, post) (*contract*),
+            Some (EmpAsn adt_def_loc, ("result", post)) (*contract*),
             false (*terminates*),
             Some
               ( [
@@ -4669,7 +4669,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
         false (*nonghost_callers_only*),
         None
         (*implemented function type, with function type type arguments and function type arguments*),
-        Some (pre, post) (*contract*),
+        Some (pre, ("result", post)) (*contract*),
         false (*terminates*),
         None (*body*),
         false (*virtual*),
@@ -4761,7 +4761,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               false (*nonghost_callers_only*),
               None
               (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               None (*body*),
               false (*virtual*),
@@ -4865,7 +4865,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               false (*nonghost_callers_only*),
               None
               (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               None (*body*),
               false (*virtual*),
@@ -4948,7 +4948,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               false (*nonghost_callers_only*),
               None
               (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               None (*body*),
               false (*virtual*),
@@ -5434,7 +5434,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               [(PtrTypeExpr (def_loc, StructTypeExpr (def_loc, Some name, None, [], tparams_targs)), "p")],
               false (*nonghost_callers_only*),
               None (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               Some ([ExprStmt (CallExpr (def_loc, "#assume", [], [], [LitPat (False def_loc)], Static))], def_loc) (*body*),
               false (*virtual*),
@@ -5479,7 +5479,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               [(PtrTypeExpr (def_loc, StructTypeExpr (def_loc, Some name, None, [], tparams_targs)), "p"); (ManifestTypeExpr (def_loc, RealType), "coef")],
               false (*nonghost_callers_only*),
               None (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               Some ([ExprStmt (CallExpr (def_loc, "#assume", [], [], [LitPat (False def_loc)], Static))], def_loc) (*body*),
               false (*virtual*),
@@ -5511,7 +5511,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               [(PtrTypeExpr (def_loc, StructTypeExpr (def_loc, Some name, None, [], tparams_targs)), "p")],
               false (*nonghost_callers_only*),
               None (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               Some ([ExprStmt (CallExpr (def_loc, "#assume", [], [], [LitPat (False def_loc)], Static))], def_loc) (*body*),
               false (*virtual*),
@@ -5545,7 +5545,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               [(PtrTypeExpr (def_loc, StructTypeExpr (def_loc, Some name, None, [], tparams_targs)), "p")],
               false (*nonghost_callers_only*),
               None (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               Some ([ExprStmt (CallExpr (def_loc, "#assume", [], [], [LitPat (False def_loc)], Static))], def_loc) (*body*),
               false (*virtual*),
@@ -5579,7 +5579,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
               [(PtrTypeExpr (def_loc, StructTypeExpr (def_loc, Some name, None, [], tparams_targs)), "p")],
               false (*nonghost_callers_only*),
               None (*implemented function type, with function type type arguments and function type arguments*),
-              Some (pre, post) (*contract*),
+              Some (pre, ("result", post)) (*contract*),
               false (*terminates*),
               Some ([ExprStmt (CallExpr (def_loc, "#assume", [], [], [LitPat (False def_loc)], Static))], def_loc) (*body*),
               false (*virtual*),
@@ -5711,7 +5711,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                                  ps,
                                  false,
                                  None,
-                                 Some (pre, post),
+                                 Some (pre, (result_var, post)),
                                  terminates,
                                  body,
                                  false,
@@ -5736,7 +5736,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                                              self_ty_typeid,
                                              VarPat (lf, "Self_typeid") ),
                                          Ast.Sep
-                                           (lf, pre, Ast.EnsuresAsn (lf, post))
+                                           (lf, pre, Ast.EnsuresAsn (lf, result_var, post))
                                        ) )
                                in
                                let post = Ast.EmpAsn lf in
@@ -5750,7 +5750,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                                       ps,
                                       false,
                                       None,
-                                      Some (pre, post),
+                                      Some (pre, ("result", post)),
                                       terminates,
                                       None,
                                       false,

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -820,14 +820,14 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * type_ map (* params *)
       * asn (* pre *)
       * type_ map (* tenv after pre *)
-      * asn (* post *)
+      * (string (* result variable *) * asn) (* post *)
       * bool (* terminates *)
       * ((string * (expr * bool (* is written *)) option) list (* init list *) * (stmt list * loc)) option option
     type cxx_dtor_info =
         loc 
       * asn (* pre *)
       * type_ map (* tenv after pre *)
-      * asn (* post *)
+      * (string (* result variable *) * asn) (* post *)
       * bool (* terminates *)
       * (stmt list * loc) option option
       * bool (* is_virtual *)
@@ -942,7 +942,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * bool (* nonghost_callers_only *)
       * asn (* precondition *)
       * (string * type_) list (* type environment after precondition *)
-      * asn (* postcondition *)
+      * (string (* result variable *) * asn) (* postcondition *)
       * bool  (* terminates *)
       * (string * pred_fam_info map * type_ list * (loc * string) list) option (* implemented function type, with function type type arguments and function type arguments *)
       * (stmt list * loc (* closing brace *) ) option option (* body; None if prototype; Some None if ? *)
@@ -956,7 +956,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       * type_ map (* parameters of the function type *)
       * type_ map (* parameters of the function *)
       * asn (* precondition *)
-      * asn (* postcondition *)
+      * (string (* result variable *) * asn) (* postcondition *)
       * bool (* terminates *)
       * pred_fam_info map (* the is_xyz predicate, if any *)
       * termnode (* typeid *)
@@ -6694,14 +6694,14 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           let (wbody, tenv, infTps) = check_asn tenv body in
           (CoefAsn (l, wcoef, wbody), merge_tenvs l tenv' tenv, infTps)
         end
-      | EnsuresAsn (l, body) ->
+      | EnsuresAsn (l, result_var, body) ->
         begin match try_assoc "#pre" tenv with
           None -> static_error l "Ensures clause not allowed here." None
         | Some rt ->
           let tenv = List.remove_assoc "#pre" tenv in
-          let tenv = if rt = Void then tenv else ("result", rt)::tenv in
+          let tenv = if rt = Void then tenv else (result_var, rt)::tenv in
           let (wbody, tenv, infTps) = check_asn tenv body in
-          (EnsuresAsn (l, wbody), tenv, infTps)
+          (EnsuresAsn (l, result_var, wbody), tenv, infTps)
         end
       | e ->
         let a =


### PR DESCRIPTION
This might be useful for specifying unwind behavior in Rust.
