### PR TITLE
[Rust] Eliminate unsound struct layout assumption

### DIFF
--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -4,6 +4,14 @@ abstract_type type_info;
 
 @*/
 
+mod hint {
+
+    fn assert_unchecked(b: bool);
+    //@ req b;
+    //@ ens true;
+
+}
+
 mod ops {
 
     trait FnMut<Output, Args> {

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -6066,7 +6066,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         begin match fields with
         | [] -> if packed then assume_axiom (fun targs_env targs s -> (sn ^ "_packed_size", s, ctxt#mk_eq s (current targs_env)))
         | (f, (lf, Real, t, Some offset_func, init))::fs ->
-          if is_first || packed then
+          if is_first && (fs = [] || dialect <> Some Rust) || packed then
             assume_axiom begin fun targs_env targs s ->
               let offset = ctxt#mk_app offset_func targs in
               (sn ^ "_" ^ f ^ "_packed_offset", offset, ctxt#mk_eq offset (current targs_env))

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1740,6 +1740,8 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           match t with
             StaticArrayType (_, _) | StructType _ | UnionType _ ->
             produce_c_object l coef (field_address l env addr sn targs f) t eval_h init allowGhostFields true h env $. fun h env ->
+            let Some offsetFunc = offset in
+            assume (mk_field_pointer_within_limits addr (ctxt#mk_app offsetFunc (List.map (typeid_of_core l env) targs))) $. fun () ->
             iter h env fields inits
           | _ ->
             begin fun cont ->

--- a/tests/rust/safe_abstraction/arc.rs
+++ b/tests/rust/safe_abstraction/arc.rs
@@ -28,7 +28,8 @@ pred_ctor Arc_inv<T>(dk: lifetime_t, gid: isize, ptr: *ArcInner<T>)() = counting
 
 pred<T> <Arc<T>>.own(t, arc) = [_]std::ptr::NonNull_own(default_tid, arc.ptr) &*& [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInner<T>>(arc.ptr) == ptr &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*& ticket(dlft_pred(dk), gid, ?frac) &*& [frac]dlft_pred(dk)(gid, false) &*&
-    [_](<T>.share)(dk, default_tid, &(*ptr).data) &*& pointer_within_limits(&(*ptr).data) == true &*& is_Send(typeid(T)) == true;
+    [_](<T>.share)(dk, default_tid, &(*ptr).data) &*&
+    pointer_within_limits(&(*ptr).strong) == true &*& pointer_within_limits(&(*ptr).data) == true &*& is_Send(typeid(T)) == true;
 
 lem Arc_own_mono<T0, T1>()
     req type_interp::<T0>() &*& type_interp::<T1>() &*& Arc_own::<T0>(?t, ?v) &*& is_subtype_of::<T0, T1>() == true;
@@ -43,6 +44,7 @@ pred_ctor ticket_(dk: lifetime_t, gid: isize, frac: real)(;) = ticket(dlft_pred(
 pred<T> <Arc<T>>.share(k, t, l) = [_]exists(?nnp) &*& [_]frac_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
     [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInner<T>>(nnp) == ptr &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
     [_]exists(?frac) &*& [_]frac_borrow(k, ticket_(dk, gid, frac)) &*& [_]frac_borrow(k, lifetime_token_(frac, dk)) &*& [_](<T>.share)(dk, default_tid, &(*ptr).data) &*&
+    pointer_within_limits(&(*ptr).strong) == true &*&
     pointer_within_limits(&(*ptr).data) == true;
 
 lem Arc_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Arc<T>)
@@ -68,6 +70,7 @@ lem Arc_fbor_split<T>(k: lifetime_t, t: thread_id_t, l: *Arc<T>)
         [_]exists(?nnp) &*& full_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
         [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInner<T>>(nnp) == ptr &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
         [_]exists(?frac) &*& full_borrow(k, ticket_(dk, gid, frac)) &*& full_borrow(k, lifetime_token_(frac, dk)) &*& [_](<T>.share)(dk, default_tid, &(*ptr).data) &*&
+        pointer_within_limits(&(*ptr).strong) == true &*&
         pointer_within_limits(&(*ptr).data) == true;
 {
     let klong = open_full_borrow_strong_m(k, Arc_full_borrow_content(t, l), qk);
@@ -201,6 +204,7 @@ impl<T: Sync + Send> Arc<T> {
 
     unsafe fn strong_count_inner<'a>(ptr: &'a ArcInner<T>) -> usize
     /*@ req [?qa]lifetime_token(?a) &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
+        pointer_within_limits(&(*ptr).strong) == true &*&
         [_]exists(?frac) &*& [_]frac_borrow(a, ticket_(dk, gid, frac)) &*& [_]frac_borrow(a, lifetime_token_(frac, dk));
     @*/
     //@ ens [qa]lifetime_token(a);
@@ -248,6 +252,7 @@ impl<T: Sync + Send> Arc<T> {
 
     unsafe fn clone_inner<'a>(ptr: &'a ArcInner<T>)
     /*@ req [?qa]lifetime_token(?a) &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
+        pointer_within_limits(&(*ptr).strong) == true &*&
         [_]exists(?frac) &*& [_]frac_borrow(a, ticket_(dk, gid, frac)) &*& [_]frac_borrow(a, lifetime_token_(frac, dk)); @*/
     //@ ens [qa]lifetime_token(a) &*& ticket(dlft_pred(dk), gid, ?frac1) &*& [frac1]dlft_pred(dk)(gid, false);
     {

--- a/tests/rust/safe_abstraction/arc_u32.rs
+++ b/tests/rust/safe_abstraction/arc_u32.rs
@@ -30,7 +30,7 @@ pred_ctor Arc_inv(dk: lifetime_t, gid: isize, ptr: *ArcInnerU32)() = counting(dl
 
 pred <ArcU32>.own(t, arcU32) = [_]std::ptr::NonNull_own(default_tid, arcU32.ptr) &*& [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInnerU32>(arcU32.ptr) == ptr &*&
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*& ticket(dlft_pred(dk), gid, ?frac) &*& [frac]dlft_pred(dk)(gid, false) &*&
-    [_]u32_share(dk, default_tid, &(*ptr).data) &*& pointer_within_limits(&(*ptr).data) == true;
+    [_]u32_share(dk, default_tid, &(*ptr).data) &*& pointer_within_limits(&(*ptr).strong) == true &*& pointer_within_limits(&(*ptr).data) == true;
 
 pred_ctor Arc_frac_bc(l: *ArcU32, nnp: std::ptr::NonNull<ArcInnerU32>)(;) = (*l).ptr |-> nnp;
 pred_ctor ticket_(dk: lifetime_t, gid: isize, frac: real)(;) = ticket(dlft_pred(dk), gid, frac) &*& [frac]ghost_cell(gid, false);
@@ -38,6 +38,7 @@ pred_ctor ticket_(dk: lifetime_t, gid: isize, frac: real)(;) = ticket(dlft_pred(
 pred <ArcU32>.share(k, t, l) = [_]exists(?nnp) &*& [_]frac_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
     [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInnerU32>(nnp) == ptr &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
     [_]exists(?frac) &*& [_]frac_borrow(k, ticket_(dk, gid, frac)) &*& [_]frac_borrow(k, lifetime_token_(frac, dk)) &*& [_]u32_share(dk, default_tid, &(*ptr).data) &*&
+    pointer_within_limits(&(*ptr).strong) == true &*&
     pointer_within_limits(&(*ptr).data) == true;
 
 lem ArcU32_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *ArcU32)
@@ -63,6 +64,7 @@ lem ArcU32_fbor_split(k: lifetime_t, t: thread_id_t, l: *ArcU32)
         [_]exists(?nnp) &*& full_borrow(k, Arc_frac_bc(l, nnp)) &*& [_]std::ptr::NonNull_own(default_tid, nnp) &*&
         [_]exists(?ptr) &*& std::ptr::NonNull_ptr::<ArcInnerU32>(nnp) == ptr &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
         [_]exists(?frac) &*& full_borrow(k, ticket_(dk, gid, frac)) &*& full_borrow(k, lifetime_token_(frac, dk)) &*& [_]u32_share(dk, default_tid, &(*ptr).data) &*&
+        pointer_within_limits(&(*ptr).strong) == true &*&
         pointer_within_limits(&(*ptr).data) == true;
 {
     let klong = open_full_borrow_strong_m(k, ArcU32_full_borrow_content(t, l), qk);
@@ -190,6 +192,7 @@ impl ArcU32 {
 
     unsafe fn strong_count_inner<'a>(ptr: &'a ArcInnerU32) -> usize
     /*@ req [?qa]lifetime_token(?a) &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
+        pointer_within_limits(&(*ptr).strong) == true &*&
         [_]exists(?frac) &*& [_]frac_borrow(a, ticket_(dk, gid, frac)) &*& [_]frac_borrow(a, lifetime_token_(frac, dk));
     @*/
     //@ ens [qa]lifetime_token(a);
@@ -237,6 +240,7 @@ impl ArcU32 {
 
     unsafe fn clone_inner<'a>(ptr: &'a ArcInnerU32)
     /*@ req [?qa]lifetime_token(?a) &*& [_]exists(?dk) &*& [_]exists(?gid) &*& [_]atomic_space(Marc, Arc_inv(dk, gid, ptr)) &*&
+        pointer_within_limits(&(*ptr).strong) == true &*&
         [_]exists(?frac) &*& [_]frac_borrow(a, ticket_(dk, gid, frac)) &*& [_]frac_borrow(a, lifetime_token_(frac, dk)); @*/
     //@ ens [qa]lifetime_token(a) &*& ticket(dlft_pred(dk), gid, ?frac1) &*& [frac1]dlft_pred(dk)(gid, false);
     {

--- a/tests/rust/safe_abstraction/generic_pair.rs
+++ b/tests/rust/safe_abstraction/generic_pair.rs
@@ -38,6 +38,7 @@ lem Pair_send<A, B>(t1: thread_id_t)
 }
 
 pred<A, B> <Pair<A, B>>.share(k, t, l) =
+    pointer_within_limits(&(*l).fst) == true &*&
     [_](<A>.share)(k, t, &(*l).fst) &*&
     pointer_within_limits(&(*l).snd) == true &*&
     [_](<B>.share)(k, t, &(*l).snd) &*&
@@ -70,6 +71,7 @@ lem Pair_split_full_borrow_m<A, B>(k: lifetime_t, t: thread_id_t, l: *Pair<A, B>
         full_borrow(k, <B>.full_borrow_content(t, &(*l).snd)) &*&
         full_borrow(k, struct_Pair_padding_(l)) &*&
         [q]lifetime_token(k) &*&
+        pointer_within_limits(&(*l).fst) == true &*&
         pointer_within_limits(&(*l).snd) == true;
 {
     let klong = open_full_borrow_strong_m(k, Pair_full_borrow_content::<A, B>(t, l), q);
@@ -110,6 +112,7 @@ lem Pair_split_full_borrow<A, B>(k: lifetime_t, t: thread_id_t, l: *Pair<A, B>) 
         full_borrow(k, <A>.full_borrow_content(t, &(*l).fst)) &*&
         full_borrow(k, <B>.full_borrow_content(t, &(*l).snd)) &*&
         [q]lifetime_token(k) &*&
+        pointer_within_limits(&(*l).fst) == true &*&
         pointer_within_limits(&(*l).snd) == true;
 {
     produce_type_interp::<A>();
@@ -197,6 +200,7 @@ lem init_ref_Pair<A, B>(p: *Pair<A, B>)
     
     init_ref_share_m(k, t, &(*p).fst);
     init_ref_share_m(k, t, &(*p).snd);
+    note(pointer_within_limits(ref_origin(&(*p).fst)));
     note(pointer_within_limits(ref_origin(&(*p).snd)));
     close Pair_share::<A, B>(k, t, p);
     leak Pair_share(k, t, p);

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -35,6 +35,7 @@ pred_ctor Mutex_frac_borrow_content<T>(kfcc: lifetime_t, l: *Mutex<T>)(;) =
     sys::locks::SysMutex_share(&(*l).inner, full_borrow_(kfcc, <T>.full_borrow_content(t0, &(*l).data))) &*& struct_Mutex_padding(l);
 
 pred<T> <Mutex<T>>.share(k, t, l) =
+    pointer_within_limits(&(*l).inner) == true &*&
     exists_np(?kfcc) &*& lifetime_inclusion(k, kfcc) == true &*& frac_borrow(k, Mutex_frac_borrow_content::<T>(kfcc, l));
 
 lem Mutex_share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *Mutex<T>)
@@ -91,6 +92,7 @@ lem Mutex_share_full<T>(k: lifetime_t, t: thread_id_t, l: *Mutex<T>)
             close Mutex_fbc_inner::<T>(l)();
         }{
             open Mutex_fbc_inner::<T>(l)();
+            points_to_limits(&(*l).inner);
             assert (*l).inner |-> ?inner;
             close full_borrow_(k, <T>.full_borrow_content(t0, &(*l).data))();
             sys::locks::SysMutex_renew(inner, full_borrow_(k, <T>.full_borrow_content(t0, &(*l).data)));
@@ -142,6 +144,7 @@ pub struct MutexGuard<'a, T: Send> {
 
 // TODO: Is this extra lifetime `klong` necessary here?
 pred<'a, T> <MutexGuard<'a, T>>.own(t, mutexGuard) =
+    pointer_within_limits(&(*mutexGuard.lock).inner) == true &*&
     [_]exists_np(?klong) &*& lifetime_inclusion('a, klong) == true &*& [_]frac_borrow('a, Mutex_frac_borrow_content(klong, mutexGuard.lock))
     &*& sys::locks::SysMutex_locked(&(*mutexGuard.lock).inner, full_borrow_(klong, <T>.full_borrow_content(t0, &(*mutexGuard.lock).data)), t)
     &*& full_borrow(klong, <T>.full_borrow_content(t0, &(*mutexGuard.lock).data));

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -36,6 +36,7 @@ pred_ctor MutexU32_frac_borrow_content(kfcc: lifetime_t, l: *MutexU32)(;) =
     SysMutex_share(&(*l).inner, full_borrow_(kfcc, u32_full_borrow_content(t0, &(*l).data))) &*& struct_MutexU32_padding(l);
 
 pred <MutexU32>.share(k, t, l) =
+    pointer_within_limits(&(*l).inner) == true &*&
     exists_np(?kfcc) &*& lifetime_inclusion(k, kfcc) == true &*& frac_borrow(k, MutexU32_frac_borrow_content(kfcc, l));
 
 lem MutexU32_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *MutexU32)
@@ -84,6 +85,7 @@ lem MutexU32_share_full(k: lifetime_t, t: thread_id_t, l: *MutexU32)
         }{
             open MutexU32_fbc_inner(l)();
             assert (*l).inner |-> ?inner;
+            points_to_limits(&(*l).inner);
             close full_borrow_(k, u32_full_borrow_content(t0, &(*l).data))();
             SysMutex_renew(inner, full_borrow_(k, u32_full_borrow_content(t0, &(*l).data)));
             SysMutex_share_full(&(*l).inner);
@@ -185,6 +187,7 @@ lem MutexGuardU32_sync(km: lifetime_t, t: thread_id_t, t1: thread_id_t)
 /*@
 // TODO: Is this extra lifetime `klong` necessary here?
 pred_ctor MutexGuardU32_own_(km: lifetime_t)(t: thread_id_t, lock: *MutexU32) =
+    pointer_within_limits(&(*lock).inner) == true &*&
     [_]exists_np(?klong) &*& lifetime_inclusion(km, klong) == true &*& [_]frac_borrow(km, MutexU32_frac_borrow_content(klong, lock))
     &*& SysMutex_locked(&(*lock).inner, full_borrow_(klong, u32_full_borrow_content(t0, &(*lock).data)), t)
     &*& full_borrow(klong, u32_full_borrow_content(t0, &(*lock).data));
@@ -220,6 +223,7 @@ impl MutexGuardU32 {
     unsafe fn new<'a>(lock: &'a MutexU32) -> MutexGuardU32
     /*@ req thread_token(?t) &*& [?qa]lifetime_token(?a) &*& [_]exists_np(?km) &*& lifetime_inclusion(a, km) == true
         &*& [_]frac_borrow(a, MutexU32_frac_borrow_content(km, lock))
+        &*& pointer_within_limits(&(*lock).inner) == true
         &*& SysMutex_locked(&(*lock).inner, full_borrow_(km, u32_full_borrow_content(t0, &(*lock).data)), t)
         &*& full_borrow(km, u32_full_borrow_content(t0, &(*lock).data));
     @*/

--- a/tests/rust/safe_abstraction/rc_u32.rs
+++ b/tests/rust/safe_abstraction/rc_u32.rs
@@ -26,6 +26,7 @@ pred <RcU32>.own(t, rcU32) =
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(std::ptr::NonNull_ptr(rcU32.ptr)), rc_na_inv(dk, gid, std::ptr::NonNull_ptr(rcU32.ptr), t)) &*&
     ticket(dlft_pred(dk), gid, ?frac) &*& [frac]dlft_pred(dk)(gid, false) &*&
     [_]frac_borrow(dk, u32_full_borrow_content(t, &(*std::ptr::NonNull_ptr::<RcBoxU32>(rcU32.ptr)).value)) &*&
+    pointer_within_limits(&(*std::ptr::NonNull_ptr::<RcBoxU32>(rcU32.ptr)).strong) == true &*&
     pointer_within_limits(&(*std::ptr::NonNull_ptr::<RcBoxU32>(rcU32.ptr)).value) == true;
 
 pred_ctor Rc_frac_bc(l: *RcU32, nnp: std::ptr::NonNull<RcBoxU32>)(;) = (*l).ptr |-> nnp;
@@ -35,6 +36,7 @@ pred <RcU32>.share(k, t, l) =
     [_]exists(?dk) &*& [_]exists(?gid) &*& [_]na_inv(t, MaskNshrSingle(std::ptr::NonNull_ptr(nnp)), rc_na_inv(dk, gid, std::ptr::NonNull_ptr(nnp), t)) &*&
     [_]exists(?frac) &*& [_]frac_borrow(k, ticket_(dk, gid, frac)) &*& [_]frac_borrow(k, lifetime_token_(frac, dk)) &*&
     [_]frac_borrow(dk, u32_full_borrow_content(t, &(*std::ptr::NonNull_ptr::<RcBoxU32>(nnp)).value)) &*&
+    pointer_within_limits(&(*std::ptr::NonNull_ptr::<RcBoxU32>(nnp)).strong) == true &*&
     pointer_within_limits(&(*std::ptr::NonNull_ptr::<RcBoxU32>(nnp)).value) == true;
 
 lem RcU32_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *RcU32)
@@ -63,6 +65,7 @@ lem RcU32_fbor_split(t: thread_id_t, l: *RcU32) -> std::ptr::NonNull<RcBoxU32> /
         [_]na_inv(t, MaskNshrSingle(std::ptr::NonNull_ptr(result)), rc_na_inv(dk, gid, std::ptr::NonNull_ptr(result), t)) &*&
         [_]exists(?frac) &*& full_borrow(k, ticket_(dk, gid, frac)) &*& full_borrow(k, lifetime_token_(frac, dk)) &*&
         [_]frac_borrow(dk, u32_full_borrow_content(t, &(*std::ptr::NonNull_ptr::<RcBoxU32>(result)).value)) &*&
+        pointer_within_limits(&(*std::ptr::NonNull_ptr::<RcBoxU32>(result)).strong) == true &*&
         pointer_within_limits(&(*std::ptr::NonNull_ptr::<RcBoxU32>(result)).value) == true &*&
         [q]lifetime_token(k);
 {
@@ -200,7 +203,7 @@ impl Clone for RcU32 {
             //@ assert [_]exists::<std::ptr::NonNull<RcBoxU32>>(?nnp);
             //@ open_frac_borrow('a, Rc_frac_bc(self, nnp), _q_a/2);
             //@ open [?qp]Rc_frac_bc(self, nnp)();
-            let strong = self.ptr.as_ref().strong.get(); //TODO: Why do we not get pointer_within_limits req here?
+            let strong = self.ptr.as_ref().strong.get();
             //@ assert [_]exists::<lifetime_t>(?dk) &*& [_]exists::<usize>(?gid) &*& [?df]exists::<real>(?frac);
             //@ open_frac_borrow('a, ticket_(dk, gid, frac), _q_a/4);
             //@ open [?qp_t]ticket_(dk, gid, frac)();
@@ -237,8 +240,8 @@ impl Drop for RcU32 {
     {
         unsafe {
             //@ open RcU32_full_borrow_content(_t, self)();
-            let strong = self.ptr.as_ref().strong.get();
             //@ open RcU32_own(_t, ?rcU32);
+            let strong = self.ptr.as_ref().strong.get();
             //@ let nnp = rcU32.ptr;
             //@ assert [_]exists::<lifetime_t>(?dk) &*& [_]exists::<usize>(?gid);
             //@ let ptr = std::ptr::NonNull_ptr::<RcBoxU32>(nnp);

--- a/tests/rust/struct_layout.rs
+++ b/tests/rust/struct_layout.rs
@@ -1,0 +1,10 @@
+struct Foo {
+    f1: i32,
+    f2: i32,
+}
+
+fn main() {
+    let f = Foo { f1: 42, f2: 24 };
+
+    unsafe { std::hint::assert_unchecked(&raw const f as usize == &raw const f.f1 as usize); } //~should_fail
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -1,4 +1,5 @@
 begin_parallel
+verifast -allow_dead_code -allow_should_fail struct_layout.rs
 verifast ghost_cmd_inj.rs
 verifast parser_test.rs
 verifast -allow_should_fail type_pred_defs_for_imported_structs.rs


### PR DESCRIPTION
VeriFast used to reuse the C logic unchanged, which assumes the first field has offset 0. It now makes no assumptions (except for a struct with just one field).
