### PR TITLE
Don't crash when 'this' is used in Rust/C

### DIFF
--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -1300,10 +1300,10 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           match try_assoc' Ghost (pn,ilist) g predctormap with
             None ->
             begin match try_assoc "this" tenv with
-              None -> static_error l "No such predicate instance." None
             | Some (ObjType (target_tn, _) | PtrType (StructType (target_tn, _))) ->
               let this = List.assoc "this" env in
               open_instance_predicate this target_tn
+            | _ -> static_error l "No such predicate instance." None
             end
           | Some (PredCtorInfo (lp, predctor_tparams, ps1, ps2, inputParamCount, body, funcsym)) ->
             reportUseSite DeclKind_Predicate lp l;

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -12,6 +12,7 @@ verifast -allow_should_fail pred_arg_lft.rs
 verifast -allow_should_fail -allow_dead_code lemma_without_body.rs
 verifast -allow_should_fail -allow_dead_code assume_stmt.rs
 verifast hidden_locals.rs
+verifast -allow_should_fail -allow_dead_code this_pred.rs
 begin_sequential
 cd unverified
   cd platform

--- a/tests/rust/this_pred.rs
+++ b/tests/rust/this_pred.rs
@@ -1,0 +1,3 @@
+fn foo(this: i32) {
+    //@ open bar(); //~should_fail
+}


### PR DESCRIPTION
Fixes #671
