### PR TITLE
Reduce fixpoints with typeid-carrying tparams

### DIFF
--- a/examples/busywaiting/flexiblespecs/ticketlock-stronger/cohortlock.c
+++ b/examples/busywaiting/flexiblespecs/ticketlock-stronger/cohortlock.c
@@ -1,4 +1,4 @@
-// tab_size:2
+// tab_size:2 verifast_options{I:../..}
 
 // Justus Fasse and Bart Jacobs. Expressive modular verification of termination for busy-waiting programs. 2023.
 

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -2709,7 +2709,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               end
             | _ -> static_error l "Fixpoint function must switch on a parameter." None
           in
-          let fsym = mk_func_symbol g fsym_paramtypes (provertype_of_type rt) (Proverapi.Fixpoint (subtype, index)) in
+          let fsym = mk_func_symbol g fsym_paramtypes (provertype_of_type rt) (Proverapi.Fixpoint (subtype, List.length typeid_paramtypes + index)) in
           iter (pn,ilist) imap ((g, (l, tparams, rt, List.map (fun (p, t) -> p, t) pmap, fsym))::pfm) pfprm ((g, (l, tparams, rt, pmap, Some index, body, pn, ilist, fst fsym))::fpm) ds
         | Some ([ReturnStmt (lr, Some e) as body], _) ->
           let fsym = mk_func_symbol g fsym_paramtypes (provertype_of_type rt) Proverapi.Uninterp in

--- a/tests/rust/safe_abstraction/linked_list.rs
+++ b/tests/rust/safe_abstraction/linked_list.rs
@@ -1,4 +1,4 @@
-// verifast_options{prover:z3v4.5 skip_specless_fns}
+// verifast_options{skip_specless_fns}
 
 //! A doubly-linked list with owned nodes.
 //!

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -93,7 +93,7 @@ cd safe_abstraction
     verifast -allow_assume proof_obligs_quick_fix_test_generic_result.rs
     del proof_obligs_quick_fix_test_generic_result.rs
   end_sequential
-  verifast -skip_specless_fns -prover z3v4.5 -allow_assume linked_list.rs
+  verifast -skip_specless_fns -allow_assume linked_list.rs
   ifnotwindows rustup run nightly-2024-11-23 vf-rust-mir-exporter btree_node.rs > /dev/null 2> /dev/null
 cd ..
 end_parallel


### PR DESCRIPTION
Fixes a bug where recursive fixpoint functions that have type parameters that carry a typeid would not reduce when using Redux because the index of the inductive argument was not reported to Redux correctly.

linked_list.rs now verifies with Redux, in half a second.
