### PR TITLE
[Rust] thread_token(?_t) &*& _t == currentThread

### DIFF
--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -21,8 +21,8 @@ struct str_ref<'a> { ptr: *u8, len: usize }
 pred junk();
 
 fn_type main_full(mainModule: i32) = fn();
-    req thread_token(?_t);
-    ens thread_token(_t) &*& junk();
-    on_unwind_ens thread_token(_t);
+    req thread_token(currentThread);
+    ens thread_token(currentThread) &*& junk();
+    on_unwind_ens thread_token(currentThread);
 
 @*/

--- a/rust_tutorials/purely_unsafe/solutions/threads.rs
+++ b/rust_tutorials/purely_unsafe/solutions/threads.rs
@@ -1,4 +1,4 @@
-// verifast_options{extern:../../../tests/rust/unverified/platform disable_overflow_check}
+// verifast_options{ignore_unwind_paths extern:../../../tests/rust/unverified/platform disable_overflow_check}
 
 use std::alloc::{Layout, alloc, handle_alloc_error};
 //use platform::threading::Thread;

--- a/src/assertions.ml
+++ b/src/assertions.ml
@@ -812,14 +812,14 @@ module Assertions(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       result
   and lookup_integer__chunk h0 env l tp t =
     match int_rank_and_signedness tp with
-      Some (k, signedness) ->
+      Some (k, signedness) when match dialect with Some Rust -> false | _ -> true ->
       begin match lookup_integer__chunk_core h0 t k signedness with
         None -> assert_false h0 env l ("No matching points-to chunk: integer_(" ^ ctxt#pprint t ^ ", " ^ ctxt#pprint (rank_size_term k) ^ ", " ^ (if signedness = Signed then "true" else "false") ^ ", _)") None
       | Some v ->
         assert_has_type env t tp h0 env l "This read might violate C's effective types rules" None;
         v
       end
-    | None ->
+    | _ ->
     match tp with
       StructType (sn, targs) ->
       let (_, tparams, body, _, structTypeidFunc) = List.assoc sn structmap in

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -3462,7 +3462,12 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
           Sep (loc, pointee_fbc, asn))
         in_out_params asn
     in
-    let pre_na_token = nonatomic_token_b (bind_pat_b thread_id_name) in
+    let pre_na_token =
+      Sep
+        ( contract_loc,
+          nonatomic_token_b (bind_pat_b thread_id_name),
+          Operation ( contract_loc, Eq, [ Var (contract_loc, "_t"); Var (contract_loc, "currentThread") ] ) )
+    in
     let post_na_token = nonatomic_token_b (lit_pat_b thread_id_name) in
     let lft_token_b q_pat_b n =
       let coef_n = "_q_" ^ n in
@@ -3573,7 +3578,12 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
           Static )
     in
     let thread_id_name = "_t" in
-    let pre_na_token = nonatomic_token_b (bind_pat_b thread_id_name) in
+    let pre_na_token =
+      Sep
+        ( limpl,
+          nonatomic_token_b (bind_pat_b thread_id_name),
+          Operation ( limpl, Eq, [ Var (limpl, "_t"); Var (limpl, "currentThread") ] ) )
+    in
     let post_na_token = nonatomic_token_b (lit_pat_b thread_id_name) in
     let lft_token_b q_pat_b n =
       let coef_n = "_q_" ^ n in
@@ -3622,8 +3632,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
         (Some
            (Ast.Sep
               ( ls,
-                Ast.CallExpr
-                  (ls, "thread_token", [], [], [ VarPat (ls, "_t") ], Static),
+                pre_na_token,
                 Ast.CallExpr
                   ( ls,
                     self_ty ^ "_full_borrow_content",
@@ -3664,13 +3673,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
         (Some
            (Ast.Sep
               ( ls,
-                Ast.CallExpr
-                  ( ls,
-                    "thread_token",
-                    [],
-                    [],
-                    [ LitPat (Var (ls, "_t")) ],
-                    Static ),
+                post_na_token,
                 List.fold_right
                   (fun ({ name; ty; loc } : Mir.field_def_tr) asn ->
                     match

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -113,7 +113,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     cont h coef value
 
   let current_thread_name = "currentThread"
-  let current_thread_type = intType
+  let current_thread_type = match dialect with Some Rust -> AbstractType "thread_id_t" | _ -> intType
   
   (* Region: function contracts *)
   

--- a/tests/rust/purely_unsafe/simple_mutex/spec/lib.rsspec
+++ b/tests/rust/purely_unsafe/simple_mutex/spec/lib.rsspec
@@ -4,7 +4,7 @@ struct Mutex;
 
 pred Mutex(mutex: Mutex, inv_: pred(););
 
-pred Mutex_held(mutex: Mutex, inv_: pred(), owner: usize, frac: real);
+pred Mutex_held(mutex: Mutex, inv_: pred(), owner: thread_id_t, frac: real);
 
 @*/
 

--- a/tests/rust/purely_unsafe/simple_mutex/src/lib.rs
+++ b/tests/rust/purely_unsafe/simple_mutex/src/lib.rs
@@ -31,7 +31,7 @@ pub pred Mutex(mutex: Mutex, inv_: pred();) =
     ghost_cell::<unit>(held_token, unit) &*&
     atomic_space(MaskTop, Mutex_inv(mutex.mutex, held_token, held_frac_cell, inv_));
 
-pub pred Mutex_held(mutex: Mutex, inv_: pred(), owner: usize, frac: real) =
+pub pred Mutex_held(mutex: Mutex, inv_: pred(), owner: thread_id_t, frac: real) =
     [frac]platform::threading::Mutex(mutex.mutex, ?ghost_cell_id) &*&
     [frac]ghost_cell::<i32>(ghost_cell_id, ?ghost_cell0_id) &*&
     [frac]ghost_cell::<pair<i32, i32>>(ghost_cell0_id, pair(?held_token, ?held_frac_cell)) &*&

--- a/tests/rust/safe_abstraction/mutex.rs
+++ b/tests/rust/safe_abstraction/mutex.rs
@@ -187,7 +187,7 @@ impl<T: Send> Mutex<T> {
     Note that in either case it is not undefined behaviour.
     */
     pub fn lock<'a>(&'a self) -> MutexGuard<'a, T>
-    //@ req thread_token(?t) &*& [?qa]lifetime_token('a) &*& [_]Mutex_share('a, t, self);
+    //@ req thread_token(?t) &*& t == currentThread &*& [?qa]lifetime_token('a) &*& [_]Mutex_share('a, t, self);
     //@ ens thread_token(t) &*& [qa]lifetime_token('a) &*& MutexGuard_own::<'a, T>(t, result);
     {
         unsafe {
@@ -300,7 +300,7 @@ impl<'b, T: Send> DerefMut for MutexGuard<'b, T> {
 impl<'a, T: Send> Drop for MutexGuard<'a, T> {
 
     fn drop<'b>(self: &'b mut MutexGuard<'a, T>)
-    //@ req thread_token(?t) &*& [?qa]lifetime_token('a) &*& MutexGuard_full_borrow_content::<'a, T>(t, self)();
+    //@ req thread_token(?t) &*& t == currentThread &*& [?qa]lifetime_token('a) &*& MutexGuard_full_borrow_content::<'a, T>(t, self)();
     //@ ens thread_token(t) &*& [qa]lifetime_token('a) &*& (*self).lock |-> ?lock &*& [_]Mutex_share('a, t, lock) &*& struct_MutexGuard_padding(self);
     {
         //@ open MutexGuard_full_borrow_content::<'a, T>(t, self)();

--- a/tests/rust/safe_abstraction/mutex_u32.rs
+++ b/tests/rust/safe_abstraction/mutex_u32.rs
@@ -143,7 +143,7 @@ impl MutexU32 {
     */
     // TODO: remove keyword `unsafe`
     pub unsafe fn lock<'a>(&'a self) -> MutexGuardU32
-    //@ req thread_token(?t) &*& [?qa]lifetime_token(?a) &*& [_]MutexU32_share(a, t, self);
+    //@ req thread_token(?t) &*& t == currentThread &*& [?qa]lifetime_token(?a) &*& [_]MutexU32_share(a, t, self);
     //@ ens thread_token(t) &*& [qa]lifetime_token(a) &*& MutexGuardU32_own_(a)(t, result.lock);
     {
         unsafe {
@@ -305,7 +305,7 @@ impl MutexGuardU32 {
 
     // TODO: It should be an `impl` of `Drop` and a safe function
     unsafe fn drop<'a>(&'a mut self)
-    //@ req thread_token(?t) &*& exists(?km) &*& [?qkm]lifetime_token(km) &*& MutexGuardU32_full_borrow_content0(km, t, self)();
+    //@ req thread_token(?t) &*& t == currentThread &*& exists(?km) &*& [?qkm]lifetime_token(km) &*& MutexGuardU32_full_borrow_content0(km, t, self)();
     //@ ens thread_token(t) &*& [qkm]lifetime_token(km) &*& (*self).lock |-> ?lock &*& [_]MutexU32_share(km, t, lock);
     {
         //@ open MutexGuardU32_full_borrow_content0(km, t, self)();

--- a/tests/rust/safe_abstraction/tree.rs
+++ b/tests/rust/safe_abstraction/tree.rs
@@ -219,7 +219,7 @@ impl Tree {
     }
 
     unsafe fn accept0<'a, V: TreeVisitor>(mut x: *mut Node, mut x_is_new: bool, visitor: &'a mut V)
-    //@ req Tree(?root, 0, ?rootShape) &*& x == root &*& x_is_new &*& thread_token(?t) &*& [?q]lifetime_token(?k) &*& full_borrow(k, <V>.full_borrow_content(t, visitor));
+    //@ req Tree(?root, 0, ?rootShape) &*& x == root &*& x_is_new &*& thread_token(?t) &*& t == currentThread &*& [?q]lifetime_token(?k) &*& full_borrow(k, <V>.full_borrow_content(t, visitor));
     //@ ens Tree(root, 0, rootShape) &*& thread_token(t) &*& [q]lifetime_token(k) &*& full_borrow(k, <V>.full_borrow_content(t, visitor));
     {
         //@ Tree_inv();

--- a/tests/rust/unverified/platform/spec/lib.rsspec
+++ b/tests/rust/unverified/platform/spec/lib.rsspec
@@ -76,29 +76,29 @@ mod threading {
     /*@
 
     pred Mutex(mutex: Mutex; ghost_cell_id: i32);
-    pred Mutex_state(mutex: Mutex; owner: option<usize>);
+    pred Mutex_state(mutex: Mutex; owner: option<thread_id_t>);
 
-    lem_type Mutex_acquire_op(mutex: Mutex, acquirer: usize, P: pred(), Q: pred()) = lem();
+    lem_type Mutex_acquire_op(mutex: Mutex, acquirer: thread_id_t, P: pred(), Q: pred()) = lem();
         req [?f]Mutex_state(mutex, ?state) &*& P() &*& state != none || f == 1;
         ens Mutex_state(mutex, some(acquirer)) &*& state == none &*& Q();
 
-    lem_type Mutex_acquire_ghop(mutex: Mutex, acquirer: usize, pre: pred(), post: pred()) = lem();
+    lem_type Mutex_acquire_ghop(mutex: Mutex, acquirer: thread_id_t, pre: pred(), post: pred()) = lem();
         req atomic_mask(MaskTop) &*& is_Mutex_acquire_op(?op, mutex, acquirer, ?P, ?Q) &*& P() &*& pre();
         ens atomic_mask(MaskTop) &*& is_Mutex_acquire_op(op, mutex, acquirer, P, Q) &*& Q() &*& post();
     
-    lem_type Mutex_try_acquire_op(mutex: Mutex, acquirer: usize, P: pred(), Q: pred(bool)) = lem();
+    lem_type Mutex_try_acquire_op(mutex: Mutex, acquirer: thread_id_t, P: pred(), Q: pred(bool)) = lem();
         req [?f]Mutex_state(mutex, ?state) &*& P() &*& state != none || f == 1;
         ens Mutex_state(mutex, match state { none() => some(acquirer), some(owner) => some(owner) }) &*& Q(state == none);
 
-    lem_type Mutex_try_acquire_ghop(mutex: Mutex, acquirer: usize, pre: pred(), post: pred(bool)) = lem();
+    lem_type Mutex_try_acquire_ghop(mutex: Mutex, acquirer: thread_id_t, pre: pred(), post: pred(bool)) = lem();
         req atomic_mask(MaskTop) &*& is_Mutex_try_acquire_op(?op, mutex, acquirer, ?P, ?Q) &*& P() &*& pre();
         ens atomic_mask(MaskTop) &*& is_Mutex_try_acquire_op(op, mutex, acquirer, P, Q) &*& Q(?success) &*& post(success);
     
-    lem_type Mutex_release_op(mutex: Mutex, releaser: usize, P: pred(), Q: pred()) = lem();
+    lem_type Mutex_release_op(mutex: Mutex, releaser: thread_id_t, P: pred(), Q: pred()) = lem();
         req Mutex_state(mutex, some(releaser)) &*& P();
         ens Mutex_state(mutex, none) &*& Q();
 
-    lem_type Mutex_release_ghop(mutex: Mutex, releaser: usize, pre: pred(), post: pred()) = lem();
+    lem_type Mutex_release_ghop(mutex: Mutex, releaser: thread_id_t, pre: pred(), post: pred()) = lem();
         req atomic_mask(MaskTop) &*& is_Mutex_release_op(?op, mutex, releaser, ?P, ?Q) &*& P() &*& pre();
         ens atomic_mask(MaskTop) &*& is_Mutex_release_op(op, mutex, releaser, P, Q) &*& Q() &*& post();
     

--- a/tests/rust/unverified/sys/spec/lib.rsspec
+++ b/tests/rust/unverified/sys/spec/lib.rsspec
@@ -40,14 +40,13 @@ mod locks {
         //@ req exists::<pred()>(?P) &*& P();
         //@ ens SysMutex(result, P);
 
-        // TODO: Use `current_thread` var in `SysMutex_locked` like in the `threading.h`. The `SysMutex` interface does not need `thread_token` in the contracts.
         unsafe fn lock<'a>(self: &'a Mutex);
-        //@ req thread_token(?t) &*& [?q]SysMutex_share(self, ?P);
-        //@ ens thread_token(t) &*& [q]SysMutex_share(self, P) &*& SysMutex_locked(self, P, t) &*& P();
+        //@ req [?q]SysMutex_share(self, ?P);
+        //@ ens [q]SysMutex_share(self, P) &*& SysMutex_locked(self, P, currentThread) &*& P();
 
         unsafe fn unlock<'a>(self: &'a Mutex);
-        //@ req thread_token(?t) &*& SysMutex_locked(self, ?P, t) &*& P() &*& [?q]SysMutex_share(self, P);
-        //@ ens thread_token(t) &*& [q]SysMutex_share(self, P);
+        //@ req SysMutex_locked(self, ?P, currentThread) &*& P() &*& [?q]SysMutex_share(self, P);
+        //@ ens [q]SysMutex_share(self, P);
         
     }
     


### PR DESCRIPTION
In Rust, the type of currentThread is now thread_id_t.

Fixes the TODO in the sys::lock spec.
