### PR TITLE
[Rust] Support const items in array lengths

### DIFF
--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -2370,6 +2370,13 @@ mod vf_mir_builder {
             ty_const_cpn: ty_const_cpn::Builder<'_>,
         ) {
             debug!("Encoding typesystem constant {:?}", ty_const);
+            let mut ty_const = *ty_const;
+            if let ty::ConstKind::Unevaluated(_) = ty_const.kind() {
+                let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::PostAnalysis, param_env: ty::ParamEnv::empty() };
+                if let Ok(ty_const_normalized) = tcx.try_normalize_erasing_regions(typing_env, ty_const) {
+                    ty_const = ty_const_normalized;
+                }
+            }
             let kind_cpn = ty_const_cpn.init_kind();
             Self::encode_const_kind(tcx, enc_ctx, &ty_const.kind(), kind_cpn);
         }

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -1620,17 +1620,30 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
     | Int int_ty_cpn -> `Int
     | UInt u_int_ty_cpn -> `Uint
     | Char -> `Char
+    | Float -> `Float
     | Adt adt_ty_cpn -> `Adt (decode_adt_ty adt_ty_cpn)
+    | Foreign -> `Foreign
     | RawPtr raw_ptr_ty_cpn -> `RawPtr
     | Ref ref_ty_cpn -> `Ref (decode_ref_ty ref_ty_cpn)
     | FnDef fn_def_ty_cpn -> `FnDef
     | FnPtr fn_ptr_ty_cpn -> `FnPtr
+    | Dynamic -> `Dynamic
+    | Closure -> `Closure
+    | CoroutineClosure -> `CoroutineClosure
+    | Coroutine -> `Coroutine
+    | CoroutineWitness -> `CoroutineWitness
     | Never -> `Never
     | Tuple substs_cpn -> `Tuple
+    | Alias _ -> `Alias
     | Param name -> `Param name
+    | Bound -> `Bound
+    | Placeholder -> `Placeholder
+    | Infer -> `Infer
+    | Error -> `Error
     | Str -> `Str
+    | Array array_ty_cpn -> `Array
+    | Pattern -> `Pattern
     | Slice elem_ty_cpn -> `Slice (decode_ty elem_ty_cpn)
-    | Undefined _ -> `Undefined
 
   and string_of_decoded_type ty =
     match ty with
@@ -1701,7 +1714,11 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
   and translate_ty_const_kind (ck_cpn : TyRd.ConstKind.t) (loc : Ast.loc) =
     let open TyRd.ConstKind in
     match get ck_cpn with
-    | Param _ -> failwith "Todo: ConstKind::Param"
+    | Param _ -> Ast.static_error loc "Todo: ConstKind::Param" None
+    | Infer -> Ast.static_error loc "Todo: ConstKind::Infer" None
+    | Bound -> Ast.static_error loc "Todo: ConstKind::Bound" None
+    | Placeholder -> Ast.static_error loc "Todo: ConstKind::Placeholder" None
+    | Unevaluated -> Ast.static_error loc "Todo: ConstKind::Unevaluated" None
     | Value v_cpn -> (
         let open Value in
         let* ty = translate_ty (ty_get v_cpn) loc in
@@ -1711,7 +1728,8 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
         | Leaf scalar_int_cpn ->
             translate_scalar_int scalar_int_cpn (Mir.basic_type_of ty) loc
         | Branch -> failwith "Todo: ConstKind::ValTree::Branch")
-    | Undefined _ -> Error (`TrTyConstKind "Unknown ConstKind")
+    | Error -> Ast.static_error loc "Todo: ConstKind::Error" None
+    | Expr -> Ast.static_error loc "Todo: ConstKind::Expr" None
 
   and translate_ty_const (ty_const_cpn : TyRd.Const.t) (loc : Ast.loc) =
     let open TyRd.Const in

--- a/tests/rust/purely_unsafe/arrays.rs
+++ b/tests/rust/purely_unsafe/arrays.rs
@@ -1,6 +1,8 @@
+const N: usize = 1;
+
 fn main() {
     unsafe {
-        let xs: [i32; 3] = [10, 20, 30];
+        let xs: [i32; 2 * N + 1] = [10, 20, 30];
         let mut sum = 0;
         let mut p: *const i32 = &raw const xs as *const i32;
         sum += *p;


### PR DESCRIPTION
VeriFast now supports array types whose length is a const expression
that refers to const items. VeriFast will currently fully evaluate
the const expression.

(This is probably just a temporary measure. Eventually, to support
verification of code under const generic parameters, we will need
to support non-literal array lengths.)
