### PR TITLE
[Rust] Public fields

### DIFF
--- a/examples/crypto_ccs/crypto_ccs/crypto/identifiers.c
+++ b/examples/crypto_ccs/crypto_ccs/crypto/identifiers.c
@@ -49,6 +49,7 @@ void write_identifier(char *array, int id)
   /*@ cs_to_ccs_append(chars_of_int(id_val),
                        append(chars_of_int(id_val), chars_of_int(id_val))); @*/
   //@ public_cs(identifier(id_val));
+  //@ chars_to_integer(&id);
 }
 
 void check_identifier(char *array, int id)

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -3005,7 +3005,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
     match ps with
       [] -> cont h
     | (_, x, t, addr) :: ps ->
-      consume_points_to_chunk rules h env [] [] [] l t real_unit real_unit_pat addr RegularPointsTo dummypat $. fun chunk h _ value _ _ _ ->
+      consume_points_to_chunk_ rules h env [] [] [] l t real_unit real_unit_pat addr RegularPointsTo dummypat true $. fun chunk h _ value _ _ _ ->
       cleanup_heapy_locals_core (pn, ilist) l h env ps cont
     in
     match ps, varargsLastParam with

--- a/tests/rust/public_fields.rs
+++ b/tests/rust/public_fields.rs
@@ -1,3 +1,0 @@
-struct Foo {
-    pub v: i32, //~should_fail
-}

--- a/tests/rust/safe_abstraction/public_fields.rs
+++ b/tests/rust/safe_abstraction/public_fields.rs
@@ -1,0 +1,30 @@
+pub struct Pair<A, B> {
+    pub x: A,
+    pub y: B,
+}
+
+pub fn bad_own<A, B>(pair: Pair<A, B>) { //~allow_dead_code
+    unsafe { std::hint::unreachable_unchecked(); } //~should_fail
+} //~allow_dead_code
+
+pub fn bad_share<'a, A, B>(pair: &'a Pair<A, B>) { //~allow_dead_code
+    //@ open <Pair<A, B>>.share('a, _t, pair);
+    unsafe { std::hint::unreachable_unchecked(); } //~should_fail
+}
+
+
+pub fn drop<A, B>(pair: Pair<A, B>) {}
+
+pub fn get_x<'a, A, B>(pair: &'a Pair<A, B>) -> &'a A {
+    //@ open <Pair<A, B>>.share('a, _t, pair);
+    //@ let p = precreate_ref(&(*pair).x);
+    //@ produce_type_interp::<A>();
+    //@ init_ref_share::<A>('a, _t, p);
+    //@ leak type_interp::<A>();
+    //@ open_frac_borrow('a, ref_initialized_::<A>(p), _q_a);
+    //@ open [?f]ref_initialized_::<A>(p)();
+    let r = &pair.x;
+    //@ close [f]ref_initialized_::<A>(p)();
+    //@ close_frac_borrow(f, ref_initialized_::<A>(p));
+    r
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -4,7 +4,6 @@ verifast ghost_cmd_inj.rs
 verifast parser_test.rs
 verifast -allow_should_fail type_pred_defs_for_imported_structs.rs
 verifast -allow_should_fail duplicate_type_pred_defs.rs
-verifast -allow_should_fail public_fields.rs
 verifast -allow_should_fail -allow_assume preprocessor_test.rs
 verifast -allow_should_fail -allow_assume preprocessor_test_crlf.rs
 verifast -allow_should_fail -allow_assume preprocessor_test_crlf_bom.rs
@@ -68,6 +67,7 @@ cd purely_unsafe
   verifast -ignore_unwind_paths -target LP64 -ignore_ref_creation -extern ../unverified/platform atomics_example.rs
 cd ..
 cd safe_abstraction
+  verifast -allow_should_fail public_fields.rs
   verifast box.rs
   verifast full_bor_primitive_types.rs
   verifast shared_primitive_types.rs


### PR DESCRIPTION
Structs with public fields are now allowed. For

pub struct S { f1: T1, f2: T2 }

the following default type predicates are now generated:

pred <S>.own(t, s) = <T1>.own(t, s.f1) &*& <T2>.own(t, s.f2);

pred <S>.share(k, t, l) = pointer_within_limits(&(*l).f1) == true &*& [_]<T1>.share(k, t, &(*l).f1) &*& pointer_within_limits(&(*l).f2) == true &*& [_]<T2>.share(k, t, &(*l).f2);

For now, custom .own or .share type predicates are not supported for structs with public fields.
