### PR TITLE
[Rust] #[repr(C)] structs

### DIFF
--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -1026,6 +1026,7 @@ and
 and
   struct_attr =
   | Packed
+  | ReprC
 and constant_value = (* ?constant_value *)
   IntConst of big_int
 | BoolConst of bool

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -1123,6 +1123,7 @@ and of_ctor = function
   ])
 and of_struct_attr = function
   Packed -> c "Packed"
+| ReprC -> c "ReprC"
 and of_constant_value = function
   IntConst n -> C ("IntConst", [BigInt n])
 | BoolConst b -> C ("BoolConst", [B b])

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -271,6 +271,7 @@ struct Ty {
         variances @10: List(Variance); # One for each generic lifetime or type parameter
         predicates @7: List(Predicate);
         implementsDrop @8: Bool;
+        isReprC @11: Bool;
     }
 
     struct AdtTy {

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -979,6 +979,7 @@ mod vf_mir_builder {
                 Self::encode_predicate(enc_ctx, pred, pred_cpn);
             });
             adt_def_cpn.set_implements_drop(adt_def.has_dtor(tcx));
+            adt_def_cpn.set_is_repr_c(adt_def.repr().c());
         }
 
         fn encode_adt_kind(adt_kind: ty::AdtKind, mut adt_kind_cpn: adt_kind_cpn::Builder<'_>) {

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -5605,7 +5605,8 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
                       (*field list*) field_defs,
                       (*instance_pred_decl list*) [],
                       (*is polymorphic*) false ),
-                  (*struct_attr list*) [] )
+                  (*struct_attr list*)
+                  if is_repr_c_get adt_def_cpn then [ ReprC ] else [] )
             in
             let struct_typedef_aux =
               Ast.TypedefDecl

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -6079,6 +6079,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       end
     in
     let packed = List.mem Packed attrs in
+    let repr_c = dialect <> Some Rust || List.mem ReprC attrs in
     assume_axiom (fun _ _ s -> (sn ^ "_size_limits", s, ctxt#mk_and (ctxt#mk_lt (ctxt#mk_intlit 0) s) (ctxt#mk_le s max_uintptr_term)));
     match body_opt with
     | Some (_, fmap, _) ->
@@ -6086,7 +6087,7 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         begin match fields with
         | [] -> if packed then assume_axiom (fun targs_env targs s -> (sn ^ "_packed_size", s, ctxt#mk_eq s (current targs_env)))
         | (f, (lf, Real, t, Some offset_func, init))::fs ->
-          if is_first && (fs = [] || dialect <> Some Rust) || packed then
+          if is_first && (fs = [] || repr_c) || packed then
             assume_axiom begin fun targs_env targs s ->
               let offset = ctxt#mk_app offset_func targs in
               (sn ^ "_" ^ f ^ "_packed_offset", offset, ctxt#mk_eq offset (current targs_env))

--- a/tests/rust/struct_layout.rs
+++ b/tests/rust/struct_layout.rs
@@ -3,8 +3,18 @@ struct Foo {
     f2: i32,
 }
 
-fn main() {
-    let f = Foo { f1: 42, f2: 24 };
+#[repr(C)]
+struct Bar {
+    f1: i32,
+    f2: i32,
+}
 
+fn repr_c_test() {
+    let b = Bar { f1: 42, f2: 24 };
+    unsafe { std::hint::assert_unchecked(&raw const b.f1 == &raw const b as *const i32); }
+}
+
+fn repr_rust_test() {
+    let f = Foo { f1: 42, f2: 24 };
     unsafe { std::hint::assert_unchecked(&raw const f as usize == &raw const f.f1 as usize); } //~should_fail
 }


### PR DESCRIPTION
For Rust structs marked as #[repr(C)], VeriFast now assumes the first field is at offset 0, just like it does for C structs.
