### PR TITLE
[Rust] Don't crash on nested fns

### DIFF
--- a/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/preprocessor.rs
@@ -207,8 +207,9 @@ pub fn preprocess(
                         cs.next();
                         output.push('{');
                         if next_block_is_fn_body {
-                            assert!(fn_body_brace_depth == -1, "{}:{}: nested functions are not yet supported", start_of_block.line, start_of_block.column);
-                            fn_body_brace_depth = brace_depth;
+                            if fn_body_brace_depth == -1 {
+                                fn_body_brace_depth = brace_depth;
+                            }
                             next_block_is_fn_body = false;
                         }
                         brace_depth += 1;

--- a/tests/rust/safe_abstraction/linked_list.rs
+++ b/tests/rust/safe_abstraction/linked_list.rs
@@ -2337,7 +2337,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
 
     /// Retains only the elements specified by the predicate.
     ///
-    /// In other words, remove all elements `e` for which `f(&e)` returns false.
+    /// In other words, remove all elements `e` for which `f(&mut e)` returns false.
     /// This method operates in place, visiting each element exactly once in the
     /// original order, and preserves the order of the retained elements.
     ///
@@ -2945,6 +2945,14 @@ impl<'a, T, A: Allocator> Cursor<'a, T, A> {
     pub fn back(&self) -> Option<&'a T> {
         self.list.back()
     }
+
+    /// Provides a reference to the cursor's parent list.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "linked_list_cursors", issue = "58533")]
+    pub fn as_list(&self) -> &'a LinkedList<T, A> {
+        self.list
+    }
 }
 
 impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
@@ -3264,6 +3272,18 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn as_cursor(&self) -> Cursor<'_, T, A> {
         Cursor { list: self.list, current: self.current, index: self.index }
+    }
+
+    /// Provides a read-only reference to the cursor's parent list.
+    ///
+    /// The lifetime of the returned reference is bound to that of the
+    /// `CursorMut`, which means it cannot outlive the `CursorMut` and that the
+    /// `CursorMut` is frozen for the lifetime of the reference.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "linked_list_cursors", issue = "58533")]
+    pub fn as_list(&self) -> &LinkedList<T, A> {
+        self.list
     }
 }
 
@@ -3968,18 +3988,16 @@ impl<T, const N: usize> From<[T; N]> for LinkedList<T> {
 
 // Ensure that `LinkedList` and its read-only iterators are covariant in their type parameters.
 #[allow(dead_code)]
-fn assert_covariance_a<'a>(x: LinkedList<&'static str>) -> LinkedList<&'a str> {
+fn assert_covariance() {
+    fn a<'a>(x: LinkedList<&'static str>) -> LinkedList<&'a str> {
         x
     }
-
-#[allow(dead_code)]
-fn assert_covariance_b<'i, 'a>(x: Iter<'i, &'static str>) -> Iter<'i, &'a str> {
+    fn b<'i, 'a>(x: Iter<'i, &'static str>) -> Iter<'i, &'a str> {
         x
     }
-
-#[allow(dead_code)]
-fn assert_covariance_c<'a>(x: IntoIter<&'static str>) -> IntoIter<&'a str> {
+    fn c<'a>(x: IntoIter<&'static str>) -> IntoIter<&'a str> {
         x
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
The Rust preprocessor no longer crashes when it encounters a
function nested within another function.
