### PR TITLE
refinement-checker: check fn `unsafe`ty

### DIFF
--- a/src/refinement_checker/refinement_checker.ml
+++ b/src/refinement_checker/refinement_checker.ml
@@ -498,6 +498,13 @@ let decode_generic_param generic_param =
 
 let check_body_refines_body def_path body0 body1 =
   Printf.printf "Checking function body %s\n" def_path;
+  let visibility0 = VfMirRd.Visibility.get @@ VfMirRd.Body.visibility_get body0 in
+  let visibility1 = VfMirRd.Visibility.get @@ VfMirRd.Body.visibility_get body1 in
+  if visibility0 <> visibility1 then failwith "The two functions have different visibilities";
+  let unsafety0 = VfMirRd.Unsafety.get @@ VfMirRd.Body.unsafety_get body0 in
+  let unsafety1 = VfMirRd.Unsafety.get @@ VfMirRd.Body.unsafety_get body1 in
+  (* We allow private functions to have different visibility *)
+  if visibility0 = Public && unsafety0 = Safe && unsafety1 = Unsafe then failwith "The two functions have different unsafety";
   let generics0 = VfMirRd.Body.generics_get_list body0 in
   let generics1 = VfMirRd.Body.generics_get_list body1 in
   if List.length generics0 <> List.length generics1 then failwith "The two functions have a different number of generic parameters";

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -755,7 +755,7 @@ struct Body {
     predicates @17: List(Predicate);
     isTraitFn @12: Bool;
     isDropFn @13: Bool; # Implements std::ops::Drop::drop
-    # Todo @Nima: Add Visibility data
+    visibility @22: Visibility;
 }
 
 struct Trait {

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -1303,6 +1303,8 @@ mod vf_mir_builder {
                     );
                 },
             );
+
+            Self::encode_visibility(tcx.visibility(def_id), body_cpn.reborrow().init_visibility());
         }
 
         fn encode_unsafety(us: hir::Safety, mut us_cpn: unsafety_cpn::Builder<'_>) {

--- a/tests/rust/refinement_checker/testsuite.mysh
+++ b/tests/rust/refinement_checker/testsuite.mysh
@@ -16,4 +16,5 @@ begin_parallel
   !refinement-checker structs_orig.rs structs_verified_bad.rs
   refinement-checker enums_orig.rs enums_verified.rs
   !refinement-checker enums_orig.rs enums_verified_bad.rs
+  !refinement-checker unsafety_orig.rs unsafety_verified_bad.rs
 end_parallel

--- a/tests/rust/refinement_checker/unsafety_orig.rs
+++ b/tests/rust/refinement_checker/unsafety_orig.rs
@@ -1,0 +1,1 @@
+pub fn foo(p: *mut i32) { unsafe { p.write(42); } }

--- a/tests/rust/refinement_checker/unsafety_verified_bad.rs
+++ b/tests/rust/refinement_checker/unsafety_verified_bad.rs
@@ -1,0 +1,1 @@
+pub unsafe fn foo(p: *mut i32) { unsafe { p.write(42); } }


### PR DESCRIPTION
Fixes #729
