### PR TITLE
refchecker: allow extra shared ref creations in verified program

### DIFF
--- a/tests/rust/refinement_checker/testsuite.mysh
+++ b/tests/rust/refinement_checker/testsuite.mysh
@@ -17,4 +17,5 @@ begin_parallel
   refinement-checker enums_orig.rs enums_verified.rs
   !refinement-checker enums_orig.rs enums_verified_bad.rs
   !refinement-checker unsafety_orig.rs unsafety_verified_bad.rs
+  refinement-checker wrapper_fns_orig.rs wrapper_fns_verified0.rs
 end_parallel

--- a/tests/rust/refinement_checker/wrapper_fns_orig.rs
+++ b/tests/rust/refinement_checker/wrapper_fns_orig.rs
@@ -1,0 +1,8 @@
+#![feature(allocator_api)]
+
+use std::alloc::Allocator;
+
+pub fn foo<A: Allocator + Clone>(alloc: A) -> (A, A) {
+    let alloc_clone = alloc.clone();
+    (alloc, alloc_clone)
+}

--- a/tests/rust/refinement_checker/wrapper_fns_verified0.rs
+++ b/tests/rust/refinement_checker/wrapper_fns_verified0.rs
@@ -1,0 +1,9 @@
+#![feature(allocator_api)]
+
+use std::alloc::Allocator;
+
+pub fn foo<A: Allocator + Clone>(alloc: A) -> (A, A) {
+    let alloc_ref = &alloc;
+    let alloc_clone = alloc_ref.clone();
+    (alloc, alloc_clone)
+}


### PR DESCRIPTION
Extra shared reference creations can only cause the program to have more UB.

Also adds support for generic parameter predicates.
