### PR TITLE
refinement-checker: Reservations

### DIFF
--- a/tests/rust/refinement_checker/reservation_orig.rs
+++ b/tests/rust/refinement_checker/reservation_orig.rs
@@ -1,0 +1,3 @@
+fn my_replace(r: &mut i32, v: i32) -> i32 {
+    std::mem::replace(r, { *r; v })
+}

--- a/tests/rust/refinement_checker/reservation_verified.rs
+++ b/tests/rust/refinement_checker/reservation_verified.rs
@@ -1,0 +1,5 @@
+fn my_replace(r: &mut i32, v: i32) -> i32 {
+    let r_ref = &mut *r as *mut i32; 
+    *r;
+    std::mem::replace(unsafe { &mut *r_ref }, v)
+}

--- a/tests/rust/refinement_checker/testsuite.mysh
+++ b/tests/rust/refinement_checker/testsuite.mysh
@@ -21,4 +21,5 @@ begin_parallel
   refinement-checker wrapper_fns_orig.rs wrapper_fns_verified.rs
   refinement-checker wrapper_fns_orig.rs wrapper_fns_verified2.rs
   !refinement-checker wrapper_fns_orig.rs wrapper_fns_verified_bad.rs
+  refinement-checker reservation_orig.rs reservation_verified.rs
 end_parallel

--- a/tests/rust/safe_abstraction/linked_list.rs
+++ b/tests/rust/safe_abstraction/linked_list.rs
@@ -1344,7 +1344,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 head: second_part_head,
                 tail: second_part_tail,
                 len: self.len - at,
-                alloc: clone_allocator(&self.alloc),
+                alloc: Allocator_clone__VeriFast_wrapper(&self.alloc),
                 marker: PhantomData,
             };
             //@ std::alloc::end_ref_Allocator::<'static, A>();
@@ -1364,7 +1364,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
         } else {
             //@ let alloc_ref = precreate_ref(&(*self).alloc);
             //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
-            let alloc = clone_allocator(&self.alloc);
+            let alloc = Allocator_clone__VeriFast_wrapper(&self.alloc);
             //@ std::alloc::end_ref_Allocator::<'static, A>();
             //@ std::alloc::Allocator_to_own::<A>(alloc);
             //@ close_points_to(self);
@@ -1377,7 +1377,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     }
 }
 
-unsafe fn clone_allocator<'a, A: Allocator + Clone>(alloc: &'a A) -> A
+unsafe fn Allocator_clone__VeriFast_wrapper<'a, A: Allocator + Clone>(alloc: &'a A) -> A
 //@ req thread_token(?t) &*& Allocator::<&'a A>(t, alloc, ?alloc_id);
 //@ ens thread_token(t) &*& Allocator::<&'a A>(t, _, alloc_id) &*& Allocator::<A>(t, result, alloc_id);
 {
@@ -2150,7 +2150,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
         if at == 0 {
                 //@ let alloc_ref = precreate_ref(&(*self).alloc);
                 //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
-                let alloc1 = clone_allocator(&self.alloc);
+                let alloc1 = Allocator_clone__VeriFast_wrapper(&self.alloc);
                 //@ std::alloc::end_ref_Allocator::<'static, A>();
                 //@ std::alloc::Allocator_to_own::<A>(alloc1);
                 //@ close_points_to(self);
@@ -2160,7 +2160,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
         } else if at == len {
                 //@ let alloc_ref = precreate_ref(&(*self).alloc);
                 //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
-                let alloc2 = clone_allocator(&self.alloc);
+                let alloc2 = Allocator_clone__VeriFast_wrapper(&self.alloc);
                 //@ std::alloc::end_ref_Allocator::<'static, A>();
                 //@ std::alloc::Allocator_to_own::<A>(alloc2);
                 //@ close_points_to(self);

--- a/tests/rust/safe_abstraction/linked_list/verified/lib.rs
+++ b/tests/rust/safe_abstraction/linked_list/verified/lib.rs
@@ -1,4 +1,4 @@
-// verifast_options{skip_specless_fns}
+// verifast_options{skip_specless_fns ignore_unwind_paths}
 
 #![no_std]
 #![allow(internal_features)]

--- a/tests/rust/safe_abstraction/linked_list/verified/linked_list.rs
+++ b/tests/rust/safe_abstraction/linked_list/verified/linked_list.rs
@@ -1147,41 +1147,94 @@ impl<T, A: Allocator> LinkedList<T, A> {
     ) -> Self
     where
         A: Clone,
+    /*@
+    req thread_token(?t) &*&
+        (*self).alloc |-> ?alloc0 &*& Allocator::<A>(t, alloc0, ?alloc_id) &*&
+        (*self).head |-> ?head0 &*&
+        (*self).tail |-> ?tail0 &*&
+        struct_LinkedList_padding(self) &*&
+        Nodes::<T>(alloc_id, head0, None, split_node, ?next0, ?nodes1) &*&
+        Nodes::<T>(alloc_id, next0, split_node, tail0, None, ?nodes2) &*&
+        foreach(nodes1, elem_fbc::<T>(t)) &*&
+        foreach(nodes2, elem_fbc::<T>(t)) &*&
+        (*self).len |-> length(nodes1) + length(nodes2) &*&
+        length(nodes1) == at;
+    @*/
+    /*@
+    ens thread_token(t) &*&
+        *self |-> ?self1 &*& <LinkedList<T, A>>.own(t, self1) &*&
+        <LinkedList<T, A>>.own(t, result);
+    @*/
     {
         // The split node is the new tail node of the first part and owns
         // the head of the second part.
         if let Some(mut split_node) = split_node {
+            //@ Nodes_last_lemma(head0);
+            //@ Nodes_split_off_last(head0);
+            //@ assert Nodes(alloc_id, head0, None, ?prev0, split_node, ?nodes10);
             let second_part_head;
             let second_part_tail;
             unsafe {
                 second_part_head = split_node.as_mut().next.take();
             }
+            //@ open Nodes(_, next0, split_node, tail0, None, nodes2);
             if let Some(mut head) = second_part_head {
                 unsafe {
                     head.as_mut().prev = None;
                 }
                 second_part_tail = self.tail;
+                //@ close Nodes::<T>(alloc_id, next0, None, tail0, None, nodes2);
             } else {
+                //@ close Nodes::<T>(alloc_id, next0, None, None, None, nodes2);
                 second_part_tail = None;
             }
 
+            //@ let alloc_ref = precreate_ref(&(*self).alloc);
+            //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
             let second_part = LinkedList {
                 head: second_part_head,
                 tail: second_part_tail,
                 len: self.len - at,
-                alloc: self.alloc.clone(),
+                alloc: Allocator_clone__VeriFast_wrapper(&self.alloc),
                 marker: PhantomData,
             };
+            //@ std::alloc::end_ref_Allocator::<'static, A>();
 
             // Fix the tail ptr of the first part
             self.tail = Some(split_node);
             self.len = at;
-
+            //@ close Nodes::<T>(alloc_id, None, split_node, split_node, None, []);
+            //@ close Nodes::<T>(alloc_id, split_node, prev0, split_node, None, [split_node_1]);
+            //@ Nodes_append(head0);
+            //@ close_points_to(self);
+            //@ close <LinkedList<T, A>>.own(t, *self);
+            //@ assert Nodes(_, _, _, _, _, nodes2);
+            //@ assert length(nodes2) == second_part.len;
+            //@ close <LinkedList<T, A>>.own(t, second_part);
             second_part
         } else {
-            mem::replace(self, LinkedList::new_in(self.alloc.clone()))
+            let self_ref = &mut *self as *mut LinkedList<T, A>;
+            //@ let alloc_ref = precreate_ref(&(*self).alloc);
+            //@ std::alloc::init_ref_Allocator::<'static, A>(alloc_ref);
+            let alloc = Allocator_clone__VeriFast_wrapper(&self.alloc);
+            //@ std::alloc::end_ref_Allocator::<'static, A>();
+            //@ std::alloc::Allocator_to_own::<A>(alloc);
+            //@ close_points_to(self);
+            //@ Nodes_append(head0);
+            //@ foreach_append(nodes1, nodes2);
+            //@ close <LinkedList<T, A>>.own(t, *self);
+            let r = LinkedList::new_in(alloc);
+            mem::replace(unsafe { &mut *self_ref }, r)
         }
     }
+}
+
+unsafe fn Allocator_clone__VeriFast_wrapper<'a, A: Allocator + Clone>(alloc: &'a A) -> A
+//@ req thread_token(?t) &*& Allocator::<&'a A>(t, alloc, ?alloc_id);
+//@ ens thread_token(t) &*& Allocator::<&'a A>(t, _, alloc_id) &*& Allocator::<A>(t, result, alloc_id);
+//@ assume_correct
+{
+    alloc.clone()
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1276,8 +1329,16 @@ impl<T, A: Allocator> LinkedList<T, A> {
     /// ```
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    pub const fn new_in(alloc: A) -> Self {
-        LinkedList { head: None, tail: None, len: 0, alloc, marker: PhantomData }
+    pub const fn new_in(alloc: A) -> Self
+    //@ req thread_token(?t) &*& <A>.own(t, alloc);
+    //@ ens thread_token(t) &*& <LinkedList<T, A>>.own(t, result);
+    //@ on_unwind_ens thread_token(t);
+    {
+        let r = LinkedList { head: None, tail: None, len: 0, alloc, marker: PhantomData };
+        //@ std::alloc::open_Allocator_own::<A>(alloc);
+        //@ close foreach(nil, elem_fbc::<T>(t));
+        //@ close <LinkedList<T, A>>.own(t, r);
+        r
     }
     /// Provides a forward iterator.
     ///

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -100,7 +100,7 @@ cd safe_abstraction
   end_sequential
   verifast -ignore_unwind_paths -skip_specless_fns -allow_assume linked_list.rs
   cd linked_list
-    verifast -rustc_args "--edition 2021 --cfg test" -skip_specless_fns -allow_assume verified/lib.rs
+    verifast -rustc_args "--edition 2021 --cfg test" -ignore_unwind_paths -skip_specless_fns -allow_assume verified/lib.rs
     refinement-checker --rustc-args "--edition 2021 --cfg test" orig/lib.rs verified/lib.rs
   cd ..
   verifast -ignore_unwind_paths -skip_specless_fns -allow_assume btree_node.rs


### PR DESCRIPTION
The refinement checker now treats assignments x = &raw mut *x or x = &raw const *x like no-ops (which they are, semantically). Furthermore, it now also allows extra mutable reference creations in the verified program, not just extra shared reference creations.

As a result, refinement-checker now supports pulling apart a function call that involves a reservation of a mutable reference.

This enables verifying LinkedList::split_off_after_node.
