### PR TITLE
refinement-checker: Box deref -> Box::as_ptr

### DIFF
--- a/tests/rust/refinement_checker/box-deref_orig.rs
+++ b/tests/rust/refinement_checker/box-deref_orig.rs
@@ -1,0 +1,10 @@
+#![feature(box_as_ptr)]
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn foo(b: Box<Point>) -> (i32, Box<Point>) {
+    (b.x, b)
+}

--- a/tests/rust/refinement_checker/box-deref_verified.rs
+++ b/tests/rust/refinement_checker/box-deref_verified.rs
@@ -1,0 +1,12 @@
+#![feature(box_as_ptr)]
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn foo(b: Box<Point>) -> (i32, Box<Point>) {
+    let p = Box::as_ptr(&b);
+    let x = unsafe { (*p).x };
+    (x, b)
+}

--- a/tests/rust/refinement_checker/box-ref-deref_orig.rs
+++ b/tests/rust/refinement_checker/box-ref-deref_orig.rs
@@ -1,0 +1,10 @@
+#![feature(box_as_ptr)]
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn foo(b: &Box<Point>) -> i32 {
+    b.x
+}

--- a/tests/rust/refinement_checker/box-ref-deref_verified.rs
+++ b/tests/rust/refinement_checker/box-ref-deref_verified.rs
@@ -1,0 +1,11 @@
+#![feature(box_as_ptr)]
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn foo(b: &Box<Point>) -> i32 {
+    let p = Box::as_ptr(b);
+    unsafe { (*p).x }
+}

--- a/tests/rust/refinement_checker/testsuite.mysh
+++ b/tests/rust/refinement_checker/testsuite.mysh
@@ -33,4 +33,6 @@ begin_parallel
   refinement-checker option-map-generics_orig.rs option-map-generics_verified.rs
   !refinement-checker option-map-generics_orig.rs option-map-generics_verified_bad.rs
   !refinement-checker option-map-generics_orig.rs option-map-generics_verified_bad2.rs
+  refinement-checker box-deref_orig.rs box-deref_verified.rs
+  refinement-checker box-ref-deref_orig.rs box-ref-deref_verified.rs
 end_parallel


### PR DESCRIPTION
The refinement checker now accepts replacing box deref magic by a Box::as_ptr call.
