### PR TITLE
[Rust] Verify trait calls against impl spec

### DIFF
--- a/src/refinement_checker/refinement_checker.ml
+++ b/src/refinement_checker/refinement_checker.ml
@@ -460,7 +460,6 @@ let fns_to_be_inlined: (string * body) list =
                   ty={
                     kind=FnDef {
                       id={name="std::ops::Drop::drop"};
-                      id_mono=Nothing;
                       substs=[
                         {kind=Type {kind=Adt {id={name="std::boxed::Box"}; kind=StructKind; substs=[{kind=Type {kind=Param "T"}}; {kind=Type {kind=Param "A"}}]}}};
                       ];
@@ -777,7 +776,6 @@ let fns_to_be_inlined: (string * body) list =
                 ty={
                   kind=FnDef {
                     id={name="std::ops::FnOnce::call_once--VeriFast"};
-                    id_mono=Nothing;
                     substs=[
                       {kind=Type {kind=Param "F"}};
                       {kind=Type {kind=Tuple [{kind=Param "T"}]}};

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -287,9 +287,8 @@ struct TyKind {
 
     struct FnDefTy {
         id @0: FnDefId;
-        idMono @1: Option(FnDefId);
-        substs @2: List(GenericArg);
-        lateBoundGenericParamCount @3: UInt16; # The generic args are only for the early-bound params.
+        substs @1: List(GenericArg);
+        lateBoundGenericParamCount @2: UInt16; # The generic args are only for the early-bound params.
     }
 
     struct FnPtrTy {
@@ -781,6 +780,11 @@ struct Trait {
     requiredFns @1: IndList(RequiredFn);
 }
 
+struct TraitImplItem {
+    name @0: Text;
+    defId @1: Text;
+}
+
 struct TraitImpl {
     span @3: SpanData;
     isUnsafe @4: Bool;
@@ -790,7 +794,7 @@ struct TraitImpl {
     selfTy @1: Text;
     generics @6: List(GenericParamDef);
     predicates @7: List(Predicate);
-    items @2: List(Text);
+    items @2: List(TraitImplItem);
 }
 
 struct Module {

--- a/tests/rust/safe_abstraction/my_range_iterator.rs
+++ b/tests/rust/safe_abstraction/my_range_iterator.rs
@@ -1,0 +1,64 @@
+//@ use std::option::Option;
+
+struct MyStruct<T> {
+    x: Option<T>
+}
+
+/*@
+
+lem MyStruct_drop<T>()
+    req MyStruct_own::<T>(?_t, ?_v);
+    ens <std::option::Option<T>>.own(_t, _v.x);
+{
+    assume(false);
+}
+
+lem MyStruct_own_mono<T0, T1>()
+    req type_interp::<T0>() &*& type_interp::<T1>() &*& MyStruct_own::<T0>(?t, ?v) &*& is_subtype_of::<T0, T1>() == true;
+    ens type_interp::<T0>() &*& type_interp::<T1>() &*& MyStruct_own::<T1>(t, MyStruct::<T1> { x: upcast(v.x) });
+{
+    assume(false);
+}
+
+lem MyStruct_send<T>(t1: thread_id_t)
+    req type_interp::<T>() &*& is_Send(typeid(T)) == true &*& MyStruct_own::<T>(?t0, ?v);
+    ens type_interp::<T>() &*& MyStruct_own::<T>(t1, v);
+{
+    assume(false);
+}
+
+@*/
+
+//@ pred<T> <MyStruct<T>>.own(t, v) = <Option<T>>.own(t, v.x);
+
+impl<U> Iterator for MyStruct<U> {
+    type Item = U;
+
+    fn next(self: &mut MyStruct<U>) -> Option<U> // forall U, Iterator::next::<MyStruct<U>>
+    //@ req thread_token(?t) &*& *self |-> ?self0 &*& <MyStruct<U>>.own(t, self0);
+    //@ ens thread_token(t) &*& *self |-> ?self1 &*& <MyStruct<U>>.own(t, self1) &*& result == self0.x &*& <Option<U>>.own(t, result);
+    //@ on_unwind_ens false;
+    {
+        //@ open <MyStruct<U>>.own(t, self0);
+        //@ open_points_to(self);
+        let r = std::mem::replace(&mut self.x, None);
+        //@ close_points_to(self);
+        //@ close <std::option::Option<U>>.own(t, Option::None);
+        //@ close <MyStruct<U>>.own(t, *self);
+        r
+    }
+}
+
+fn main() {
+    let mut s = MyStruct { x: Some(42) };
+    //@ close i32_own(_t, 42);
+    //@ close <std::option::Option<i32>>.own(_t, s.x);
+    //@ close <MyStruct<i32>>.own(_t, s);
+    let e1 = s.next(); // Iterator::next::<MyStruct<i32>>
+    //@ leak <MyStruct<i32>>.own(_t, _);
+    match e1 {
+        None => { unsafe { std::hint::unreachable_unchecked(); } }
+        Some(x) => { unsafe { std::hint::assert_unchecked(x == 42); } }
+    }
+    //@ leak <Option<i32>>.own(_t, e1);
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -100,6 +100,7 @@ cd safe_abstraction
     verifast -allow_assume proof_obligs_quick_fix_test_generic_result.rs
     del proof_obligs_quick_fix_test_generic_result.rs
   end_sequential
+  verifast -ignore_unwind_paths -allow_assume my_range_iterator.rs
   verifast -ignore_unwind_paths -skip_specless_fns -allow_assume linked_list.rs
   cd linked_list
     verifast -rustc_args "--edition 2021 --cfg test" -ignore_unwind_paths -skip_specless_fns -allow_assume verified/lib.rs


### PR DESCRIPTION
If the crate being verified implements a trait T for a struct S and also contains a call of a method M of T on S, VeriFast used to verify the call against the general spec of M in T, but now verifies it against the spec of the implementation of M for S.
