### PR TITLE
Fix devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
   "onCreateCommand": "./setup-devcontainer.sh",
   "postCreateCommand": ". ./config.sh && . ./install-vfdeps.sh",
   "postStartCommand": ". ./config.sh && . ./install-vfdeps.sh",

--- a/setup-build.sh
+++ b/setup-build.sh
@@ -41,10 +41,11 @@ if [ $(uname -s) = "Linux" ]; then
        git wget ca-certificates m4 \
        patch unzip libgtk2.0-dev \
        valac \
-       cmake build-essential ninja-build
+       cmake build-essential ninja-build \
+       software-properties-common # For add-apt-repository
   if ! sudo apt-get install -y --no-install-recommends libgtksourceview2.0-dev; then
     # libgtksourceview2.0-dev is not in recent Ubuntu releases, so add focal (20.04 LTS) repo
-    sudo add-apt-repository "deb http://mirrors.kernel.org/ubuntu/ focal universe"
+    sudo add-apt-repository -y "deb http://mirrors.kernel.org/ubuntu/ focal universe"
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends libgtksourceview2.0-dev
   fi

--- a/setup-devcontainer.sh
+++ b/setup-devcontainer.sh
@@ -10,7 +10,8 @@ set -x
 # The toolchain for building VeriFast is installed by ./setup-build.sh (not using opam), but
 # we now use opam to install ocaml-lsp-server.
 sudo apt-get install -y --no-install-recommends opam
-opam init -n -c 4.14.0
+opam init --disable-sandboxing -y -n -c 4.14.0
+opam repo add archive git+https://github.com/ocaml/opam-repository-archive
 opam install -y dune.3.14.2 ocaml-lsp-server ocamlformat
 
 WORKSPACEFOLDER=`pwd`


### PR DESCRIPTION
It was no longer working because
- the GitHub Codespaces base image had grown, causing the devcontainer setup to run out of disk space
- some OPAM packages have been moved to opam-repository-archive