### PR TITLE
Allow pure autolemmas with protected parameters

### DIFF
--- a/bin/rust/prelude_core.rsspec
+++ b/bin/rust/prelude_core.rsspec
@@ -40,7 +40,7 @@ lem_auto is_power_of_2_lem();
     req true;
     ens is_power_of_2(1) && is_power_of_2(2) && is_power_of_2(4) && is_power_of_2(8) && is_power_of_2(16) && is_power_of_2(32);
 
-lem is_power_of_2_pos(n: i32);
+lem_auto is_power_of_2_pos(n: i32);
     req is_power_of_2(n) == true;
     ens 1 <= n;
 

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -412,7 +412,7 @@ mod ptr {
     
     fix NonNull::without_provenance_<T>(addr: std::num::NonZero<usize>) -> NonNull<T>;
     
-    lem NonNull_ptr_NonNull_without_provenance_<T>(addr: std::num::NonZero<usize>);
+    lem_auto(NonNull_ptr(NonNull::without_provenance_::<T>(addr))) NonNull_ptr_NonNull_without_provenance_<T>(addr: std::num::NonZero<usize>);
         req true;
         ens NonNull_ptr(NonNull::without_provenance_::<T>(addr)) == std::num::NonZero::get_(addr) as *T;
     
@@ -489,8 +489,7 @@ mod ptr {
     
     /*@
     
-    lem Unique_non_null__from_non_null_<T>(nn: NonNull<T>);
-    //lem_auto(Unique::non_null_(Unique::from_non_null_(nn))) Unique_non_null__from_non_null_<T>(nn: NonNull<T>);
+    lem_auto(Unique::non_null_(Unique::from_non_null_(nn))) Unique_non_null__from_non_null_<T>(nn: NonNull<T>);
         req true;
         ens Unique::non_null_(Unique::from_non_null_(nn)) == nn;
     

--- a/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
+++ b/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
@@ -464,14 +464,7 @@ impl<A: Allocator> RawVecInner<A> {
         let cap = ZERO_CAP;
         //@ let layout = Layout::from_size_align_(elemSize, NonZero::get_(Alignment::as_nonzero_(align)));
         let r = Self { ptr, cap, alloc };
-        //@ std::ptr::NonNull_ptr_nonnull(Unique::non_null_(ptr));
-        //@ std::ptr::Unique_non_null__from_non_null_(NonNull::without_provenance_::<u8>(Alignment::as_nonzero_(align)));
-        //@ std::ptr::NonNull_ptr_NonNull_without_provenance_::<u8>(Alignment::as_nonzero_(align));
-        //@ std::ptr::Alignment_is_power_of_2(align);
-        //@ is_power_of_2_pos(NonZero::get_(Alignment::as_nonzero_(align)));
-        //@ std::alloc::Layout_align__Layout_from_size_align_(elemSize, NonZero::get_(Alignment::as_nonzero_(align)));
         //@ div_rem_nonneg_unique(NonZero::get_(Alignment::as_nonzero_(align)), NonZero::get_(Alignment::as_nonzero_(align)), 1, 0);
-        //@ std::num::niche_types::UsizeNoHighBit_as_inner__transmute_uint(0);
         //@ close RawVecInner0(alloc_id, ptr, cap, layout, _, 0);
         //@ close RawVecInner(t, r, layout, _, 0);
         //@ std::num::NonZero_usize_limits(Alignment::as_nonzero_(align));


### PR DESCRIPTION
Until now, VeriFast would allow a pure autolemma only if all parameter
types were "universal types", defined as being "isomorphic to the SMT
solver universe". Struct types are currently never deemed universal.
From now on, "protected" parameters are exempted from this restriction.
A parameter is protected if the autolemma has a trigger and the
parameter appears in the trigger as an argument to a pure function that
has only typeid-carrying type parameters. If a term matches such a
trigger, the subterm matching the protected parameter is necessarily of
the type of the parameter, despite type erasure.
