### PR TITLE
[Rust] Fix unify_strict unsoundness #886

### DIFF
--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -348,6 +348,7 @@ type type_expr = (* ?type_expr *)
   | LValueRefTypeExpr of loc * type_expr
   | ConstTypeExpr of loc * type_expr
   | ProjectionTypeExpr of loc * type_expr * string (* trait name *) * type_expr list (* trait generic args *) * string (* associated type name *) (* In Rust: <T as X<GArgs>>::Y *)
+  | InferredTypeExpr of loc (* A placeholder `_` to be filled by the typechecker. *)
 and
   operator =  (* ?operator *)
   | Add | Sub | PtrDiff | Le | Ge | Lt | Gt | Eq | Neq | And | Or | Xor | Not | Mul | Div | Mod | BitNot | BitAnd | BitXor | BitOr | ShiftLeft | ShiftRight

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -759,7 +759,8 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
 
   let vf_ty_arg_of_region loc (reg : string) =
     match reg with
-    | "'static" | "'<erased>" -> Ast.ManifestTypeExpr (loc, StaticLifetime)
+    | "'static" -> Ast.ManifestTypeExpr (loc, StaticLifetime)
+    | "'<erased>" -> Ast.InferredTypeExpr loc
     | x -> Ast.IdentTypeExpr (loc, None, x)
 
   let translate_region_expr loc (reg_cpn : D.region) =
@@ -2247,7 +2248,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
           |> Util.flatmap @@ function
              | Mir.GenArgType ty -> [ ty.vf_ty ]
              | Mir.GenArgLifetime region ->
-                 [ Ast.ManifestTypeExpr (call_loc, StaticLifetime) ]
+                 [ Ast.InferredTypeExpr call_loc ]
              | Mir.GenArgConst ty -> [ ty ]
         in
         let* targs =

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -989,7 +989,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           [] -> tcont sizemap tenv ghostenv h env
         | (l, te, x, e, (address_taken, blockPtr))::xs ->
           let is_const_var = match te with Some (ConstTypeExpr (_, _)) -> true | _ -> false in
-          let t = option_map (check_pure_type (pn,ilist) tparams (if pure then Ghost else Real)) te in
+          let t = option_map (fun te -> check_pure_type_core typedefmap (pn,ilist) tparams te (if pure then Ghost else Real) allow_inferred_types) te in
           if List.mem_assoc x tenv then static_error l ("Declaration hides existing local variable '" ^ x ^ "'.") None;
           let ghostenv = if pure then x::ghostenv else List.filter (fun y -> y <> x) ghostenv in
           match t with

--- a/tests/rust/safe_abstraction/linked_list/verified/linked_list.rs
+++ b/tests/rust/safe_abstraction/linked_list/verified/linked_list.rs
@@ -1082,10 +1082,10 @@ impl<T, A: Allocator> LinkedList<T, A> {
                     //@ open elem_fbc::<T>(t)(node);
                     //@ borrow_points_to_at_lft(alloc_id.lft, node.as_ptr());
                     //@ leak points_to_at_lft_end_token(alloc_id.lft, node.as_ptr());
-                    let node = Box::from_raw_in(node.as_ptr(), &*alloc_ref);
+                    let node = Box::from_raw_in/*@::<Node<T>, &'a A>@*/(node.as_ptr(), &*alloc_ref);
                     //@ close [f]ref_initialized_::<A>(alloc_ref)();
                     //@ close_frac_borrow(f, ref_initialized_(alloc_ref));
-                    //@ std::boxed::Box_separate_contents(&node_1);
+                    //@ std::boxed::Box_separate_contents::<Node<T>, &'a A>(&node_1);
                     //@ assert std::boxed::Box_minus_contents_in(_, _, _, _, _, ?contents_ptr);
                     //@ assume(alloc_id.lft == 'static);
                     //@ produce_lifetime_token_static();
@@ -1395,7 +1395,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
                     head: second_part_head,
                     tail: second_part_tail,
                     len: self.len - at,
-                    alloc: Allocator_clone__VeriFast_wrapper(&self.alloc),
+                    alloc: Allocator_clone__VeriFast_wrapper/*@::<A, 'a>@*/(&self.alloc),
                     marker: PhantomData,
                 };
             }
@@ -1422,7 +1422,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
             {
                 //@ let_lft 'a = k;
                 //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                alloc = Allocator_clone__VeriFast_wrapper(&self.alloc);
+                alloc = Allocator_clone__VeriFast_wrapper/*@::<A, 'a>@*/(&self.alloc);
             }
             //@ end_lifetime(k);
             //@ std::alloc::end_ref_Allocator_at_lifetime::<A>();
@@ -2136,9 +2136,9 @@ impl<T, A: Allocator> LinkedList<T, A> {
                 //@ let_lft 'b = k;
                 //@ std::alloc::init_ref_Allocator_at_lifetime::<'b, A>(alloc_ref);
                 //@ close drop_perm::<Node<T>>(false, True, t, node0);
-                let node = Box::new_in(node0, &self.alloc);
+                let node = Box::new_in/*@::<Node<T>, &'b A>@*/(node0, &self.alloc);
                 //@ open drop_perm::<Node<T>>(false, True, t, node0);
-                node_ptr = NonNull_from_ref_mut__VeriFast_wrapper(Box::leak(node));
+                node_ptr = NonNull_from_ref_mut__VeriFast_wrapper(Box::leak/*@::<Node<T>, &'b A, 'static>@*/(node));
             }
             //@ end_lifetime(k);
             //@ std::alloc::end_ref_Allocator_at_lifetime::<A>();
@@ -2341,7 +2341,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
             unsafe {
                 //@ let_lft 'a = k;
                 //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                alloc1 = Allocator_clone__VeriFast_wrapper(&self.alloc);
+                alloc1 = Allocator_clone__VeriFast_wrapper/*@::<A, 'a>@*/(&self.alloc);
             }
             //@ end_lifetime(k);
             //@ std::alloc::end_ref_Allocator_at_lifetime::<A>();
@@ -2358,7 +2358,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
             unsafe {
                 //@ let_lft 'a = k;
                 //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                alloc2 = Allocator_clone__VeriFast_wrapper(&self.alloc);
+                alloc2 = Allocator_clone__VeriFast_wrapper/*@::<A, 'a>@*/(&self.alloc);
             }
             //@ end_lifetime(k);
             //@ std::alloc::end_ref_Allocator_at_lifetime::<A>();
@@ -3733,7 +3733,7 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
                     //@ borrow_points_to_at_lft(alloc_id.lft, unlinked_node.as_ptr());
                     //@ leak points_to_at_lft_end_token(_, _);
                     let unlinked_node = Box::from_raw_in/*@::<Node<T>, &'b A>@*/(unlinked_node.as_ptr(), &self.list.alloc);
-                    r = Some(Box_into_inner_with_ref_Allocator__VeriFast_wrapper(unlinked_node).element); // Some(unlinked_node_.element)
+                    r = Some(Box_into_inner_with_ref_Allocator__VeriFast_wrapper/*@::<Node<T>, A, 'b>@*/(unlinked_node).element); // Some(unlinked_node_.element)
                 }
                 //@ close [f]ref_initialized_::<A>(alloc_ref)();
                 //@ close_frac_borrow(f, ref_initialized_(alloc_ref));
@@ -4078,7 +4078,7 @@ where
                             //@ std::alloc::close_Allocator_ref::<'b, A>(t, alloc_ref);
                             //@ borrow_points_to_at_lft(alloc_id.lft, node.as_ptr());
                             //@ leak points_to_at_lft_end_token(_, _);
-                            r = Some(Box_into_inner_with_ref_Allocator__VeriFast_wrapper(Box::from_raw_in/*@::<Node<T>, &'b A>@*/(node.as_ptr(), &self.list.alloc)).element);
+                            r = Some(Box_into_inner_with_ref_Allocator__VeriFast_wrapper/*@::<Node<T>, A, 'b>@*/(Box::from_raw_in/*@::<Node<T>, &'b A>@*/(node.as_ptr(), &self.list.alloc)).element);
                         }
                         //@ close [f]ref_initialized_::<A>(alloc_ref)();
                         //@ close_frac_borrow(f, ref_initialized_(alloc_ref));

--- a/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
+++ b/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
@@ -1628,7 +1628,7 @@ impl<A: Allocator> RawVecInner<A> {
                 unsafe {
                     //@ let_lft 'a = k;
                     //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                    r = alloc.allocate(layout);
+                    r = alloc.allocate/*@::<A, 'a>@*/(layout);
                     //@ leak Allocator(_, _, _);
                 }
                 //@ end_lifetime(k);
@@ -1643,7 +1643,7 @@ impl<A: Allocator> RawVecInner<A> {
                 {
                     //@ let_lft 'a = k;
                     //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                    r = alloc.allocate_zeroed(layout);
+                    r = alloc.allocate_zeroed/*@::<A, 'a>@*/(layout);
                     //@ leak Allocator(_, _, _);
                 }
                 //@ end_lifetime(k);
@@ -2441,7 +2441,7 @@ impl<A: Allocator> RawVecInner<A> {
             unsafe {
                 //@ let_lft 'a = k1;
                 //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                self.alloc.deallocate(ptr, layout);
+                self.alloc.deallocate/*@::<A, 'a>@*/(ptr, layout);
                 //@ leak Allocator(_, _, _);
             };
             //@ end_lifetime(k1);
@@ -2466,7 +2466,7 @@ impl<A: Allocator> RawVecInner<A> {
                 {
                     //@ let_lft 'a = k1;
                     //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                    r = self.alloc.shrink(ptr, layout, new_layout);
+                    r = self.alloc.shrink/*@::<A, 'a>@*/(ptr, layout, new_layout);
                     //@ leak Allocator(_, _, _);
                 };
                 //@ end_lifetime(k1);
@@ -2544,7 +2544,7 @@ impl<A: Allocator> RawVecInner<A> {
                 //@ std::alloc::Layout_inv(allocLayout);
                 //@ std::alloc::Layout_size_Layout_from_size_align(capacity * elem_layout.size(), elem_layout.align());
                 //@ assert capacity * elem_layout.size() == layout.size();
-                self.alloc.deallocate(ptr, layout);
+                self.alloc.deallocate/*@::<A, 'a>@*/(ptr, layout);
                 //@ leak Allocator(_, _, _);
             }
             //@ end_lifetime(k1);
@@ -2621,7 +2621,7 @@ ens thread_token(t) &*& *alloc |-> ?alloc1 &*& Allocator(t, alloc1, alloc_id) &*
             {
                 //@ let_lft 'a = k1;
                 //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-                r = alloc.grow(ptr, old_layout, new_layout);
+                r = alloc.grow/*@::<A, 'a>@*/(ptr, old_layout, new_layout);
                 //@ leak Allocator(_, _, _);
             }
             //@ end_lifetime(k1);
@@ -2635,7 +2635,7 @@ ens thread_token(t) &*& *alloc |-> ?alloc1 &*& Allocator(t, alloc1, alloc_id) &*
         {
             //@ let_lft 'a = k1;
             //@ std::alloc::init_ref_Allocator_at_lifetime::<'a, A>(alloc_ref);
-            r = alloc.allocate(new_layout);
+            r = alloc.allocate/*@::<A, 'a>@*/(new_layout);
             //@ leak Allocator(_, _, _);
         }
         //@ end_lifetime(k1);


### PR DESCRIPTION
VeriFast no longer incorrectly considers 'static equivalent with other
lifetimes in predicate type arguments.

Fixes #886.

Also, this commit introduces "inferred type expressions", placeholders
in type expressions to be filled in by the type checker through type
inference. These are not (yet?) exposed to the user but are generated by
the MIR translator as the translation for lifetimes that were erased in
MIR local variable types and function call type arguments. Core VeriFast
currently allows inferred types in local variable types and function
call type arguments.

Furthermore, VeriFast now no longer throws an error when needing to get
the typeid for an inferred type that has not yet been inferred. Instead,
it generates a fresh typeid symbol S. Once the inferred type has been
resolved to a type T, it assumes that S equals the typeid of T.
