### PR TITLE
[Rust] Treat S_sync PO pre semantically

### DIFF
--- a/bin/rust/rust_belt/general.rsspec
+++ b/bin/rust/rust_belt/general.rsspec
@@ -224,11 +224,91 @@ lem init_ref_share_m<T>(k: lifetime_t, t: thread_id_t, p: *T);
 
 fix is_Send(type_id: *_) -> bool;
 
+lem_auto is_Send_u8_def();
+    req true;
+    ens is_Send(typeid(u8)) == true;
+
+lem_auto is_Send_u16_def();
+    req true;
+    ens is_Send(typeid(u16)) == true;
+
+lem_auto is_Send_u32_def();
+    req true;
+    ens is_Send(typeid(u32)) == true;
+
+lem_auto is_Send_u64_def();
+    req true;
+    ens is_Send(typeid(u64)) == true;
+
+lem_auto is_Send_u128_def();
+    req true;
+    ens is_Send(typeid(u128)) == true;
+
+lem_auto is_Send_i8_def();
+    req true;
+    ens is_Send(typeid(i8)) == true;
+
+lem_auto is_Send_i16_def();
+    req true;
+    ens is_Send(typeid(i16)) == true;
+
+lem_auto is_Send_i32_def();
+    req true;
+    ens is_Send(typeid(i32)) == true;
+
+lem_auto is_Send_i64_def();
+    req true;
+    ens is_Send(typeid(i64)) == true;
+
+lem_auto is_Send_i128_def();
+    req true;
+    ens is_Send(typeid(i128)) == true;
+
 lem Send::send<T>(t0: thread_id_t, t1: thread_id_t, v: T);
     req type_interp::<T>() &*& is_Send(typeid(T)) == true &*& (<T>.own)(t0, v);
     ens type_interp::<T>() &*& (<T>.own)(t1, v);
 
 fix is_Sync(type_id: *_) -> bool;
+
+lem_auto is_Sync_u8_def();
+    req true;
+    ens is_Sync(typeid(u8)) == true;
+
+lem_auto is_Sync_u16_def();
+    req true;
+    ens is_Sync(typeid(u16)) == true;
+
+lem_auto is_Sync_u32_def();
+    req true;
+    ens is_Sync(typeid(u32)) == true;
+
+lem_auto is_Sync_u64_def();
+    req true;
+    ens is_Sync(typeid(u64)) == true;
+
+lem_auto is_Sync_u128_def();
+    req true;
+    ens is_Sync(typeid(u128)) == true;
+
+lem_auto is_Sync_i8_def();
+    req true;
+    ens is_Sync(typeid(i8)) == true;
+
+lem_auto is_Sync_i16_def();
+    req true;
+    ens is_Sync(typeid(i16)) == true;
+
+lem_auto is_Sync_i32_def();
+    req true;
+    ens is_Sync(typeid(i32)) == true;
+
+lem_auto is_Sync_i64_def();
+    req true;
+    ens is_Sync(typeid(i64)) == true;
+
+lem_auto is_Sync_i128_def();
+    req true;
+    ens is_Sync(typeid(i128)) == true;
 
 lem Sync::sync<T>(k: lifetime_t, t0: thread_id_t, t1: thread_id_t, l: *T);
     req type_interp::<T>() &*& is_Sync(typeid(T)) == true &*& [_](<T>.share)(k, t0, l);

--- a/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
+++ b/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
@@ -185,7 +185,7 @@ lem RawVecInner_own_mono<A0, A1>()
     req type_interp::<A0>() &*& type_interp::<A1>() &*& RawVecInner_own::<A0>(?t, ?v) &*& is_subtype_of::<A0, A1>() == true;
     ens type_interp::<A0>() &*& type_interp::<A1>() &*& RawVecInner_own::<A1>(t, RawVecInner::<A1> { ptr: upcast(v.ptr), cap: upcast(v.cap), alloc: upcast(v.alloc) });
 {
-    assume(false);
+    assume(false); // https://github.com/verifast/verifast/issues/610
 }
 
 lem RawVecInner_send<A>(t1: thread_id_t)
@@ -578,7 +578,7 @@ lem RawVec_own_mono<T0, T1, A0, A1>()
     req type_interp::<T0>() &*& type_interp::<T1>() &*& type_interp::<A0>() &*& type_interp::<A1>() &*& RawVec_own::<T0, A0>(?t, ?v) &*& is_subtype_of::<T0, T1>() == true &*& is_subtype_of::<A0, A1>() == true;
     ens type_interp::<T0>() &*& type_interp::<T1>() &*& type_interp::<A0>() &*& type_interp::<A1>() &*& RawVec_own::<T1, A1>(t, RawVec::<T1, A1> { inner: upcast(v.inner) });
 {
-    assume(false);
+    assume(false); // https://github.com/verifast/verifast/issues/610
 }
 
 lem RawVec_send<T, A>(t1: thread_id_t)
@@ -606,13 +606,13 @@ lem RawVec_share__mono<T, A>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *
 }
 
 lem RawVec_sync_<T, A>(t1: thread_id_t)
-    req type_interp::<T>() &*& type_interp::<A>() &*& is_Sync(typeid(T)) == true &*& [_]RawVec_share_::<T, A>(?k, ?t0, ?l, ?alloc_id, ?ptr, ?capacity);
+    req type_interp::<T>() &*& type_interp::<A>() &*& is_Sync(typeid(RawVec<T, A>)) == true &*& [_]RawVec_share_::<T, A>(?k, ?t0, ?l, ?alloc_id, ?ptr, ?capacity);
     ens type_interp::<T>() &*& type_interp::<A>() &*& [_]RawVec_share_::<T, A>(k, t1, l, alloc_id, ptr, capacity);
 {
-    assume(false); // TODO!
-    //open RawVec_share_::<T, A>(k, t0, l, alloc_id, ptr, capacity);
-    //RawVecInner_sync_::<A>(t1);
-    //close RawVec_share_::<T, A>(k, t1, l, alloc_id, ptr, capacity);
+    open RawVec_share_::<T, A>(k, t0, l, alloc_id, ptr, capacity);
+    RawVecInner_sync_::<A>(t1);
+    close RawVec_share_::<T, A>(k, t1, l, alloc_id, ptr, capacity);
+    leak RawVec_share_::<T, A>(k, t1, l, alloc_id, ptr, capacity);
 }
 
 pred RawVec_share_end_token<T, A>(k: lifetime_t, t: thread_id_t, l: *RawVec<T, A>, alloc_id: alloc_id_t, ptr: *T, capacity: usize) =
@@ -737,7 +737,7 @@ lem RawVec_share_full<T, A>(k: lifetime_t, t: thread_id_t, l: *RawVec<T, A>)
 }
 
 lem RawVec_sync<T, A>(t1: thread_id_t)
-    req type_interp::<T>() &*& type_interp::<A>() &*& is_Sync(typeid(T)) == true &*& [_]RawVec_share::<T, A>(?k, ?t0, ?l);
+    req type_interp::<T>() &*& type_interp::<A>() &*& is_Sync(typeid(RawVec<T, A>)) == true &*& [_]RawVec_share::<T, A>(?k, ?t0, ?l);
     ens type_interp::<T>() &*& type_interp::<A>() &*& [_]RawVec_share::<T, A>(k, t1, l);
 {
     open RawVec_share::<T, A>(k, t0, l);


### PR DESCRIPTION
The MIR translator computes, for each struct S defined by the program,
which type parameters of S are necessarily Send or Sync when S is Sync.
For each of these, it used to add a separate precondition to the S_sync
proof obligation. The problem with that is that the set computed by the
MIR translator is a conservative approximation, which does not take into
account the definitions of structs other than S. For example, this
analysis does not see that if RawVec<T, A> is Sync, then A is
necessarily Sync as well, because A only appears in the definition of
RawVec as part of type RawVecInner<A>, and the analysis does not look at
the definition of RawVecInner when analyzing struct S.

From now on, the precondition for S_sync is simply is_Sync(typeid(S)).
Separately, an is_Sync_S_lemma autolemma is generated that expresses the
information resulting from the MIR translator's analysis.  However, if S
has no explicit Sync impls, another lemma, called is_Sync_S_def, is now
also generated, stating is_Sync(S) == is_Sync(T1) && ... && is_Sync(Tn),
where T1, ..., Tn are the types of the fields of S. This means VeriFast
can now tell that is_Sync(RawVec<T, A>) implies is_Sync(A).

TODO: Generate an is_Sync_S_def lemma also if S has Sync impls.
