### PR TITLE
[Rust] If p1!=p2, assume ref_origins different

### DIFF
--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -6151,6 +6151,8 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
   
   let lazy_predfamsymb name = lazy_value (fun () -> get_pred_symb name)
   let lazy_purefuncsymb name = lazy_value (fun () -> get_pure_func_symb name)
+
+  let ref_origin_symb = lazy_purefuncsymb "ref_origin"
   
   let bitand_uintN_symb = lazy_purefuncsymb "bitand_uintN"
   let bitand_intN_symb = lazy_purefuncsymb "bitand_intN"

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -3144,6 +3144,9 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             cont h env (if op = Eq then true_term else false_term)
           end
           begin fun () ->
+            let v1, v2 =
+              if is_rust then mk_app !!ref_origin_symb [v1], mk_app !!ref_origin_symb [v2] else v1, v2
+            in
             assume (ctxt#mk_not (ctxt#mk_eq v1 v2)) $. fun () ->
             cont h env (if op = Eq then false_term else true_term)
           end


### PR DESCRIPTION
If a Rust expression `p1 == p2` evaluates to `false`, where `p1` and
`p2` are pointers, then we know the pointers are different, but we
also know `ref_origin(p1) != ref_origin(p2)`.

Also:
- cell.rs: Prove init_ref_Cell
- cell.rs: Modernize the proof
