### PR TITLE
vf_mir_exporter: Don't crash on const generic params

### DIFF
--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -2082,7 +2082,7 @@ mod vf_mir_builder {
                         let is_identifier = source_text.chars().all(|c| c.is_alphanumeric() || c == '_');
                         ref_data_cpn.set_is_implicit(is_identifier);
                     }
-                    let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::PostAnalysis, param_env: ty::ParamEnv::empty() };
+                    let typing_env = enc_ctx.body().typing_env(tcx);
                     ref_data_cpn.set_place_does_not_need_drop(!place_ty.ty.needs_drop(tcx, typing_env));
                 }
                 mir::Rvalue::ThreadLocalRef(def_id) => rvalue_cpn.set_thread_local_ref(()),
@@ -2133,7 +2133,7 @@ mod vf_mir_builder {
                                     None => {}
                                     Some(discr) => {
                                         if discr.val != i.try_into().unwrap() {
-                                            todo!()
+                                            todo!("For ADT {:?}, the discriminant value for variant index {} is not {}, but {:?}", ty.ty, i, i, discr);
                                         }
                                     }
                                 }

--- a/tests/rust/const_generic_param.rs
+++ b/tests/rust/const_generic_param.rs
@@ -1,0 +1,8 @@
+// verifast_options{skip_specless_fns}
+
+use std::mem::MaybeUninit;
+
+fn foo<T, const N: usize>() {
+    let zs: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+    let r = &zs;
+}

--- a/tests/rust/safe_abstraction/raw_vec/verified/Cargo.lock
+++ b/tests/rust/safe_abstraction/raw_vec/verified/Cargo.lock
@@ -3,5 +3,5 @@
 version = 4
 
 [[package]]
-name = "linked_list"
+name = "raw_vec"
 version = "0.1.0"

--- a/tests/rust/safe_abstraction/raw_vec/verified/Cargo.toml
+++ b/tests/rust/safe_abstraction/raw_vec/verified/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "linked_list"
+name = "raw_vec"
 version = "0.1.0"
 
 [dependencies]

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -1,4 +1,5 @@
 begin_parallel
+verifast -skip_specless_fns const_generic_param.rs
 verifast -allow_dead_code -allow_should_fail struct_layout.rs
 verifast ghost_cmd_inj.rs
 verifast parser_test.rs


### PR DESCRIPTION
The TypingEnv for analyzing types that occur inside a function body needs to include a ConstArgHasType clause for each of the function's const generic parameters.
