### PR TITLE
[Rust] Enums with explicit discriminants

### DIFF
--- a/src/refinement_checker/refinement_checker.ml
+++ b/src/refinement_checker/refinement_checker.ml
@@ -711,7 +711,7 @@ let fns_to_be_inlined: (string * body) list =
       {
         id={index=Stdint.Uint32.of_int 0};
         statements=[
-          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant (local "self")}; source_info={span}}
+          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant {place=local "self"; discriminant_ty=Signed ISize; discriminant_values=[]}}; source_info={span}}
         ];
         terminator={
           kind=SwitchInt {
@@ -954,7 +954,7 @@ let fns_to_be_inlined: (string * body) list =
       {
         id={index=Stdint.Uint32.of_int 0};
         statements=[
-          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant (local "self")}; source_info={span}}
+          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant {place=local "self"; discriminant_ty=Signed ISize; discriminant_values=[]}}; source_info={span}}
         ];
         terminator={
           kind=SwitchInt {
@@ -1196,7 +1196,7 @@ let fns_to_be_inlined: (string * body) list =
       {
         id={index=Stdint.Uint32.of_int 0};
         statements=[
-          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant (local "self")}; source_info={span}}
+          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant {place=local "self"; discriminant_ty=Signed ISize; discriminant_values=[]}}; source_info={span}}
         ];
         terminator={
           kind=SwitchInt {
@@ -1414,7 +1414,7 @@ let fns_to_be_inlined: (string * body) list =
       {
         id={index=Stdint.Uint32.of_int 0};
         statements=[
-          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant (local "self")}; source_info={span}}
+          {kind=Assign {lhs_place=local "discr"; rhs_rvalue=Discriminant {place=local "self"; discriminant_ty=Signed ISize; discriminant_values=[]}}; source_info={span}}
         ];
         terminator={
           kind=SwitchInt {
@@ -1639,7 +1639,7 @@ let commands_of_rvalue = function
 | BinaryOp {operator; operandl; operandr} -> commands_of_operand operandl @ commands_of_operand operandr @ [BinaryOp operator]
 | UnaryOp {operator; operand} -> commands_of_operand operand @ [UnaryOp operator]
 | Aggregate {aggregate_kind; operands} -> List.concat_map commands_of_operand operands @ [Aggregate (aggregate_kind, List.length operands)]
-| Discriminant place -> commands_for_loading_place place @ [Discriminant]
+| Discriminant {place} -> commands_for_loading_place place @ [Discriminant]
 
 let commands_of_statement_kind = function
   Assign {lhs_place; rhs_rvalue} ->
@@ -2074,7 +2074,7 @@ let check_rvalue_refines_rvalue genv0 env0 span0 caller0 rhsRvalue0 genv1 env1 s
 | UnaryOp unary_op_data_cpn0, UnaryOp unary_op_data_cpn1 -> failwith "Rvalue::UnaryOp not supported"
 | Aggregate aggregate_data_cpn0, Aggregate aggregate_data_cpn1 ->
   check_aggregate_refines_aggregate genv0 env0 span0 caller0 aggregate_data_cpn0 genv1 env1 span1 caller1 aggregate_data_cpn1
-| Discriminant place_cpn0, Discriminant place_cpn1 ->
+| Discriminant {place=place_cpn0}, Discriminant {place=place_cpn1} ->
   begin match check_place_refines_place env0 caller0 place_cpn0 env1 caller1 place_cpn1 with
     (Local x0, Local x1) | (LocalProjection x0, LocalProjection x1) -> if List.assoc x0 env0 <> List.assoc x1 env1 then failwith "The discriminees of the two rvalues are not equal"
   | Nonlocal, Nonlocal -> ()

--- a/src/refinement_checker/stringifier.ml
+++ b/src/refinement_checker/stringifier.ml
@@ -104,7 +104,7 @@ let string_of_rvalue = function
   | UnaryOp _ -> "<UnaryOp>"
   | Aggregate {aggregate_kind; operands} ->
     Printf.sprintf "%s(%s)" (string_of_aggregate_kind aggregate_kind) (String.concat ", " (List.map string_of_operand operands))
-  | Discriminant place ->
+  | Discriminant {place} ->
     Printf.sprintf "discriminant(%s)" (string_of_place place)
   | ShallowInitBox -> "<ShallowInitBox>"
 

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -537,6 +537,13 @@ struct AggregateKind {
     }
 }
 
+struct IntegerType {
+    union {
+        signed @0: IntTy;
+        unsigned @1: UIntTy;
+    }
+}
+
 struct Rvalue {
     struct AddressOfData {
         mutability @0: Mutability;
@@ -606,6 +613,12 @@ struct Rvalue {
         operands @1: List(Operand);
     }
 
+    struct DiscriminantData {
+        place @0: Place;
+        discriminantTy @1: IntegerType;
+        discriminantValues @2: List(UInt128); # The bit representations of the values of the discriminants for each variant of the ADT
+    }
+
     union {
         # Either move or copy depending on operand type
         use @0: Operand;
@@ -619,7 +632,7 @@ struct Rvalue {
         nullaryOp @11: Void;
         unaryOp @6: UnaryOpData;
         aggregate @5: AggregateData;
-        discriminant @7: Place;
+        discriminant @7: DiscriminantData;
         shallowInitBox @12: Void;
     }
 }

--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -1230,7 +1230,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               (iter (List.remove_assoc cn ctors) cs)
         in
         iter ctormap cs ()
-      | Int (_, _) -> 
+      | Int (_, _) as tp -> 
         let n = List.length (List.filter (function SwitchStmtDefaultClause (l, _) -> true | _ -> false) cs) in
         if n > 1 then static_error l "switch statement can have at most one default clause" None;
         let cs0 = cs in
@@ -1241,7 +1241,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
               begin fun state clause -> 
                 match clause with
                   SwitchStmtClause (l, i, ss) -> 
-                    let w2 = check_expr_t (pn,ilist) tparams tenv i intType in
+                    let w2 = check_expr_t (pn,ilist) tparams tenv i tp in
                     ctxt#mk_and state (ctxt#mk_not (ctxt#mk_eq v (ev w2))) 
                 | _ -> state
               end
@@ -1269,7 +1269,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           | c::cs' ->
             begin match c with
               SwitchStmtClause (l, i, ss) ->
-              let w2 = check_expr_t (pn,ilist) tparams tenv i intType in
+              let w2 = check_expr_t (pn,ilist) tparams tenv i tp in
               execute_branch $. fun () ->
               eval_h h env w2 $. fun h env t ->
               assume_eq t v $. fun () ->

--- a/src/verifast1.ml
+++ b/src/verifast1.ml
@@ -4865,10 +4865,12 @@ module VerifyProgram1(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ -> static_error l "List expression must not contain patterns" None
       in
       check (to_list_expr pats)
-    | CallExpr (l, "#inductive_ctor_index", [], [], [LitPat e], Static) ->
+    | CallExpr (l, "#inductive_discriminant", [discrTp], [], LitPat e::discrExprs, Static) ->
+      let discrTp = check_pure_type (pn,ilist) tparams Ghost discrTp in
       let w, t, _ = check e in
       let InductiveType (i, targs) = t in
-      (WFunCall (l, "#inductive_ctor_index", [t], [w], Static), Int (Signed, PtrRank), None)
+      let discrExprs = List.map (function LitPat e -> checkt e discrTp) discrExprs in
+      (WFunCall (l, "#inductive_discriminant", [t], w::discrExprs, Static), discrTp, None)
     | CallExpr (l, "#inductive_projection", [], [], [LitPat e; LitPat (WIntLit (_, ctor_index) as i1); LitPat (WIntLit (_, arg_index) as i2)], Static) ->
       let w, t, _ = check e in
       let InductiveType (i, targs) = t in

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -2777,7 +2777,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             | _ ->
               cont (Chunk ((get_pred_symb "malloc_block", true), [], real_unit, [result; sizeof_core l env t], None)::h)
         end
-    | WFunCall (l, "#inductive_ctor_index", [InductiveType (i, targs)], [w], Static) ->
+    | WFunCall (l, "#inductive_discriminant", [InductiveType (i, targs)], w::discrExprs, Static) ->
       eval_h h env w $. fun h env v ->
       let (_, inductive_tparams, ctormap, _, _, _, _, _, _) = List.assoc i inductivemap in
       let rec iter ctor_index ctormap =
@@ -2787,7 +2787,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             get_unique_var_symb (x ^ "__") pt
           in
           assume (ctxt#mk_eq v (mk_app ctorsymb args)) $. fun () ->
-          cont h env (ctxt#mk_intlit ctor_index)
+          cont h env (eval None [] (List.nth discrExprs ctor_index))
         in
         if ctormap = [] then verify_case () else branch verify_case (fun () -> iter (ctor_index + 1) ctormap)
       in

--- a/tests/rust/purely_unsafe/enum_discr.rs
+++ b/tests/rust/purely_unsafe/enum_discr.rs
@@ -1,0 +1,19 @@
+use std::cmp::Ordering;
+//@ use std::cmp::Ordering;
+
+unsafe fn reverse_ordering(o: Ordering) -> Ordering
+//@ req true;
+/*@
+ens result == match o {
+        Ordering::Less => Ordering::Greater,
+        Ordering::Equal => Ordering::Equal,
+        Ordering::Greater => Ordering::Less,
+    };
+@*/
+{
+    match o {
+        Ordering::Less => Ordering::Greater,
+        Ordering::Equal => Ordering::Equal,
+        Ordering::Greater => Ordering::Less
+    }
+}

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -30,6 +30,7 @@ pushd ../../rust_tutorials/purely_unsafe/solutions
 popd
 verifast -ignore_ref_creation -allow_assume nonnull.rs
 cd purely_unsafe
+  verifast enum_discr.rs
   verifast -ignore_unwind_paths leftpad.rs
   verifast arrays.rs
   verifast -allow_assume std_thread.rs


### PR DESCRIPTION
Until now, VeriFast only supported enums where each variant's discriminant equals its variant index.
