### PR TITLE
[Rust] Special-case alloc(Layout::new::<T>())

### DIFF
--- a/rust_tutorials/purely_unsafe/solutions/account.rs
+++ b/rust_tutorials/purely_unsafe/solutions/account.rs
@@ -11,13 +11,12 @@ impl Account {
 
     unsafe fn create() -> *mut Account
     //@ req true;
-    //@ ens Account_balance(result, 0) &*& alloc_block(result as *u8, Layout::new::<Account>());
+    //@ ens Account_balance(result, 0) &*& alloc_block_Account(result);
     {
         let my_account = alloc(Layout::new::<Account>()) as *mut Account;
         if my_account.is_null() {
             handle_alloc_error(Layout::new::<Account>());
         }
-        //@ close_struct(my_account);
         (*my_account).balance = 0;
         return my_account;
     }
@@ -30,10 +29,9 @@ impl Account {
     }
 
     unsafe fn dispose(my_account: *mut Account)
-    //@ req Account_balance(my_account, _) &*& alloc_block(my_account as *u8, Layout::new::<Account>());
+    //@ req Account_balance(my_account, _) &*& alloc_block_Account(my_account);
     //@ ens true;
     {
-        //@ open_struct(my_account);
         dealloc(my_account as *mut u8, Layout::new::<Account>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/account_unwind.rs
+++ b/rust_tutorials/purely_unsafe/solutions/account_unwind.rs
@@ -9,13 +9,12 @@ impl Account {
 
     unsafe fn create() -> *mut Account
     //@ req true;
-    //@ ens Account_balance(result, 0) &*& alloc_block(result as *u8, Layout::new::<Account>());
+    //@ ens Account_balance(result, 0) &*& alloc_block_Account(result);
     {
         let my_account = alloc(Layout::new::<Account>()) as *mut Account;
         if my_account.is_null() {
             handle_alloc_error(Layout::new::<Account>());
         }
-        //@ close_struct(my_account);
         (*my_account).balance = 0;
         return my_account;
     }
@@ -29,10 +28,9 @@ impl Account {
     }
 
     unsafe fn dispose(my_account: *mut Account)
-    //@ req Account_balance(my_account, _) &*& alloc_block(my_account as *u8, Layout::new::<Account>());
+    //@ req Account_balance(my_account, _) &*& alloc_block_Account(my_account);
     //@ ens true;
     {
-        //@ open_struct(my_account);
         dealloc(my_account as *mut u8, Layout::new::<Account>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/byref.rs
+++ b/rust_tutorials/purely_unsafe/solutions/byref.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -57,7 +55,6 @@ unsafe fn filter_nodes(n: *mut *mut Node, p: I32Predicate)
             //@ close Nodes(node, count + 1);
         } else {
             let next_ = (**n).next;
-            //@ open_struct(*n);
             dealloc(*n as *mut u8, Layout::new::<Node>());
             *n = next_;
             filter_nodes(n, p);
@@ -72,7 +69,6 @@ unsafe fn dispose_nodes(n: *mut Node)
     //@ open Nodes(n, _);
     if !n.is_null() {
         dispose_nodes((*n).next);
-        //@ open_struct(n);
         dealloc(n as *mut u8, Layout::new::<Node>());
     }
 }
@@ -87,7 +83,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -103,7 +98,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -120,7 +114,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -145,7 +138,6 @@ impl Stack {
     {
         //@ open Stack(stack, _);
         dispose_nodes((*stack).head);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/deposit.rs
+++ b/rust_tutorials/purely_unsafe/solutions/deposit.rs
@@ -11,13 +11,12 @@ impl Account {
 
     unsafe fn create() -> *mut Account
     //@ req true;
-    //@ ens Account_balance(result, 0) &*& alloc_block(result as *u8, Layout::new::<Account>());
+    //@ ens Account_balance(result, 0) &*& alloc_block_Account(result);
     {
         let my_account = alloc(Layout::new::<Account>()) as *mut Account;
         if my_account.is_null() {
             handle_alloc_error(Layout::new::<Account>());
         }
-        //@ close_struct(my_account);
         (*my_account).balance = 0;
         return my_account;
     }
@@ -47,10 +46,9 @@ impl Account {
     }
 
     unsafe fn dispose(my_account: *mut Account)
-    //@ req Account_balance(my_account, _) &*& alloc_block(my_account as *u8, Layout::new::<Account>());
+    //@ req Account_balance(my_account, _) &*& alloc_block_Account(my_account);
     //@ ens true;
     {
-        //@ open_struct(my_account);
         dealloc(my_account as *mut u8, Layout::new::<Account>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/dispose.rs
+++ b/rust_tutorials/purely_unsafe/solutions/dispose.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -42,7 +40,6 @@ unsafe fn dispose_nodes(n: *mut Node)
     //@ open Nodes(n, _);
     if !n.is_null() {
         dispose_nodes((*n).next);
-        //@ open_struct(n);
         dealloc(n as *mut u8, Layout::new::<Node>());
     }
 }
@@ -57,7 +54,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -86,7 +82,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -103,7 +98,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -115,7 +109,6 @@ impl Stack {
     {
         //@ open Stack(stack, _);
         dispose_nodes((*stack).head);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/filter.rs
+++ b/rust_tutorials/purely_unsafe/solutions/filter.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -60,7 +58,6 @@ unsafe fn filter_nodes(n: *mut Node, p: I32Predicate) -> *mut Node
             return n;
         } else {
             next = (*n).next;
-            //@ open_struct(n);
             dealloc(n as *mut u8, Layout::new::<Node>());
             let result = filter_nodes(next, p);
             return result;
@@ -75,7 +72,6 @@ unsafe fn dispose_nodes(n: *mut Node)
     //@ open Nodes(n, _);
     if !n.is_null() {
         dispose_nodes((*n).next);
-        //@ open_struct(n);
         dealloc(n as *mut u8, Layout::new::<Node>());
     }
 }
@@ -90,7 +86,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -106,7 +101,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -123,7 +117,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -148,7 +141,6 @@ impl Stack {
     {
         //@ open Stack(stack, _);
         dispose_nodes((*stack).head);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/fixpoints.rs
+++ b/rust_tutorials/purely_unsafe/solutions/fixpoints.rs
@@ -36,16 +36,14 @@ pred Nodes(node: *mut Node, values: i32s) =
     } else {
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, ?values0) &*&
         values == i32s_cons(value, values0)
     };
 
 pred Stack(stack: *mut Stack, values: i32s) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     Nodes(head, values);
 
 @*/
@@ -60,7 +58,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, i32s_nil);
         //@ close Stack(stack, i32s_nil);
@@ -76,7 +73,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -93,7 +89,6 @@ impl Stack {
         //@ open Nodes(head, values);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, i32s_tail(values));
         return result;
@@ -105,7 +100,6 @@ impl Stack {
     {
         //@ open Stack(stack, i32s_nil);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/foreach.rs
+++ b/rust_tutorials/purely_unsafe/solutions/foreach.rs
@@ -20,16 +20,14 @@ pred Nodes<T>(node: *mut Node<T>, values: list<T>) =
     } else {
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node<T>>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, ?values0) &*&
         values == cons(value, values0)
     };
 
 pred Stack<T>(stack: *mut Stack<T>, values: list<T>) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack<T>>()) &*&
+    alloc_block_Stack(stack) &*&
     Nodes(head, values);
 
 @*/
@@ -44,7 +42,6 @@ impl<T> Stack<T> {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack<T>>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes::<T>(0, nil);
         //@ close Stack(stack, nil);
@@ -60,7 +57,6 @@ impl<T> Stack<T> {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node<T>>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (&raw mut (*n).value).write(value);
         (*stack).head = n;
@@ -91,7 +87,6 @@ impl<T> Stack<T> {
         (*stack).head = (*head).next;
         let result = (&raw mut (*head).value).read();
         //@ close Node_value(head, _);
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node<T>>());
         //@ close Stack(stack, tail(values));
         result
@@ -103,7 +98,6 @@ impl<T> Stack<T> {
     {
         //@ open Stack(stack, nil);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack<T>>());
     }
 
@@ -130,8 +124,7 @@ struct Vector {
 
 pred Vector(v: *mut Vector) =
     (*v).x |-> ?x &*& (*v).y |-> ?y &*&
-    struct_Vector_padding(v) &*&
-    alloc_block(v as *u8, Layout::new::<Vector>());
+    alloc_block_Vector(v);
 
 @*/
 
@@ -145,7 +138,6 @@ impl Vector {
         if result.is_null() {
             handle_alloc_error(Layout::new::<Vector>());
         }
-        //@ close_struct(result);
         (*result).x = x;
         (*result).y = y;
         //@ close Vector(result);
@@ -183,9 +175,7 @@ fn main() {
                     //@ open foreach(tail(values), Vector);
                     //@ open Vector(v2);
                     let sum = Vector::create((*v1).x + (*v2).x, (*v1).y + (*v2).y);
-                    //@ open_struct(v1);
                     dealloc(v1 as *mut u8, Layout::new::<Vector>());
-                    //@ open_struct(v2);
                     dealloc(v2 as *mut u8, Layout::new::<Vector>());
                     Stack::push(s, sum);
                     //@ close foreach(cons(sum, tail(tail(values))), Vector);
@@ -199,7 +189,6 @@ fn main() {
                     //@ open Vector(v_);
                     output_i32((*v_).x);
                     output_i32((*v_).y);
-                    //@ open_struct(v_);
                     dealloc(v_ as *mut u8, Layout::new::<Vector>());
                 }
                 _ => {

--- a/rust_tutorials/purely_unsafe/solutions/fractions.rs
+++ b/rust_tutorials/purely_unsafe/solutions/fractions.rs
@@ -42,8 +42,7 @@ pred Tree(t: *mut Tree, depth: i32) =
         (*t).left |-> ?left &*& Tree(left, depth - 1) &*&
         (*t).right |-> ?right &*& Tree(right, depth - 1) &*&
         (*t).value |-> ?value &*&
-        struct_Tree_padding(t) &*&
-        alloc_block(t as *u8, Layout::new::<Tree>())
+        alloc_block_Tree(t)
     };
 
 fn_type FoldFunction() = unsafe fn(acc: i32, x: i32) -> i32;
@@ -71,7 +70,6 @@ impl Tree {
             if t.is_null() {
                 handle_alloc_error(Layout::new::<Tree>());
             }
-            //@ close_struct(t);
             (*t).left = left;
             (*t).right = right;
             (*t).value = value;
@@ -137,8 +135,7 @@ unsafe fn start_fold_thread(tree: *mut Tree, f: FoldFunction, acc: i32) -> *mut 
     if data.is_null() {
         handle_alloc_error(Layout::new::<FoldData>());
     }
-    //@ close_struct(data);
-    //@ leak alloc_block(data as *u8, _) &*& struct_FoldData_padding(data);
+    //@ leak alloc_block_FoldData(data);
     (*data).tree = tree;
     (*data).f = f;
     (*data).acc = acc;

--- a/rust_tutorials/purely_unsafe/solutions/fractions0.rs
+++ b/rust_tutorials/purely_unsafe/solutions/fractions0.rs
@@ -42,8 +42,7 @@ pred Tree(t: *mut Tree, depth: i32) =
         (*t).left |-> ?left &*& Tree(left, depth - 1) &*&
         (*t).right |-> ?right &*& Tree(right, depth - 1) &*&
         (*t).value |-> ?value &*&
-        struct_Tree_padding(t) &*&
-        alloc_block(t as *u8, Layout::new::<Tree>())
+        alloc_block_Tree(t)
     };
 
 fn_type FoldFunction() = unsafe fn(acc: i32, x: i32) -> i32;
@@ -71,7 +70,6 @@ impl Tree {
             if t.is_null() {
                 handle_alloc_error(Layout::new::<Tree>());
             }
-            //@ close_struct(t);
             (*t).left = left;
             (*t).right = right;
             (*t).value = value;
@@ -137,8 +135,7 @@ unsafe fn start_fold_thread(tree: *mut Tree, f: FoldFunction, acc: i32) -> *mut 
     if data.is_null() {
         handle_alloc_error(Layout::new::<FoldData>());
     }
-    //@ close_struct(data);
-    //@ leak alloc_block(data as *u8, _) &*& struct_FoldData_padding(data);
+    //@ leak alloc_block_FoldData(data);
     (*data).tree = tree;
     (*data).f = f;
     (*data).acc = acc;
@@ -189,7 +186,7 @@ fn main() {
         let sum_left = join_fold_thread(left_data);
         let sum_right = join_fold_thread(right_data);
         let f = fac((*tree).value);
-        //@ leak (*tree).left |-> _ &*& (*tree).right |-> _ &*& (*tree).value |-> _ &*& struct_Tree_padding(tree) &*& alloc_block(tree as *u8, _);
+        //@ leak (*tree).left |-> _ &*& (*tree).right |-> _ &*& (*tree).value |-> _ &*& alloc_block_Tree(tree);
         print_i32(sum_left + sum_right + f);
     }
 }

--- a/rust_tutorials/purely_unsafe/solutions/generics.rs
+++ b/rust_tutorials/purely_unsafe/solutions/generics.rs
@@ -20,16 +20,14 @@ pred Nodes<T>(node: *mut Node<T>, values: list<T>) =
     } else {
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node<T>>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, ?values0) &*&
         values == cons(value, values0)
     };
 
 pred Stack<T>(stack: *mut Stack<T>, values: list<T>) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack<T>>()) &*&
+    alloc_block_Stack(stack) &*&
     Nodes(head, values);
 
 @*/
@@ -44,7 +42,6 @@ impl<T> Stack<T> {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack<T>>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes::<T>(0, nil);
         //@ close Stack(stack, nil);
@@ -60,7 +57,6 @@ impl<T> Stack<T> {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node<T>>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (&raw mut (*n).value).write(value);
         (*stack).head = n;
@@ -91,7 +87,6 @@ impl<T> Stack<T> {
         (*stack).head = (*head).next;
         let result = (&raw mut (*head).value).read();
         //@ close Node_value(head, _);
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node<T>>());
         //@ close Stack(stack, tail(values));
         result
@@ -130,7 +125,6 @@ impl<T> Stack<T> {
     {
         //@ open Stack(stack, nil);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack<T>>());
     }
 
@@ -145,13 +139,12 @@ impl Point {
 
     unsafe fn create(x: i32, y: i32) -> *mut Point
     //@ req true;
-    //@ ens (*result).x |-> x &*& (*result).y |-> y &*& struct_Point_padding(result) &*& alloc_block(result as *u8, Layout::new::<Point>());
+    //@ ens (*result).x |-> x &*& (*result).y |-> y &*& alloc_block_Point(result);
     {
         let result = alloc(Layout::new::<Point>()) as *mut Point;
         if result.is_null() {
             handle_alloc_error(Layout::new::<Point>());
         }
-        //@ close_struct(result);
         (*result).x = x;
         (*result).y = y;
         result

--- a/rust_tutorials/purely_unsafe/solutions/leaks/src/main.rs
+++ b/rust_tutorials/purely_unsafe/solutions/leaks/src/main.rs
@@ -46,8 +46,7 @@ struct CountPulsesData {
 pred count_pulses_pre(data: *mut CountPulsesData) =
     (*data).counter |-> ?counter &*&
     (*data).source |-> ?source &*&
-    struct_CountPulsesData_padding(data) &*&
-    alloc_block(data as *u8, Layout::new::<CountPulsesData>()) &*&
+    alloc_block_CountPulsesData(data) &*&
     [_](*counter).mutex |-> ?mutex &*& [_]Mutex(mutex, Counter(counter));
 
 @*/
@@ -59,7 +58,6 @@ unsafe fn count_pulses(data: *mut CountPulsesData)
     //@ open count_pulses_pre(data);
     let counter = (*data).counter;
     let source = (*data).source;
-    //@ open_struct(data);
     dealloc(data as *mut u8, Layout::new::<CountPulsesData>());
 
     let mutex = (*counter).mutex;
@@ -84,7 +82,6 @@ unsafe fn count_pulses_async(counter: *mut Counter, source: i32)
     if data.is_null() {
         handle_alloc_error(Layout::new::<CountPulsesData>());
     }
-    //@ close_struct(data);
     (*data).counter = counter;
     (*data).source = source;
     //@ close count_pulses_pre(data);
@@ -122,7 +119,6 @@ fn main() {
         if counter.is_null() {
             handle_alloc_error(Layout::new::<Counter>());
         }
-        //@ close_struct(counter);
         (*counter).count = 0;
         //@ close Counter(counter)();
         //@ close exists(Counter(counter));

--- a/rust_tutorials/purely_unsafe/solutions/lemma.rs
+++ b/rust_tutorials/purely_unsafe/solutions/lemma.rs
@@ -14,8 +14,7 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *mut u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
@@ -25,8 +24,7 @@ pred lseg(first: *mut Node, last: *mut Node, count: i32) =
     } else {
         0 < count &*& first != 0 &*&
         (*first).value |-> ?value &*& (*first).next |-> ?next &*&
-        struct_Node_padding(first) &*&
-        alloc_block(first as *mut u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(first) &*&
         lseg(next, last, count - 1)
     };
 

--- a/rust_tutorials/purely_unsafe/solutions/limit.rs
+++ b/rust_tutorials/purely_unsafe/solutions/limit.rs
@@ -12,13 +12,12 @@ impl Account {
 
     unsafe fn create(limit: i32) -> *mut Account
     //@ req limit <= 0;
-    //@ ens (*result).limit |-> limit &*& (*result).balance |-> 0 &*& struct_Account_padding(result) &*& alloc_block(result as *u8, Layout::new::<Account>());
+    //@ ens (*result).limit |-> limit &*& (*result).balance |-> 0 &*& alloc_block_Account(result);
     {
         let my_account = alloc(Layout::new::<Account>()) as *mut Account;
         if my_account.is_null() {
             handle_alloc_error(Layout::new::<Account>());
         }
-        //@ close_struct(my_account);
         (*my_account).limit = limit;
         (*my_account).balance = 0;
         return my_account;
@@ -51,10 +50,9 @@ impl Account {
     }
 
     unsafe fn dispose(my_account: *mut Account)
-    //@ req (*my_account).limit |-> _ &*& (*my_account).balance |-> _ &*& struct_Account_padding(my_account) &*& alloc_block(my_account as *u8, Layout::new::<Account>());
+    //@ req (*my_account).limit |-> _ &*& (*my_account).balance |-> _ &*& alloc_block_Account(my_account);
     //@ ens true;
     {
-        //@ open_struct(my_account);
         dealloc(my_account as *mut u8, Layout::new::<Account>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/map.rs
+++ b/rust_tutorials/purely_unsafe/solutions/map.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -61,7 +59,6 @@ unsafe fn dispose_nodes(n: *mut Node)
     //@ open Nodes(n, _);
     if !n.is_null() {
         dispose_nodes((*n).next);
-        //@ open_struct(n);
         dealloc(n as *mut u8, Layout::new::<Node>());
     }
 }
@@ -76,7 +73,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -92,7 +88,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -109,7 +104,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -130,7 +124,6 @@ impl Stack {
     {
         //@ open Stack(stack, _);
         dispose_nodes((*stack).head);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/mutexes/src/main.rs
+++ b/rust_tutorials/purely_unsafe/solutions/mutexes/src/main.rs
@@ -37,8 +37,7 @@ struct CountPulsesData {
 pred count_pulses_pre(data: *mut CountPulsesData) =
     (*data).counter |-> ?counter &*&
     (*data).source |-> ?source &*&
-    struct_CountPulsesData_padding(data) &*&
-    alloc_block(data as *u8, Layout::new::<CountPulsesData>()) &*&
+    alloc_block_CountPulsesData(data) &*&
     [1/2](*counter).mutex |-> ?mutex &*& [1/3]Mutex(mutex, Counter(counter));
 
 @*/
@@ -50,7 +49,6 @@ unsafe fn count_pulses(data: *mut CountPulsesData)
     //@ open count_pulses_pre(data);
     let counter = (*data).counter;
     let source = (*data).source;
-    //@ open_struct(data);
     dealloc(data as *mut u8, Layout::new::<CountPulsesData>());
 
     let mutex = (*counter).mutex;
@@ -74,7 +72,6 @@ unsafe fn count_pulses_async(counter: *mut Counter, source: i32)
     if data.is_null() {
         handle_alloc_error(Layout::new::<CountPulsesData>());
     }
-    //@ close_struct(data);
     (*data).counter = counter;
     (*data).source = source;
     //@ close count_pulses_pre(data);
@@ -88,7 +85,6 @@ fn main() {
         if counter.is_null() {
             handle_alloc_error(Layout::new::<Counter>());
         }
-        //@ close_struct(counter);
         (*counter).count = 0;
         //@ close Counter(counter)();
         //@ close exists(Counter(counter));

--- a/rust_tutorials/purely_unsafe/solutions/popn.rs
+++ b/rust_tutorials/purely_unsafe/solutions/popn.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -59,7 +57,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -98,7 +95,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -115,7 +111,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -149,12 +144,10 @@ impl Stack {
             }
             //@ open Nodes(n, _);
             let next = (*n).next;
-            //@ open_struct(n);
             dealloc(n as *mut u8, Layout::new::<Node>());
             n = next;
         }
         //@ open Nodes(0, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/pred.rs
+++ b/rust_tutorials/purely_unsafe/solutions/pred.rs
@@ -12,7 +12,7 @@ struct Account {
 
 pred Account_pred(my_account: *mut Account, theLimit: i32, theBalance: i32) =
     (*my_account).limit |-> theLimit &*& (*my_account).balance |-> theBalance &*&
-    struct_Account_padding(my_account) &*& alloc_block(my_account as *u8, Layout::new::<Account>());
+    alloc_block_Account(my_account);
 
 @*/
 
@@ -26,7 +26,6 @@ impl Account {
         if my_account.is_null() {
             handle_alloc_error(Layout::new::<Account>());
         }
-        //@ close_struct(my_account);
         (*my_account).limit = limit;
         (*my_account).balance = 0;
         //@ close Account_pred(my_account, limit, 0);
@@ -68,7 +67,6 @@ impl Account {
     //@ ens true;
     {
         //@ open Account_pred(my_account, _, _);
-        //@ open_struct(my_account);
         dealloc(my_account as *mut u8, Layout::new::<Account>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/predctors.rs
+++ b/rust_tutorials/purely_unsafe/solutions/predctors.rs
@@ -20,16 +20,14 @@ pred Nodes<T>(node: *mut Node<T>, values: list<T>) =
     } else {
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node<T>>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, ?values0) &*&
         values == cons(value, values0)
     };
 
 pred Stack<T>(stack: *mut Stack<T>, values: list<T>) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack<T>>()) &*&
+    alloc_block_Stack(stack) &*&
     Nodes(head, values);
 
 @*/
@@ -44,7 +42,6 @@ impl<T> Stack<T> {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack<T>>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes::<T>(0, nil);
         //@ close Stack(stack, nil);
@@ -60,7 +57,6 @@ impl<T> Stack<T> {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node<T>>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (&raw mut (*n).value).write(value);
         (*stack).head = n;
@@ -91,7 +87,6 @@ impl<T> Stack<T> {
         (*stack).head = (*head).next;
         let result = (&raw mut (*head).value).read();
         //@ close Node_value(head, _);
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node<T>>());
         //@ close Stack(stack, tail(values));
         result
@@ -103,7 +98,6 @@ impl<T> Stack<T> {
     {
         //@ open Stack(stack, nil);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack<T>>());
     }
 
@@ -130,8 +124,7 @@ struct Vector {
 
 pred_ctor Vector(limit: i32)(v: *mut Vector) =
     (*v).x |-> ?x &*& (*v).y |-> ?y &*&
-    struct_Vector_padding(v) &*&
-    alloc_block(v as *u8, Layout::new::<Vector>()) &*&
+    alloc_block_Vector(v) &*&
     x * x + y * y <= limit * limit;
 
 @*/
@@ -149,7 +142,6 @@ impl Vector {
         if result.is_null() {
             handle_alloc_error(Layout::new::<Vector>());
         }
-        //@ close_struct(result);
         (*result).x = x;
         (*result).y = y;
         //@ close Vector(limit)(result);
@@ -188,9 +180,7 @@ fn main() {
                     //@ open foreach(tail(values), Vector(limit));
                     //@ open Vector(limit)(v2);
                     let sum = Vector::create(limit, (*v1).x + (*v2).x, (*v1).y + (*v2).y);
-                    //@ open_struct(v1);
                     dealloc(v1 as *mut u8, Layout::new::<Vector>());
-                    //@ open_struct(v2);
                     dealloc(v2 as *mut u8, Layout::new::<Vector>());
                     Stack::push(s, sum);
                     //@ close foreach(cons(sum, tail(tail(values))), Vector(limit));
@@ -204,7 +194,6 @@ fn main() {
                     //@ open Vector(limit)(v_);
                     output_i32((*v_).x);
                     output_i32((*v_).y);
-                    //@ open_struct(v_);
                     dealloc(v_ as *mut u8, Layout::new::<Vector>());
                 }
                 _ => {

--- a/rust_tutorials/purely_unsafe/solutions/push_all.rs
+++ b/rust_tutorials/purely_unsafe/solutions/push_all.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -39,8 +37,7 @@ pred lseg(first: *mut Node, last: *mut Node, count: i32) =
     } else {
         0 < count &*& first != 0 &*&
         (*first).value |-> ?value &*& (*first).next |-> ?next &*&
-        struct_Node_padding(first) &*&
-        alloc_block(first as *mut u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(first) &*&
         lseg(next, last, count - 1)
     };
 
@@ -68,7 +65,7 @@ lem lseg_to_Nodes_lemma(first: *mut Node)
 
 lem lseg_add_lemma(first: *mut Node)
     req lseg(first, ?last, ?count) &*& last != 0 &*& (*last).value |-> ?last_value &*& (*last).next |-> ?next &*&
-        struct_Node_padding(last) &*& alloc_block(last as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(last) &*&
         lseg(next, 0, ?count0);
     ens lseg(first, next, count + 1) &*& lseg(next, 0, count0);
 {
@@ -108,7 +105,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -150,7 +146,6 @@ impl Stack {
         //@ open Stack(other, count0);
         //@ Nodes_to_lseg_lemma((*other).head);
         let head0 = (*other).head;
-        //@ open_struct(other);
         dealloc(other as *mut u8, Layout::new::<Stack>());
         let mut n = head0;
         //@ open lseg(head0, 0, count0);
@@ -159,8 +154,8 @@ impl Stack {
             loop {
                 /*@
                 inv lseg(head0, n, ?count1) &*& n != 0 &*& (*n).value |-> ?n_value &*& 
-                    (*n).next |-> ?next &*& struct_Node_padding(n) &*&
-                    alloc_block(n as *u8, Layout::new::<Node>()) &*&
+                    (*n).next |-> ?next &*&
+                    alloc_block_Node(n) &*&
                     lseg(next, 0, count0 - count1 - 1);
                 @*/
                 if (*n).next.is_null() {
@@ -189,7 +184,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -206,7 +200,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -218,7 +211,6 @@ impl Stack {
     {
         //@ open Stack(stack, 0);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/reverse.rs
+++ b/rust_tutorials/purely_unsafe/solutions/reverse.rs
@@ -74,16 +74,14 @@ pred Nodes(node: *mut Node, values: i32s) =
     } else {
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, ?values0) &*&
         values == i32s_cons(value, values0)
     };
 
 pred Stack(stack: *mut Stack, values: i32s) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     Nodes(head, values);
 
 @*/
@@ -98,7 +96,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, i32s_nil);
         //@ close Stack(stack, i32s_nil);
@@ -114,7 +111,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -131,7 +127,6 @@ impl Stack {
         //@ open Nodes(head, values);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, i32s_tail(values));
         return result;
@@ -171,7 +166,6 @@ impl Stack {
     {
         //@ open Stack(stack, i32s_nil);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/stack.rs
+++ b/rust_tutorials/purely_unsafe/solutions/stack.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -45,7 +43,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -61,7 +58,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -78,7 +74,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -90,7 +85,6 @@ impl Stack {
     {
         //@ open Stack(stack, 0);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/stack_tuerk.rs
+++ b/rust_tutorials/purely_unsafe/solutions/stack_tuerk.rs
@@ -15,7 +15,7 @@ pred Nodes(node: *mut Node, count: i32) =
     } else {
         0 < count &*&
         (*node).next |-> ?next &*& (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*& alloc_block(node as *mut u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 

--- a/rust_tutorials/purely_unsafe/solutions/sum.rs
+++ b/rust_tutorials/purely_unsafe/solutions/sum.rs
@@ -21,15 +21,13 @@ pred Nodes(node: *mut Node, count: i32) =
         0 < count &*&
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, count - 1)
     };
 
 pred Stack(stack: *mut Stack, count: i32) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     0 <= count &*&
     Nodes(head, count);
 
@@ -59,7 +57,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, 0);
         //@ close Stack(stack, 0);
@@ -98,7 +95,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -115,7 +111,6 @@ impl Stack {
         //@ open Nodes(head, count);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, count - 1);
         return result;
@@ -134,12 +129,10 @@ impl Stack {
             }
             //@ open Nodes(n, _);
             let next = (*n).next;
-            //@ open_struct(n);
             dealloc(n as *mut u8, Layout::new::<Node>());
             n = next;
         }
         //@ open Nodes(0, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/sum_full.rs
+++ b/rust_tutorials/purely_unsafe/solutions/sum_full.rs
@@ -36,16 +36,14 @@ pred Nodes(node: *mut Node, values: i32s) =
     } else {
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, ?values0) &*&
         values == i32s_cons(value, values0)
     };
 
 pred Stack(stack: *mut Stack, values: i32s) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     Nodes(head, values);
 
 fix i32s_sum(values: i32s) -> i32 {
@@ -81,7 +79,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, i32s_nil);
         //@ close Stack(stack, i32s_nil);
@@ -107,7 +104,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -124,7 +120,6 @@ impl Stack {
         //@ open Nodes(head, values);
         let result = (*head).value;
         (*stack).head = (*head).next;
-        //@ open_struct(head);
         dealloc(head as *mut u8, Layout::new::<Node>());
         //@ close Stack(stack, i32s_tail(values));
         return result;
@@ -136,7 +131,6 @@ impl Stack {
     {
         //@ open Stack(stack, i32s_nil);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/rust_tutorials/purely_unsafe/solutions/threads.rs
+++ b/rust_tutorials/purely_unsafe/solutions/threads.rs
@@ -42,8 +42,7 @@ pred Tree(t: *mut Tree, depth: i32) =
         (*t).left |-> ?left &*& Tree(left, depth - 1) &*&
         (*t).right |-> ?right &*& Tree(right, depth - 1) &*&
         (*t).value |-> ?value &*&
-        struct_Tree_padding(t) &*&
-        alloc_block(t as *u8, Layout::new::<Tree>())
+        alloc_block_Tree(t)
     };
 
 @*/
@@ -65,7 +64,6 @@ impl Tree {
             if t.is_null() {
                 handle_alloc_error(Layout::new::<Tree>());
             }
-            //@ close_struct(t);
             (*t).left = left;
             (*t).right = right;
             (*t).value = value;
@@ -126,8 +124,7 @@ unsafe fn start_sum_thread(tree: *mut Tree) -> *mut SumData
     if data.is_null() {
         handle_alloc_error(Layout::new::<SumData>());
     }
-    //@ close_struct(data);
-    //@ leak alloc_block(data as *u8, _) &*& struct_SumData_padding(data);
+    //@ leak alloc_block_SumData(data);
     (*data).tree = tree;
     //@ close summator_pre(data, summator_post(data));
     /*@
@@ -168,7 +165,7 @@ fn main() {
         let sum_left = join_sum_thread(left_data);
         let sum_right = join_sum_thread(right_data);
         let f = fac((*tree).value);
-        //@ leak (*tree).left |-> _ &*& (*tree).right |-> _ &*& (*tree).value |-> _ &*& struct_Tree_padding(tree) &*& alloc_block(tree as *u8, _);
+        //@ leak (*tree).left |-> _ &*& (*tree).right |-> _ &*& (*tree).value |-> _ &*& alloc_block_Tree(tree);
         print_i32(sum_left + sum_right + f);
     }
 }

--- a/rust_tutorials/purely_unsafe/solutions/threads0.rs
+++ b/rust_tutorials/purely_unsafe/solutions/threads0.rs
@@ -40,8 +40,7 @@ pred Tree(t: *mut Tree, depth: i32) =
         (*t).left |-> ?left &*& Tree(left, depth - 1) &*&
         (*t).right |-> ?right &*& Tree(right, depth - 1) &*&
         (*t).value |-> ?value &*&
-        struct_Tree_padding(t) &*&
-        alloc_block(t as *u8, Layout::new::<Tree>())
+        alloc_block_Tree(t)
     };
 
 @*/
@@ -63,7 +62,6 @@ impl Tree {
             if t.is_null() {
                 handle_alloc_error(Layout::new::<Tree>());
             }
-            //@ close_struct(t);
             (*t).left = left;
             (*t).right = right;
             (*t).value = value;

--- a/rust_tutorials/purely_unsafe/solutions/values.rs
+++ b/rust_tutorials/purely_unsafe/solutions/values.rs
@@ -22,16 +22,14 @@ pred Nodes(node: *mut Node, values: i32s) =
     } else {
         (*node).next |-> ?next &*&
         (*node).value |-> ?value &*&
-        struct_Node_padding(node) &*&
-        alloc_block(node as *u8, Layout::new::<Node>()) &*&
+        alloc_block_Node(node) &*&
         Nodes(next, ?values0) &*&
         values == i32s_cons(value, values0)
     };
 
 pred Stack(stack: *mut Stack, values: i32s) =
     (*stack).head |-> ?head &*&
-    struct_Stack_padding(stack) &*&
-    alloc_block(stack as *u8, Layout::new::<Stack>()) &*&
+    alloc_block_Stack(stack) &*&
     Nodes(head, values);
 
 @*/
@@ -46,7 +44,6 @@ impl Stack {
         if stack.is_null() {
             handle_alloc_error(Layout::new::<Stack>());
         }
-        //@ close_struct(stack);
         (*stack).head = std::ptr::null_mut();
         //@ close Nodes(0, i32s_nil);
         //@ close Stack(stack, i32s_nil);
@@ -62,7 +59,6 @@ impl Stack {
         if n.is_null() {
             handle_alloc_error(Layout::new::<Node>());
         }
-        //@ close_struct(n);
         (*n).next = (*stack).head;
         (*n).value = value;
         (*stack).head = n;
@@ -76,7 +72,6 @@ impl Stack {
     {
         //@ open Stack(stack, i32s_nil);
         //@ open Nodes(_, _);
-        //@ open_struct(stack);
         dealloc(stack as *mut u8, Layout::new::<Stack>());
     }
 

--- a/src/rust_frontend/vf_mir_exporter/src/lib.rs
+++ b/src/rust_frontend/vf_mir_exporter/src/lib.rs
@@ -361,6 +361,10 @@ impl<'tcx> rustc_hir::intravisit::Visitor<'tcx> for HirVisitor<'tcx> {
     fn visit_item(&mut self, item: &'tcx rustc_hir::Item<'tcx>) {
         match &item.kind {
             rustc_hir::ItemKind::Fn{ident, sig, generics, body, has_body} => {
+                if ident.as_str().starts_with("VeriFast_") || ident.as_str().starts_with("VF_") {
+                    // Skip VeriFast helper functions
+                    return;
+                }
                 self.bodies.push((item.owner_id.def_id, sig.span))
             }
             // We cannot send DefId of a struct to optimize_mir query

--- a/tests/rust/purely_unsafe/account.rs
+++ b/tests/rust/purely_unsafe/account.rs
@@ -1,5 +1,7 @@
 // verifast_options{ignore_unwind_paths}
 
+use std::alloc::{Layout, alloc, handle_alloc_error, dealloc};
+
 unsafe fn assert(b: bool)
 //@ req b;
 //@ ens true;
@@ -12,7 +14,7 @@ struct Account {
 /*@
 
 pred Account(account: *Account; balance: i32) =
-    std::alloc::alloc_block(account as *u8, std::alloc::Layout::new::<Account>()) &*& struct_Account_padding(account) &*&
+    alloc_block_Account(account) &*&
     (*account).balance |-> balance;
 
 @*/
@@ -23,11 +25,10 @@ impl Account {
     //@ req true;
     //@ ens Account(result, 0);
     {
-        let account = std::alloc::alloc(std::alloc::Layout::new::<Account>()) as *mut Account;
+        let account = alloc(Layout::new::<Account>()) as *mut Account;
         if account.is_null() {
-            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Account>());
+            handle_alloc_error(Layout::new::<Account>());
         }
-        //@ close_struct(account);
         (*account).balance = 0;
         return account;
     }
@@ -50,8 +51,7 @@ impl Account {
     //@ req Account(account, _);
     //@ ens true;
     {
-        //@ open_struct(account);
-        std::alloc::dealloc(account as *mut u8, std::alloc::Layout::new::<Account>());
+        dealloc(account as *mut u8, Layout::new::<Account>());
     }
 
 }

--- a/tests/rust/purely_unsafe/account_value.rs
+++ b/tests/rust/purely_unsafe/account_value.rs
@@ -64,12 +64,10 @@ fn main2() {
         if account_ptr.is_null() {
             handle_alloc_error(Layout::new::<Account>());
         }
-        //@ close_struct(account_ptr);
         Account::init(account_ptr);
         Account::deposit(account_ptr, 1000);
         assert(Account::get_balance(account_ptr) == 1000);
         Account::drop_in_place(account_ptr);
-        //@ open_struct(account_ptr);
         dealloc(account_ptr as *mut u8, Layout::new::<Account>());
     }
 }

--- a/tests/rust/purely_unsafe/arrays.rs
+++ b/tests/rust/purely_unsafe/arrays.rs
@@ -28,7 +28,6 @@ fn test2() {
         if foo.is_null() {
             handle_alloc_error(Layout::new::<Foo>());
         }
-        //@ close_struct(foo);
         let p: *mut i32 = &raw mut (*foo).xs as *mut i32;
         *p = 10;
         *p.add(1) = 20;
@@ -42,7 +41,6 @@ fn test2() {
         //@ close array_(p + 2, 1, _);
         //@ close array_(p + 1, 2, _);
         //@ close array_(p, 3, _);
-        //@ open_struct(foo);
         dealloc(foo as *mut u8, Layout::new::<Foo>());
     }
 }

--- a/tests/rust/purely_unsafe/point_value.rs
+++ b/tests/rust/purely_unsafe/point_value.rs
@@ -60,17 +60,17 @@ fn main1() {
 
 fn main2() {
     unsafe {
-        let point_ptr = alloc(Layout::new::<Point>()) as *mut Point;
+        let point_ptr = alloc((Layout::new::<Point>())) as *mut Point;
         if point_ptr.is_null() {
             handle_alloc_error(Layout::new::<Point>());
         }
-        //@ close_struct(point_ptr);
+        //@ from_u8s_(point_ptr);
         Point::init(point_ptr);
         Point::set_x(point_ptr, 1000);
         assert(Point::get_x(point_ptr) == 1000);
         Point::drop_in_place(point_ptr);
-        //@ open_struct(point_ptr);
-        dealloc(point_ptr as *mut u8, Layout::new::<Point>());
+        //@ to_u8s_(point_ptr);
+        dealloc(point_ptr as *mut u8, (Layout::new::<Point>()));
     }
 }
 

--- a/tests/rust/purely_unsafe/tree3.rs
+++ b/tests/rust/purely_unsafe/tree3.rs
@@ -1,5 +1,7 @@
 // verifast_options{ignore_unwind_paths}
 
+use std::alloc::{Layout, alloc, handle_alloc_error, dealloc};
+
 /*@
 
 lem_auto bitand_zero(y: usize)
@@ -77,8 +79,7 @@ lem_auto node_count_positive(tree: tree)
 
 pred Tree(node: *mut Tree; parent: *mut Tree, shape: tree) =
     node != 0 &*&
-    std::alloc::alloc_block(node as *u8, std::alloc::Layout::new::<Tree>()) &*&
-    struct_Tree_padding(node) &*&
+    alloc_block_Tree(node) &*&
     node as usize & 1 == 0 &*&
     pointer_within_limits(node as *mut u8 + 1) == true &*&
     (*node).data |-> ?data &*&
@@ -115,8 +116,7 @@ pred stack(parent: *mut Tree, current: *mut Tree, cShape: tree, root: *mut Tree,
         stepsLeft == 0 &*&
         elems_todo == []
     } else {
-        std::alloc::alloc_block(parent as *u8, std::alloc::Layout::new::<Tree>()) &*&
-        struct_Tree_padding(parent) &*&
+        alloc_block_Tree(parent) &*&
         parent as usize & 1 == 0 &*&
         pointer_within_limits(parent as *mut u8 + 1) == true &*&
         (*parent).data |-> ?data &*&
@@ -167,12 +167,12 @@ impl Tree {
     //@ req Tree(left, _, ?leftShape) &*& Tree(right, _, ?rightShape);
     //@ ens Tree(result, 0, nonempty(data, result, leftShape, rightShape));
     {
-        let result = std::alloc::alloc(std::alloc::Layout::new::<Tree>()) as *mut Tree;
+        let result = alloc(Layout::new::<Tree>()) as *mut Tree;
         if result.is_null() {
-            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Tree>());
+            handle_alloc_error(Layout::new::<Tree>());
         }
         //@ assume(result as usize & 1 == 0);
-        //@ close_struct(result);
+        //@ assume(pointer_within_limits(result as *mut u8 + 1));
         (*result).data = data;
         (*result).left = left;
         (*left).parent = result;
@@ -186,12 +186,12 @@ impl Tree {
     //@ req true;
     //@ ens Tree(result, 0, empty(result));
     {
-        let result = std::alloc::alloc(std::alloc::Layout::new::<Tree>()) as *mut Tree;
+        let result = alloc(Layout::new::<Tree>()) as *mut Tree;
         if result.is_null() {
-            std::alloc::handle_alloc_error(std::alloc::Layout::new::<Tree>());
+            handle_alloc_error(Layout::new::<Tree>());
         }
         //@ assume(result as usize & 1 == 0);
-        //@ close_struct(result);
+        //@ assume(pointer_within_limits(result as *mut u8 + 1));
         (*result).data = std::ptr::null_mut();
         (*result).left = std::ptr::null_mut();
         (*result).right = std::ptr::null_mut();
@@ -261,8 +261,7 @@ impl Tree {
             Self::dispose((*tree).left);
             Self::dispose((*tree).right);
         }
-        //@ open_struct(tree);
-        std::alloc::dealloc(tree as *mut u8, std::alloc::Layout::new::<Tree>());
+        dealloc(tree as *mut u8, Layout::new::<Tree>());
     }
 
 }


### PR DESCRIPTION
VeriFast for Rust now syntactically looks for source code fragments exactly matching

alloc(Layout::new::<T>()) as *mut T

for some T, and symbolically executes it specially, in the same way that VeriFast for C symbolically executes malloc(sizeof(T)): it produces fields chunks and an alloc_block_T(result) chunk (but no padding chunk).

Similarly, it now looks for source code fragments exactly matching

dealloc(E as *mut u8, Layout::new::<T>())

and symbolically executes it specially, in the same way that VeriFast for C symbolically executes free((T *)E): it consumes the field chunks and the malloc_block_T(E) chunk.
