### PR TITLE
vfide: Don't error on virtual paths

### DIFF
--- a/rust_tutorials/purely_unsafe/solutions/foreach.rs
+++ b/rust_tutorials/purely_unsafe/solutions/foreach.rs
@@ -131,13 +131,7 @@ struct Vector {
     y: i32,
 }
 
-/*@
-
-pred Vector(v: *mut Vector) =
-    (*v).x |-> ?x &*& (*v).y |-> ?y &*&
-    alloc_block_Vector(v);
-
-@*/
+//@ pred Vector(v: *mut Vector) = (*v).x |-> ?x &*& (*v).y |-> ?y &*& alloc_block_Vector(v);
 
 impl Vector {
 
@@ -157,7 +151,10 @@ impl Vector {
     
 }
 
-fn main() {
+fn main()
+//@ req true;
+//@ ens true;
+{
     unsafe {
         let s = Stack::create();
         //@ close foreach(nil, Vector);
@@ -196,9 +193,7 @@ fn main() {
                     output_i32((*v_).y);
                     dealloc(v_ as *mut u8, Layout::new::<Vector>());
                 }
-                _ => {
-                    std::process::abort();
-                }
+                _ => panic!("Bad command")
             }
         }
     }

--- a/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
+++ b/src/rust_frontend/vf_mir_translator/vf_mir_translator.ml
@@ -434,7 +434,7 @@ module Make (Args : VF_MIR_TRANSLATOR_ARGS) = struct
     | LocalPath path -> Ok path
     | Remapped {local_path=local_path_opt_cpn; virtual_name} ->
         match local_path_opt_cpn with
-        | Nothing -> Ok virtual_name
+        | Nothing -> Ok ("/RUSTC_VIRTUAL_PATH" ^ virtual_name)
         | Something {text} ->
             Ok text
 


### PR DESCRIPTION
Before this patch, vfide showed a "Could not load file" error dialog if the
program used assert! or another macro whose source code is in the Rust standard
library and the user did not install the rustc sources on their local machine.
