### PR TITLE
[vec] into_raw_parts_with_alloc

### DIFF
--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -14,6 +14,7 @@ struct std_tuple_0_ {}
 struct std_tuple_1_<T1>(T1)
 struct std_tuple_2_<T1, T2>(T1, T2)
 struct std_tuple_3_<T1, T2, T3>(T1, T2, T3)
+struct std_tuple_4_<T1, T2, T3, T4>(T1, T2, T3, T4)
 
 
 /*@
@@ -31,6 +32,14 @@ lem close_tuple_0_own(t: thread_id_t);
     ens <()>.own(t, std_tuple_0_ {});
 
 pred<T1, T2> <(T1, T2)>.share(k, t, l) = <T1>.share(k, t, &(*l).0) &*& <T2>.share(k, t, &(*l).1);
+
+lem open_tuple_4_own<T1, T2, T3, T4>(t: thread_id_t, v: (T1, T2, T3, T4));
+    req <(T1, T2, T3, T4)>.own(t, v);
+    ens <T1>.own(t, v.0) &*& <T2>.own(t, v.1) &*& <T3>.own(t, v.2) &*& <T4>.own(t, v.3);
+
+lem close_tuple_4_own<T1, T2, T3, T4>(t: thread_id_t, v: (T1, T2, T3, T4));
+    req <T1>.own(t, v.0) &*& <T2>.own(t, v.1) &*& <T3>.own(t, v.2) &*& <T4>.own(t, v.3);
+    ens <(T1, T2, T3, T4)>.own(t, v);
 
 @*/
 

--- a/bin/rust/prelude_core.rsspec
+++ b/bin/rust/prelude_core.rsspec
@@ -163,6 +163,8 @@ ens of_u8s_::<T>(u8s__of::<T>(v)) == v;
 pred points_to_<t>(p: *t; v: option<t>);
 pred points_to<t>(p: *t; v: t) = points_to_::<t>(p, some(v));
 
+pred_ctor mk_points_to<T>(p: *T, v: T)(;) = points_to(p, v);
+
 lem points_to_bool_to_u8(p: *bool);
     req *p |-> ?b;
     ens *(p as *u8) |-> b;

--- a/bin/rust/rust_belt/general.rsspec
+++ b/bin/rust/rust_belt/general.rsspec
@@ -203,6 +203,9 @@ fix type_depth(typeId: *_) -> i32;
 
 pred type_interp<T>(;) = ghost_rec_perm(type_depth(typeid(T)));
 
+// The intersection of the lifetimes that appear in type T, or 'static if no lifetimes appear in T
+fix lft_of_type<T>() -> lifetime_t;
+
 lem share_mono<T>(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *T);
     req type_interp::<T>() &*& lifetime_inclusion(k1, k) == true &*& [_](<T>.share)(k, t, l);
     ens type_interp::<T>() &*& [_](<T>.share)(k1, t, l);

--- a/bin/rust/rust_belt/lem_aux.rsspec
+++ b/bin/rust/rust_belt/lem_aux.rsspec
@@ -28,4 +28,42 @@ lem u32_share_mono(k: lifetime_t, k1: lifetime_t, t: thread_id_t, l: *u32)
     leak u32_share(k1, t, l);
 }
 
+pred points_to_shared<T>(k: lifetime_t, l: *T, v: T) =
+    [_]frac_borrow(k, mk_points_to(l, v));
+
+lem init_ref_readonly_points_to_shared<T>(l: *T)
+    nonghost_callers_only
+    req ref_init_perm(l, ?l0) &*& [_]points_to_shared(?k, l0, ?v) &*& [?q]lifetime_token(k);
+    ens [q]lifetime_token(k) &*& [_]points_to_shared(k, l, v) &*& [_]frac_borrow(k, ref_initialized_(l));
+{
+    open points_to_shared(k, l0, v);
+    open_frac_borrow_strong_(k, mk_points_to(l0, v), q);
+    open [?f]mk_points_to::<T>(l0, v)();
+    init_ref_readonly(l, 1/2);
+    close ref_initialized_::<T>(l)();
+    close [f/2]mk_points_to::<T>(l, v)();
+    close scaledp(f/2, mk_points_to(l, v))();
+    close sep_(ref_initialized_(l), scaledp(f/2, mk_points_to(l, v)))();
+    {
+        pred Ctx() = ref_readonly_end_token(l, l0, f/2) &*& [f/2](*l0 |-> v);
+        close Ctx();
+        produce_lem_ptr_chunk restore_frac_borrow(Ctx, sep_(ref_initialized_(l), scaledp(f/2, mk_points_to(l, v))), f, mk_points_to(l0, v))() {
+            open Ctx();
+            open sep_(ref_initialized_(l), scaledp(f/2, mk_points_to(l, v)))();
+            open ref_initialized_::<T>(l)();
+            open scaledp(f/2, mk_points_to(l, v))();
+            open [f/2]mk_points_to::<T>(l, v)();
+            end_ref_readonly(l);
+            close [f]mk_points_to::<T>(l0, v)();
+        } {
+            close_frac_borrow_strong_();
+        }
+    }
+    full_borrow_into_frac(k, sep_(ref_initialized_(l), scaledp(f/2, mk_points_to(l, v))));
+    frac_borrow_split(k, ref_initialized_(l), scaledp(f/2, mk_points_to(l, v)));
+    frac_borrow_implies_scaled(k, f/2, mk_points_to(l, v));
+    close points_to_shared(k, l, v);
+    leak points_to_shared(k, l, v);
+}
+
 @*/

--- a/bin/rust/rust_belt/lifetime_logic.rsspec
+++ b/bin/rust/rust_belt/lifetime_logic.rsspec
@@ -472,6 +472,14 @@ lem close_frac_borrow_strong_m();
     req atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& close_frac_borrow_token_strong(?k1, ?P, ?q, ?k, ?f) &*& is_frac_borrow_convert_strong(?c, ?Ctx, ?Q, k1, f, P) &*& Ctx() &*& Q();
     ens atomic_mask(mask) &*& full_borrow(k1, Q) &*& [q]lifetime_token(k) &*& is_frac_borrow_convert_strong(c, Ctx, Q, k1, f, P);
 
+lem open_frac_borrow_strong__m(k: lifetime_t, P: pred(;), q: real);
+    req atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& [_]frac_borrow(k, P) &*& [q]lifetime_token(k);
+    ens atomic_mask(mask) &*& [?f]P() &*& close_frac_borrow_strong_token_(k, P, q, f) &*& 0 < f &*& f < 1;
+
+lem close_frac_borrow_strong__m();
+    req atomic_mask(?mask) &*& mask_le(Nlft, mask) == true &*& close_frac_borrow_strong_token_(?k, ?P, ?q, ?f) &*& is_restore_frac_borrow(?lemPtr, ?Ctx, ?Q, f, P) &*& Ctx() &*& Q();
+    ens atomic_mask(mask) &*& full_borrow(k, Q) &*& [q]lifetime_token(k) &*& is_restore_frac_borrow(lemPtr, Ctx, Q, f, P);
+
 // Lemmas for proving init_ref_S proof obligations. Not in RustBelt; TODO: check soundness!
 pred close_frac_borrow_for_init_ref_lemma_token(fr: real, q: real, k: lifetime_t, P: pred(;));
 

--- a/bin/rust/rust_belt/points_to_at_lifetime.rsspec
+++ b/bin/rust/rust_belt/points_to_at_lifetime.rsspec
@@ -32,6 +32,13 @@ lem close_points_to_at_lft<T>(p: *T);
     req close_points_to_at_lft_token(?f, ?k, p, ?q) &*& [f](*p |-> ?v);
     ens [f]points_to_at_lft(k, p, v) &*& [q]lifetime_token(k);
 
+pred_ctor full_borrow_content_at_lft<T>(k: lifetime_t, t: thread_id_t, p: *T)() =
+    points_to_at_lft(k, p, ?v) &*& <T>.own(t, v);
+
+lem full_borrow_at_lft_to_full_borrow<T>(k: lifetime_t, k0: lifetime_t, t: thread_id_t, p: *T);
+    req full_borrow(k, full_borrow_content_at_lft(k0, t, p)) &*& lifetime_inclusion(k, k0) == true;
+    ens full_borrow(k, <T>.full_borrow_content(t, p));
+
 pred array_at_lft_<T>(k: lifetime_t, p: *T, n: usize; vs: list<option<T>>) =
     pointer_within_limits(p) == true &*&
     if n == 0 {
@@ -58,6 +65,17 @@ lem_auto array_at_lft_inv<T>();
     req [?f]array_at_lft::<T>(?k, ?p, ?count, ?elems);
     ens [f]array_at_lft::<T>(k, p, count, elems) &*& count == length(elems) &*& count * std::mem::size_of::<T>() <= isize::MAX &*& pointer_within_limits(p) == true &*& pointer_within_limits(p + count) == true;
 
+lem array_at_lft__join<T>(p: *T);
+    req array_at_lft_(?k, p, ?n1, ?vs1) &*& array_at_lft_(k, p + n1, ?n2, ?vs2);
+    ens array_at_lft_(k, p, n1 + n2, append(vs1, vs2));
+
+lem array_at_lft__split<T>(p: *T, n1: usize);
+    req array_at_lft_(?k, p, ?n, ?vs) &*& 0 <= n1 &*& n1 <= n;
+    ens array_at_lft_(k, p, n1, take(n1, vs)) &*& array_at_lft_(k, p + n1, n - n1, drop(n1, vs));
+
+lem array_at_lft_to_array_at_lft_<T>(p: *T);
+    req array_at_lft(?k, p, ?n, ?vs);
+    ens array_at_lft_(k, p, n, map(some, vs));
 
 pred close_array_at_lft_token<T>(f: real, k: lifetime_t, p: *T, n: usize, q: real);
 

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -362,6 +362,10 @@ mod mem {
     //@ ens result == (std::mem::size_of::<T>() == 0);
     //@ on_unwind_ens false;
     
+    fn MAX_SLICE_LEN<T>() -> usize; // The VeriFast MIR translator translates T::MAX_SLICE_LEN unevaluated constants to MAX_SLICE_LEN::<T>() calls.
+    //@ req true;
+    //@ ens result == if std::mem::size_of::<T>() == 0 { usize::MAX } else { isize::MAX / std::mem::size_of::<T>() };
+    
     fn align_of<T>() -> usize;
     //@ req true;
     //@ ens result == std::mem::align_of::<T>();
@@ -801,6 +805,10 @@ mod alloc {
             result.size() == n * layout.size() &*&
             result.align() == layout.align();
     
+    lem Layout_repeat_0_intro(layout: Layout);
+        req true;
+        ens layout.repeat(0) != none;
+    
     pred end_ref_Layout_token(p: *Layout, x: *Layout, f: real);
     
     lem init_ref_Layout(p: *Layout, coef: real);
@@ -882,6 +890,10 @@ mod alloc {
     
     pred Allocator<A>(t: thread_id_t, alloc: A, alloc_id: alloc_id_t);
     pred Allocator_share<A>(k: lifetime_t, t: thread_id_t, l: *A, alloc_id: alloc_id_t);
+
+    lem Allocator_inv<A>();
+        req Allocator::<A>(?t, ?alloc, ?alloc_id);
+        ens Allocator::<A>(t, alloc, alloc_id) &*& lifetime_inclusion(lft_of_type::<A>(), alloc_id.lft) == true;
     
     lem Allocator_upcast<A0, A1>(alloc: A0);
         req Allocator::<A0>(?t, alloc, ?alloc_id) &*& is_subtype_of::<A0, A1>() == true;

--- a/src/rust_frontend/vf_mir/vf_mir.capnp
+++ b/src/rust_frontend/vf_mir/vf_mir.capnp
@@ -706,6 +706,13 @@ struct StatementKind {
 
     union {
         assign @0: AssignData;
+        setDiscriminant @2: Void; # TODO: Elaborate
+        deinit @8: Void; # TODO: Elaborate
+        storageLive @3: LocalDeclId;
+        storageDead @4: LocalDeclId;
+        placeMention @5: Place;
+        assume @6: Operand;
+        copyNonOverlapping @7: Void; # TODO: Elaborate
         nop @1: Void;
     }
 }

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -1745,7 +1745,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ -> produce_points_to ()
       end @@ fun (tparams, fields, padding_predsymb_opt) ->
       let tpenv = List.combine tparams targs in
-      let producePaddingChunk = match language, dialect, fields with CLang, Some Rust, [] -> false | _ -> producePaddingChunk in
+      let producePaddingChunk = match language, dialect, fields with CLang, Some Rust, ([]|[_]) -> false | _ -> producePaddingChunk in
       let field_values_of_struct_as_value v =
         let (_, csym, getters, _, _) = List.assoc sn struct_accessor_map in
         if getters = [] then ctxt#assert_term (ctxt#mk_eq v (ctxt#mk_app csym []));
@@ -1886,7 +1886,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         | _ -> consume_points_to_chunk ()
       end @@ fun tparams fields padding_predsymb_opt ->
       let tpenv = List.combine tparams targs in
-      let consumePaddingChunk = match language, dialect, fields with CLang, Some Rust, [] -> false | _ -> consumePaddingChunk in
+      let consumePaddingChunk = match language, dialect, fields with CLang, Some Rust, ([]|[_]) -> false | _ -> consumePaddingChunk in
       begin fun cont ->
         match consumePaddingChunk, padding_predsymb_opt with
           true, Some padding_predsymb ->


### PR DESCRIPTION
Also:
- Fixes #949
- Allow loop spec loops in ghost code
- Support T::MAX_SLICE_LEN
- open_points_to and close_points_to no longer produce/consume padding chunk for single-field Rust struct

TODO: Merge the RawVec proof into the Vec proof
