### PR TITLE
[Rust] Stop assuming size_of::<*T>() == size_of::<usize>()

### DIFF
--- a/bin/rust/rust_belt/general.rsspec
+++ b/bin/rust/rust_belt/general.rsspec
@@ -106,7 +106,7 @@ lem close_na_inv_m(t: thread_id_t, m: mask_t);
 
 pred bool_own(t: thread_id_t, v: bool;) = true;
 pred char_own(t: thread_id_t, v: char;) = 0 <= v as u32 && v as u32 <= 0xD7FF || 0xE000 <= v as u32 && v as u32 <= 0x10FFFF;
-pred raw_ptr_own(t: thread_id_t, v: *_;) = true;
+pred_ctor raw_ptr_own<T>()(t: thread_id_t, v: *T;) = true;
 
 pred i8_own(t: thread_id_t, v: i8;) = true;
 pred i16_own(t: thread_id_t, v: i16;) = true;
@@ -150,7 +150,7 @@ pred_ctor own<T>(t: thread_id_t)(v: T) = (<T>.own)(t, v);
 
 type_pred_def <bool>.own = bool_own;
 //TODO: How to deal with Rust type `char`? Distinct Rust types should be mapped to distinct VF types, with distinct typeids.
-type_pred_def <*_>.own = raw_ptr_own;
+type_pred_def for <T> <*T>.own = raw_ptr_own::<T>;
 
 type_pred_def <i8>.own = i8_own;
 type_pred_def <i16>.own = i16_own;

--- a/src/mysh/mysh.ml
+++ b/src/mysh/mysh.ml
@@ -379,10 +379,10 @@ let rec exec_cmds macros cwd parallel cmds =
       | _ ->
         acquire_run_permission ();
         let pid = processes_started_counter () in
-        if !verbose then do_print_line (Printf.sprintf "Starting process %d" pid);
         let time0 = Unix.gettimeofday () in
         let cwd = getcwd () in
         let line' = if cwd = "." then line else cwd ^ "$ " ^ line in
+        if !verbose then do_print_line (Printf.sprintf "Starting process %d: %s" pid line');
         Mutex.lock global_mutex;
         Sys.chdir (get_abs_path ".");
         let negate_exit_status, line =

--- a/tests/rust/safe_abstraction/vec/verified/vec/mod.rs
+++ b/tests/rust/safe_abstraction/vec/verified/vec/mod.rs
@@ -1783,7 +1783,7 @@ impl<T, A: Allocator> Vec<T, A> {
         open <Vec<T, A>>.own(currentThread, self);
         assert Vec(currentThread, self, ?alloc_id, ?ptr, ?capacity, ?length);
         let result = call();
-        close raw_ptr_own(currentThread, result.0);
+        close raw_ptr_own::<T>(currentThread, result.0);
         close usize_own(currentThread, result.1);
         close usize_own(currentThread, result.2);
         std::alloc::Allocator_to_own(result.3);

--- a/tests/rust/size_of_ptr_unsized.rs
+++ b/tests/rust/size_of_ptr_unsized.rs
@@ -1,0 +1,4 @@
+unsafe fn size_of_ptr<T: ?Sized>() -> usize
+//@ req true;
+//@ ens result == 8; //~should_fail
+{ std::mem::size_of::<*const T>() }

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -1,4 +1,5 @@
 begin_parallel
+verifast -allow_should_fail size_of_ptr_unsized.rs
 verifast -skip_specless_fns const_generic_param.rs
 verifast -allow_dead_code -allow_should_fail struct_layout.rs
 verifast ghost_cmd_inj.rs


### PR DESCRIPTION
Because it's not true for fat pointers (i.e. if T is a DST).

This also means pointer types cannot all have the same typeid.

Fixes #951
