### PR TITLE
[Rust] Pointers may have metadata

### DIFF
--- a/bin/rust/aliasing.rsspec
+++ b/bin/rust/aliasing.rsspec
@@ -8,7 +8,7 @@ fix is_shared_ref_provenance(prov: pointer_provenance) -> bool;
 fix is_shared_ref(x: *_) -> bool { is_shared_ref_provenance((x as pointer).provenance) }
 
 fix ref_origin_provenance(prov: pointer_provenance) -> pointer_provenance;
-fix ref_origin<t>(p: *t) -> *t { pointer_ctor(ref_origin_provenance((p as pointer).provenance), (p as pointer).address) as *t }
+fix ref_origin<t>(p: *t) -> *t { pointer_ctor(ref_origin_provenance((p as pointer).provenance), (p as pointer).address, (p as pointer).metadata) as *t }
 
 lem_auto(ptr_provenance_min_addr(ref_origin_provenance(prov))) ref_origin_min_addr(prov: pointer_provenance);
     req true;
@@ -27,7 +27,7 @@ pred ref_mut_end_token<T>(p: *T; x: *T);
 pred ref_init_perm<T>(p: *T; x: *T);
 pred ref_padding_init_perm<T>(p: *T; x: *T);
 
-lem_auto ref_init_perm_inv<T>();
+lem_auto ref_init_perm_inv<T: ?Sized>();
     req ref_init_perm::<T>(?p, ?x);
     ens ref_init_perm::<T>(p, x) &*& ref_origin(p) == ref_origin(x);
 

--- a/bin/rust/prelude_core.rsspec
+++ b/bin/rust/prelude_core.rsspec
@@ -70,13 +70,41 @@ lem div_rem_nonneg_unique(D: i32, d: i32, q: i32, r: i32);
 
 inductive pointer_provenance =
     pointer_provenance_ctor(i32); // Do not rely on this definition; it is subject to change.
-inductive pointer = pointer_ctor(provenance: pointer_provenance, address: usize);
+inductive pointer_metadata =
+    pointer_metadata_ctor(i32); // Do not rely on this definition; it is subject to change.
+inductive pointer = pointer_ctor(provenance: pointer_provenance, address: usize, metadata: pointer_metadata);
+
+fix pointer_metadata_none() -> pointer_metadata;
+
+fix strip_pointer_metadata(p: pointer) -> pointer {
+    pointer_ctor(p.provenance, p.address, pointer_metadata_none)
+}
+
+// - If from_typeid and to_typeid have the same kind of metadata (e.g. they are both slice-based types), this preserves it
+// - If to_typeid has no metadata, this strips it
+// - Otherwise, the result is unspecified
+fix cast_pointer_metadata(from_typeid: *_, to_typeid: *_, metadata: pointer_metadata) -> pointer_metadata;
+
+fix pointer_cast(from_typeid: *_, to_typeid: *_, p: pointer) -> pointer {
+    pointer_ctor(p.provenance, p.address, cast_pointer_metadata(from_typeid, to_typeid, p.metadata))
+}
+
+fix ptr_cast<T, U>(p: *T) -> *U { pointer_cast(typeid(T), typeid(U), p as pointer) as *U }
 
 fix null_pointer_provenance() -> pointer_provenance;
-fix null_pointer() -> pointer { pointer_ctor(null_pointer_provenance, 0) }
+fix null_pointer() -> pointer { pointer_ctor(null_pointer_provenance, 0, pointer_metadata_none) }
+
+// Retain only the data that is definitely used for pointer equality tests
+fix strip_pointer_provenance(p: pointer) -> pointer {
+    pointer_ctor(null_pointer_provenance, p.address, p.metadata)
+}
 
 fix ptr_add(p: pointer, offset: i32) -> pointer {
-    pointer_ctor(p.provenance, p.address + offset)
+    pointer_ctor(p.provenance, p.address + offset, p.metadata)
+}
+
+fix ptr_add_strip_metadata(p: pointer, offset: i32) -> pointer {
+    pointer_ctor(p.provenance, p.address + offset, pointer_metadata_none)
 }
 
 fix field_ptr_provenance(p: pointer, structTypeid: *_, fieldOffset: i32) -> pointer_provenance;
@@ -85,10 +113,14 @@ fix field_ptr_provenance_parent(pr: pointer_provenance, fieldOffset: i32) -> poi
 lem_auto(field_ptr_provenance(p, structTypeid, fieldOffset)) field_ptr_provenance_injective(p: pointer, structTypeid: *_, fieldOffset: i32);
     req true;
     ens field_ptr_provenance_parent(field_ptr_provenance(p, structTypeid, fieldOffset), fieldOffset) == p;
-    
+
 fix field_ptr(p: pointer, structTypeid: *_, fieldOffset: i32) -> pointer {
-    pointer_ctor(field_ptr_provenance(p, structTypeid, fieldOffset), p.address + fieldOffset)
-}   
+    pointer_ctor(field_ptr_provenance(p, structTypeid, fieldOffset), p.address + fieldOffset, pointer_metadata_none)
+}
+
+fix last_field_ptr(p: pointer, structTypeid: *_, fieldOffset: i32) -> pointer {
+    pointer_ctor(field_ptr_provenance(p, structTypeid, fieldOffset), p.address + fieldOffset, p.metadata)
+}
 
 fix ptr_provenance_min_addr(pr: pointer_provenance) -> usize;
 fix ptr_provenance_max_addr(pr: pointer_provenance) -> usize;
@@ -137,6 +169,10 @@ lem_auto(pointer_within_limits(field_ptr(p as pointer, structTypeid, fieldOffset
     req true;
     ens field_pointer_within_limits(p, fieldOffset) == pointer_within_limits(field_ptr(p as pointer, structTypeid, fieldOffset) as *_);
 
+lem_auto(pointer_within_limits(last_field_ptr(p as pointer, structTypeid, fieldOffset) as *_)) last_field_pointer_within_limits_def(p: *_, structTypeid: *_, fieldOffset: i32);
+    req true;
+    ens field_pointer_within_limits(p, fieldOffset) == pointer_within_limits(last_field_ptr(p as pointer, structTypeid, fieldOffset) as *_);
+
 lem_auto(field_pointer_within_limits(field_ptr(p as pointer, structTypeid, fieldOffset) as *_, 0)) first_field_pointer_within_limits_elim(p: *_, structTypeid: *_, fieldOffset: i32);
     req true;
     ens field_pointer_within_limits(field_ptr(p as pointer, structTypeid, fieldOffset) as *_, 0) == field_pointer_within_limits(p, fieldOffset);
@@ -156,7 +192,7 @@ fix transmute_uint<T>(n: u128) -> T;
 fix u8s__of<T>(v: T) -> list<option<u8>>;
 fix of_u8s_<T>(cs: list<option<u8>>) -> T;
 
-lem_auto(of_u8s_::<T>(u8s__of::<T>(v as T))) of_u8s__u8s__of<T>(v: T);
+lem_auto(of_u8s_::<T>(u8s__of::<T>(v as T))) of_u8s__u8s__of<T: ?Sized>(v: T);
 req true;
 ens of_u8s_::<T>(u8s__of::<T>(v)) == v;
 
@@ -197,11 +233,11 @@ pred array<T>(p: *T, count: usize; values: list<T>) =
         *p |-> ?value &*& array(p + 1, count - 1, ?values0) &*& values == cons(value, values0)
     };
 
-lem_auto array__inv<T>();
+lem_auto array__inv<T: ?Sized>();
     req [?f]array_::<T>(?p, ?count, ?elems);
     ens [f]array_::<T>(p, count, elems) &*& count == length(elems) &*& count * std::mem::size_of::<T>() <= isize::MAX &*& pointer_within_limits(p) == true &*& pointer_within_limits(p + count) == true;
     
-lem_auto array_inv<T>();
+lem_auto array_inv<T: ?Sized>();
     req [?f]array::<T>(?p, ?count, ?elems);
     ens [f]array::<T>(p, count, elems) &*& count == length(elems) &*& count * std::mem::size_of::<T>() <= isize::MAX &*& pointer_within_limits(p) == true &*& pointer_within_limits(p + count) == true;
 

--- a/bin/rust/rust_belt/points_to_at_lifetime.rsspec
+++ b/bin/rust/rust_belt/points_to_at_lifetime.rsspec
@@ -57,11 +57,11 @@ pred array_at_lft<T>(k: lifetime_t, p: *T, n: usize; vs: list<T>) =
         vs == cons(v, vs0)
     };
 
-lem_auto array_at_lft__inv<T>();
+lem_auto array_at_lft__inv<T: ?Sized>();
     req [?f]array_at_lft_::<T>(?k, ?p, ?count, ?elems);
     ens [f]array_at_lft_::<T>(k, p, count, elems) &*& count == length(elems) &*& count * std::mem::size_of::<T>() <= isize::MAX &*& pointer_within_limits(p) == true &*& pointer_within_limits(p + count) == true;
     
-lem_auto array_at_lft_inv<T>();
+lem_auto array_at_lft_inv<T: ?Sized>();
     req [?f]array_at_lft::<T>(?k, ?p, ?count, ?elems);
     ens [f]array_at_lft::<T>(k, p, count, elems) &*& count == length(elems) &*& count * std::mem::size_of::<T>() <= isize::MAX &*& pointer_within_limits(p) == true &*& pointer_within_limits(p + count) == true;
 

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -395,11 +395,11 @@ mod mem {
     fix MaybeUninit::uninit<T>() -> MaybeUninit<T>;
     fix MaybeUninit::new_maybe_uninit<T>(v: option<T>) -> MaybeUninit<T>;
     
-    lem_auto MaybeUninit_inner_new<T>(v: T);
+    lem_auto MaybeUninit_inner_new<T: ?Sized>(v: T);
         req true;
         ens MaybeUninit::new(v).inner() == some(v);
     
-    lem_auto MaybeUninit_inner_new_maybe_uninit<T>(v: option<T>);
+    lem_auto MaybeUninit_inner_new_maybe_uninit<T: ?Sized>(v: option<T>);
         req true;
         ens MaybeUninit::new_maybe_uninit(v).inner() == v;
     
@@ -439,11 +439,11 @@ mod mem {
         req array_at_lft_(?k, self, ?n, ?elems_);
         ens array_at_lft(k, self as *MaybeUninit<T>, n, map(MaybeUninit::new_maybe_uninit, elems_));
     
-    lem_auto(std::mem::size_of::<MaybeUninit<T>>()) size_of_MaybeUninit<T>();
+    lem_auto(std::mem::size_of::<MaybeUninit<T>>()) size_of_MaybeUninit<T: ?Sized>();
         req true;
         ens std::mem::size_of::<MaybeUninit<T>>() == std::mem::size_of::<T>();
     
-    lem_auto(std::mem::align_of::<MaybeUninit<T>>()) align_of_MaybeUninit<T>();
+    lem_auto(std::mem::align_of::<MaybeUninit<T>>()) align_of_MaybeUninit<T: ?Sized>();
         req true;
         ens std::mem::align_of::<MaybeUninit<T>>() == std::mem::align_of::<T>();
     
@@ -528,7 +528,7 @@ mod ptr {
     
     fix NonNull::without_provenance<T>(addr: std::num::NonZero<usize>) -> NonNull<T>;
     
-    lem_auto(NonNull::without_provenance::<T>(addr).as_ptr()) NonNull_as_ptr_NonNull_without_provenance<T>(addr: std::num::NonZero<usize>);
+    lem_auto(NonNull::without_provenance::<T>(addr).as_ptr()) NonNull_as_ptr_NonNull_without_provenance<T: ?Sized>(addr: std::num::NonZero<usize>);
         req true;
         ens NonNull::without_provenance::<T>(addr).as_ptr() == addr.get() as *T;
     
@@ -545,7 +545,7 @@ mod ptr {
     // If ptr is 0, the result of NonNull::new_ is unspecified. (It is never the case that NonNull_ptr(nnp) == 0.)
     fix NonNull::new<T>(ptr: *T) -> NonNull<T>;
     
-    lem_auto(NonNull::new(ptr).as_ptr()) NonNull_as_ptr_new<T>(ptr: *T);
+    lem_auto(NonNull::new(ptr).as_ptr()) NonNull_as_ptr_new<T: ?Sized>(ptr: *T);
         req ptr != 0 && pointer_within_limits(ptr);
         ens NonNull::new(ptr).as_ptr() == ptr;
     
@@ -553,7 +553,7 @@ mod ptr {
         req true;
         ens NonNull::new(v.as_ptr()) == v;
     
-    lem_auto(v.as_ptr()) NonNull_as_ptr_nonnull<T>(v: NonNull<T>);
+    lem_auto(v.as_ptr()) NonNull_as_ptr_nonnull<T: ?Sized>(v: NonNull<T>);
         req true;
         ens v.as_ptr() != 0 && pointer_within_limits(v.as_ptr());
     
@@ -623,7 +623,7 @@ mod ptr {
         req true;
         ens <Unique<T>>.own(t, self_);
     
-    lem_auto(Unique::from_non_null(nn).as_non_null_ptr()) Unique_as_non_null_ptr_from_non_null<T>(nn: NonNull<T>);
+    lem_auto(Unique::from_non_null(nn).as_non_null_ptr()) Unique_as_non_null_ptr_from_non_null<T: ?Sized>(nn: NonNull<T>);
         req true;
         ens Unique::from_non_null(nn).as_non_null_ptr() == nn;
     
@@ -773,11 +773,11 @@ mod alloc {
         req true;
         ens is_valid_layout(layout.size(), layout.align()) == true;
     
-    lem_auto is_valid_layout_size_of_align_of<T>();
+    lem_auto is_valid_layout_size_of_align_of<T: ?Sized>();
         req true;
         ens is_valid_layout(std::mem::size_of::<T>(), std::mem::align_of::<T>()) == true;
     
-    lem_auto Layout_is_valid_new<T>();
+    lem_auto Layout_is_valid_new<T: ?Sized>();
         req true;
         ens Layout::is_valid(Layout::new::<T>()) == true;
     
@@ -891,7 +891,7 @@ mod alloc {
     pred Allocator<A>(t: thread_id_t, alloc: A, alloc_id: alloc_id_t);
     pred Allocator_share<A>(k: lifetime_t, t: thread_id_t, l: *A, alloc_id: alloc_id_t);
 
-    lem Allocator_inv<A>();
+    lem Allocator_inv<A: ?Sized>();
         req Allocator::<A>(?t, ?alloc, ?alloc_id);
         ens Allocator::<A>(t, alloc, alloc_id) &*& lifetime_inclusion(lft_of_type::<A>(), alloc_id.lft) == true;
     
@@ -1462,7 +1462,7 @@ mod vec {
     
     /*@
     
-    lem_auto Vec_inv<T, A>();
+    lem_auto Vec_inv<T: ?Sized, A: ?Sized>();
         req [?f]Vec::<T, A>(?vec, ?capacity, ?elems);
         ens [f]Vec::<T, A>(vec, capacity, elems) &*& length(elems) <= capacity &*& capacity <= isize::MAX;
     

--- a/src/SExpressionEmitter.ml
+++ b/src/SExpressionEmitter.ml
@@ -926,7 +926,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
     | Struct (loc,
               name,
               tparams,
-              None,
+              Right sizedness,
               attrs) ->
         build_list [ Symbol "declare-struct"
                    ; Symbol name; List (List.map (fun x -> Symbol x) tparams) ]
@@ -934,7 +934,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
     | Struct (loc,
               name,
               tparams,
-              Some (bases, fields, inst_preds, polymorphic),
+              Left (bases, fields, inst_preds, polymorphic),
               attrs) ->
         build_list [ Symbol "define-struct"
                    ; Symbol name; List (List.map (fun x -> Symbol x) tparams) ]
@@ -977,7 +977,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
             ; "postcondition", List [ Symbol result_var; sexpr_of_pred post ] ]
       in
       let kw = List.concat [ [ "kind", sexpr_of_func_kind kind
-                             ; "type-parameters", List (List.map symbol tparams )
+                             ; "type-parameters", List (List.map symbol (List.map fst tparams) )
                              ; "return-type", sexpr_of_type_expr_option rtype
                              ; "parameters", List (List.map sexpr_of_arg params)
                              ; "is_virtual", sexpr_of_bool is_virtual ]
@@ -1011,7 +1011,7 @@ and sexpr_of_decl (decl : decl) : sexpression =
       in
       build_list [ Symbol "declare-predicate-family-instance"
                  ; Symbol name ]
-                 [ "type-parameters", List (List.map symbol tparams)
+                 [ "type-parameters", List (List.map symbol (List.map fst tparams))
                  ; "parameters", List (List.map arg_pair params)
                  ; "predicate", sexpr_of_pred predicate ]
     | ImportModuleDecl (loc, name) ->

--- a/src/cxx_frontend/decl_translator.ml
+++ b/src/cxx_frontend/decl_translator.ml
@@ -162,13 +162,13 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
               bases_get body
               |> Capnp_util.arr_map (Node_translator.map ~f:transl_base)
             in
-            ( Some
+            ( Either.Left
                 ( List.rev bases,
                   List.rev fields,
                   List.rev inst_preds,
                   polymorphic ),
               List.rev decls )
-      else (None, [])
+      else (Right (Either.Left true), [])
     in
     let vf_record =
       match kind_get record with
@@ -176,7 +176,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
           Ast.Struct (loc, name, [], body, [])
       | R.RecordKind.Unio ->
           Ast.Union
-            (loc, name, body |> Option.map @@ fun (_, fields, _, _) -> fields)
+            (loc, name, match body with Left (_, fields, _, _) -> Some fields | _ -> None)
     in
     vf_record :: decls
 
@@ -379,7 +379,7 @@ module Make (Node_translator : Node_translator.Translator) : Translator = struct
             Ast.Real,
             return_type,
             name,
-            ft_type_params,
+            Ast.tparams_with_bounds_expr {Ast.sized=true} ft_type_params,
             ft_params,
             params,
             (pre, ("result", post), terminates) )

--- a/src/frontend/ast_aux.ml
+++ b/src/frontend/ast_aux.ml
@@ -131,9 +131,9 @@ let decl_fields (d : decl) =
   match d with
   | Struct (loc, name, tparams, definition_opt, attrs) -> (
       match definition_opt with
-      | Some (base_specs, fields, instance_pred_decls, is_polymorphic) ->
+      | Left (base_specs, fields, instance_pred_decls, is_polymorphic) ->
           Ok (Some fields)
-      | None -> Ok None)
+      | Right sizedness -> Ok None)
   | _ -> failwith "Todo: get Ast.decl fields"
 
 let decl_loc (d : decl) =

--- a/src/frontend/util.ml
+++ b/src/frontend/util.ml
@@ -318,6 +318,25 @@ let remove_assoc_opt x xys =
   let value = List.assoc_opt x xys in
   value, List.remove_assoc x xys
 
+let rec assoc_with_is_last x xys =
+  match xys with
+    [] -> raise Not_found
+  | [(x', y)] when x' = x -> (y, true)
+  | (x', y)::xys when x' = x -> (y, false)
+  | _::xys -> assoc_with_is_last x xys
+
+let rec iter_with_is_last f xs =
+  match xs with
+    [] -> ()
+  | [x] -> f x true
+  | x::xs -> f x false; iter_with_is_last f xs
+
+let rec map_with_is_last f xs =
+  match xs with
+    [] -> []
+  | [x] -> [f x true]
+  | x::xs -> f x false::map_with_is_last f xs
+
 exception IsNone
 
 let get x = 

--- a/src/redux.ml
+++ b/src/redux.ml
@@ -774,7 +774,7 @@ and context () =
     | Mul (t1, t2) -> Mul (simplify t1, simplify t2)
     | App (parent_sym, [target; App (parent_offset_sym, [], _) as parent_offset], cached) when parent_sym#name = "field_ptr_parent" -> 
       begin match simplify target with
-      | App (child_sym, [child_target; _; App (child_offset_sym, [], _)], _) when child_sym#name = "field_ptr" && parent_offset_sym#name = child_offset_sym#name ->
+      | App (child_sym, [child_target; _; App (child_offset_sym, [], _)], _) when (child_sym#name = "field_ptr" || child_sym#name = "last_field_ptr") && parent_offset_sym#name = child_offset_sym#name ->
         child_target
       | simpl -> 
         App (parent_sym, [simpl; parent_offset], cached)

--- a/src/rust_frontend/vf_mir_translator/ast_to_src.ml
+++ b/src/rust_frontend/vf_mir_translator/ast_to_src.ml
@@ -17,9 +17,11 @@ let string_of_val_targs = function
   [] -> ""
 | ts -> Printf.sprintf "::<%s>" (String.concat ", " (List.map string_of_type_expr ts))
 
+let string_of_tparam (x, bounds) = x
+
 let string_of_tparams = function
   [] -> ""
-| tps -> "<" ^ String.concat ", " tps ^ ">"
+| tps -> "<" ^ String.concat ", " (List.map string_of_tparam tps) ^ ">"
 
 let string_of_params ps =
   String.concat ", " (List.map (fun (tp, x) -> Printf.sprintf "%s: %s" x (string_of_type_expr tp)) ps)

--- a/src/z3v4dot5prover.ml
+++ b/src/z3v4dot5prover.ml
@@ -41,7 +41,7 @@ let rec simplify e =
     end
   | List [Atom "field_ptr_parent" as a0; ptr_e; Atom parent_offset as a1] ->
     begin match simplify ptr_e with
-    | List [Atom "field_ptr"; child_target; _; Atom child_offset] when parent_offset = child_offset ->
+    | List [Atom ("field_ptr"|"last_field_ptr"); child_target; _; Atom child_offset] when parent_offset = child_offset ->
       child_target
     | simpl ->
       List [a0; simpl; a1] 

--- a/tests/rust/safe_abstraction/linked_list/verified/linked_list.rs
+++ b/tests/rust/safe_abstraction/linked_list/verified/linked_list.rs
@@ -363,7 +363,7 @@ pred Nodes1<T>(alloc_id: alloc_id_t, n: Option<NonNull<Node<T>>>, prev: Option<N
             nexts == cons(next0, nexts0)
     };
 
-lem_auto Nodes1_inv<T>()
+lem_auto Nodes1_inv<T: ?Sized>()
     req [?f]Nodes1::<T>(?alloc_id, ?head, ?prev, ?last, ?next, ?nodes, ?prevs, ?nexts);
     ens [f]Nodes1::<T>(alloc_id, head, prev, last, next, nodes, prevs, nexts) &*& length(prevs) == length(nodes) &*& length(nexts) == length(nodes);
 {

--- a/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
+++ b/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
@@ -199,7 +199,7 @@ lem RawVecInner_send<A>(t1: thread_id_t)
     close RawVecInner_own::<A>(t1, v);
 }
 
-lem_auto RawVecInner_inv<A>()
+lem_auto RawVecInner_inv<A: ?Sized>()
     req RawVecInner::<A>(?t, ?self_, ?elemLayout, ?alloc_id, ?ptr, ?capacity);
     ens RawVecInner::<A>(t, self_, elemLayout, alloc_id, ptr, capacity) &*&
         lifetime_inclusion(lft_of_type::<A>(), alloc_id.lft) == true &*&

--- a/tests/rust/testsuite.mysh
+++ b/tests/rust/testsuite.mysh
@@ -1,4 +1,5 @@
 begin_parallel
+verifast -allow_should_fail unsized_cast.rs
 verifast -allow_should_fail size_of_ptr_unsized.rs
 verifast -skip_specless_fns const_generic_param.rs
 verifast -allow_dead_code -allow_should_fail struct_layout.rs

--- a/tests/rust/unsized_cast.rs
+++ b/tests/rust/unsized_cast.rs
@@ -1,0 +1,4 @@
+unsafe fn foo<T: ?Sized>(p: *const T, q: *const T) -> bool
+//@ req (p as *u8) == (q as *u8);
+//@ ens result; //~should_fail
+{ p == q }


### PR DESCRIPTION
Also adds support for Sized bounds on function, lemma, and predicate type parameters. These are used to determine whether a pointer-to-pointer cast strips the metadata.

Fixes #953
