### PR TITLE
[Rust] Translate *str to PtrType Str

### DIFF
--- a/bin/rust/aliasing.rsspec
+++ b/bin/rust/aliasing.rsspec
@@ -109,7 +109,7 @@ fn reborrow_slice_ref<T>(x: slice_ref<'static, T>) -> slice_ref<'static, T>;
 //@ ens result == x;
 //@ on_unwind_ens false;
 
-fn create_str_ref(x: str_ref<'static>) -> str_ref<'static>;
+fn create_str_ref(x: &'static str) -> &'static str;
 //@ req true; // TODO
 //@ ens result == x;
 //@ on_unwind_ens false;

--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -49,10 +49,6 @@ struct slice_ref<'a, T> { ptr: *T, len: usize }
 
 struct slice_ref_mut<'a, T> { ptr: *T, len: usize }
 
-struct str_ptr { ptr: *u8, len: usize }
-
-struct str_ref<'a> { ptr: *u8, len: usize }
-
 /*@
 
 pred junk();

--- a/bin/rust/prelude_core.rsspec
+++ b/bin/rust/prelude_core.rsspec
@@ -91,6 +91,9 @@ fix pointer_cast(from_typeid: *_, to_typeid: *_, p: pointer) -> pointer {
 
 fix ptr_cast<T, U>(p: *T) -> *U { pointer_cast(typeid(T), typeid(U), p as pointer) as *U }
 
+fix pointer_metadata_as_usize(metadata: pointer_metadata) -> usize;
+fix ptr_len<t>(p: *t) -> usize { pointer_metadata_as_usize((p as pointer).metadata) }
+
 fix null_pointer_provenance() -> pointer_provenance;
 fix null_pointer() -> pointer { pointer_ctor(null_pointer_provenance, 0, pointer_metadata_none) }
 

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -1810,9 +1810,9 @@ mod panicking {
     }
     
     fn panic<'a>(msg: &'a str);
-    //@ req [?f]msg.ptr[..msg.len] |-> ?cs;
+    //@ req [?f](msg as *u8)[..msg.len()] |-> ?cs;
     //@ ens false;
-    //@ on_unwind_ens [f]msg.ptr[..msg.len] |-> cs;
+    //@ on_unwind_ens [f](msg as *u8)[..msg.len()] |-> cs;
 
     fn panic_fmt<'a>(args: std::fmt::Arguments<'a>);
     //@ req thread_token(?t) &*& <std::fmt::Arguments<'a>>.own(t, args);

--- a/rust_tutorials/purely_unsafe/solutions/lemptrs.rs
+++ b/rust_tutorials/purely_unsafe/solutions/lemptrs.rs
@@ -1,7 +1,7 @@
 //@ use std::str::str;
 
-//@ pred small_str(s: *str) = str(s, _) &*& s.len <= 20;
-//@ pred large_str(s: *str) = str(s, _) &*& s.len <= 1000;
+//@ pred small_str(s: *str) = str(s, _) &*& s.len() <= 20;
+//@ pred large_str(s: *str) = str(s, _) &*& s.len() <= 1000;
 
 unsafe fn read_lines() -> *const *const str
 //@ req true;

--- a/src/frontend/ast.ml
+++ b/src/frontend/ast.ml
@@ -182,6 +182,7 @@ type type_ = (* ?type_ *)
   | AbstractType of string
   | StaticLifetime (* 'static in Rust *)
   | ProjectionType of type_ * string (* trait name *) * type_ list (* trait generic args *) * string (* associated type name *) (* In Rust: <T as X<GArgs>>::Y *)
+  | Str (* Rust's `str` type *)
 and inferred_type_state =
     Unconstrained
   | ContainsAnyConstraint of bool (* allow the type to contain 'any' in positive positions *)
@@ -251,7 +252,7 @@ let is_instance (l: loc) (t1: type_) (t2: type_) =
   in iter [] t1 t2
 
 let type_fold_open state f = function
-  Bool | Void | Int (_, _) | RustChar | RealType | Float | Double | LongDouble -> state
+  Bool | Void | Int (_, _) | RustChar | RealType | Float | Double | LongDouble | Str -> state
 | StructType (sn, targs) -> List.fold_left f state targs
 | UnionType _ -> state
 | PtrType tp -> f state tp

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -76,6 +76,7 @@ let rec of_type = function
 | RefType t -> C ("RefType", [of_type t])
 | AbstractType s -> C ("AbstractType", [S s])
 | StaticLifetime -> c "StaticLifetime"
+| Str -> c "Str"
 and of_inferred_type_state = function
   Unconstrained -> c "Unconstrained"
 | ContainsAnyConstraint b -> C ("ContainsAnyConstraint", [B b])

--- a/src/frontend/verifast0.ml
+++ b/src/frontend/verifast0.ml
@@ -272,6 +272,7 @@ let rec rust_string_of_type t =
   | AbstractType x -> x
   | StaticLifetime -> "'static"
   | ProjectionType (t, traitName, traitArgs, assocTypeName) -> Printf.sprintf "<%s as %s<%s>>::%s" (rust_string_of_type t) traitName (String.concat ", " (List.map rust_string_of_type traitArgs)) assocTypeName
+  | Str -> "str"
 
 let string_of_type lang dialect =
   match lang, dialect with

--- a/src/rust_frontend/vf_mir_translator/rust_parser.ml
+++ b/src/rust_frontend/vf_mir_translator/rust_parser.ml
@@ -56,6 +56,7 @@ let rec parse_type = function%parser
 | [ (l, Ident "f32" ) ] -> ManifestTypeExpr (l, Float)
 | [ (l, Ident "f64" ) ] -> ManifestTypeExpr (l, Double)
 | [ (l, Ident "real" ) ] -> ManifestTypeExpr (l, RealType)
+| [ (l, Ident "str") ] -> ManifestTypeExpr (l, Str)
 | [ (l, Ident x); [%let l, x = parse_simple_path_rest l x];
     [%let t = function%parser
       [ parse_type_args as targs ] -> ConstructedTypeExpr (l, x, targs)
@@ -93,7 +94,6 @@ let rec parse_type = function%parser
     [%let mutability = opt (function%parser [ (_, Kwd "const") ] -> () | [ (_, Kwd "mut") ] -> ()) ];
     [%let t = function%parser
        [ (lv, Kwd "_") ] -> PtrTypeExpr (l, ManifestTypeExpr (lv, Void))
-     | [ (lv, Ident "str") ] -> StructTypeExpr (l, Some "str_ptr", None, [], [])
      | [ parse_type as t ] -> PtrTypeExpr (l, t)
     ]
   ] -> t
@@ -115,9 +115,6 @@ let rec parse_type = function%parser
             RustRefTypeExpr (l, lft, mutability, StaticArrayTypeExpr (ls, elemTp, size))
          ]
        ] -> tp
-     | [ (l, Ident "str") ] ->
-       if mutability <> Shared then raise (ParseException (l, "Mutable string references are not yet supported"));
-       StructTypeExpr (l, Some "str_ref", None, [], [lft])
      | [ parse_type as tp ] ->
        RustRefTypeExpr (l, lft, mutability, tp)
     ]

--- a/tests/rust/purely_unsafe/httpd.rs
+++ b/tests/rust/purely_unsafe/httpd.rs
@@ -154,8 +154,8 @@ unsafe fn send_bytes<'a>(socket: platform::sockets::Socket, bytes: &'a [u8])
 }
 
 unsafe fn send_str<'a>(socket: platform::sockets::Socket, text: &'a str)
-//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]text.ptr[..text.len] |-> ?cs;
-//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]text.ptr[..text.len] |-> cs;
+//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft](text as *u8)[..text.len()] |-> ?cs;
+//@ ens [fs]platform::sockets::Socket(socket) &*& [ft](text as *u8)[..text.len()] |-> cs;
 {
     send_bytes(socket, text.as_bytes());
 }
@@ -173,8 +173,8 @@ unsafe fn handle_connection(buffer: *mut Buffer, socket: platform::sockets::Sock
 }
 
 unsafe fn print<'a>(text: &'a str)
-//@ req thread_token(?t) &*& [?f]text.ptr[..text.len] |-> ?cs;
-//@ ens thread_token(t) &*& [f]text.ptr[..text.len] |-> cs;
+//@ req thread_token(?t) &*& [?f](text as *u8)[..text.len()] |-> ?cs;
+//@ ens thread_token(t) &*& [f](text as *u8)[..text.len()] |-> cs;
 {
     let mut stdout = std::io::stdout();
     let result = stdout.write(text.as_bytes());

--- a/tests/rust/purely_unsafe/httpd_mt/src/main.rs
+++ b/tests/rust/purely_unsafe/httpd_mt/src/main.rs
@@ -175,8 +175,8 @@ unsafe fn read_line(socket: platform::sockets::Socket, buffer: *mut Buffer)
 }
 
 unsafe fn send_str<'a>(socket: platform::sockets::Socket, text: &'a str)
-//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]text.ptr[..text.len] |-> ?cs;
-//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]text.ptr[..text.len] |-> cs;
+//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft](text as *u8)[..text.len()] |-> ?cs;
+//@ ens [fs]platform::sockets::Socket(socket) &*& [ft](text as *u8)[..text.len()] |-> cs;
 {
     socket.send(text.as_ptr(), text.len());
 }
@@ -234,8 +234,8 @@ unsafe fn handle_connection(connection: *mut Connection)
 }
 
 unsafe fn print<'a>(text: &'a str)
-//@ req thread_token(?t) &*& [?f]text.ptr[..text.len] |-> ?cs;
-//@ ens thread_token(t) &*& [f]text.ptr[..text.len] |-> cs;
+//@ req thread_token(?t) &*& [?f](text as *u8)[..text.len()] |-> ?cs;
+//@ ens thread_token(t) &*& [f](text as *u8)[..text.len()] |-> cs;
 {
     let mut stdout = std::io::stdout();
     let result = stdout.write(text.as_bytes());

--- a/tests/rust/purely_unsafe/httpd_vec.rs
+++ b/tests/rust/purely_unsafe/httpd_vec.rs
@@ -73,8 +73,8 @@ unsafe fn send_bytes<'a>(socket: platform::sockets::Socket, bytes: &'a [u8])
 }
 
 unsafe fn send_str<'a>(socket: platform::sockets::Socket, text: &'a str)
-//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]text.ptr[..text.len] |-> ?bs;
-//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]text.ptr[..text.len] |-> bs;
+//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft](text as *u8)[..text.len()] |-> ?bs;
+//@ ens [fs]platform::sockets::Socket(socket) &*& [ft](text as *u8)[..text.len()] |-> bs;
 {
     send_bytes(socket, text.as_bytes());
 }
@@ -94,8 +94,8 @@ unsafe fn handle_connection<'a>(buffer: &'a mut Vec<u8>, socket: platform::socke
 }
 
 unsafe fn print<'a>(text: &'a str)
-//@ req thread_token(?t) &*& [?f]text.ptr[..text.len] |-> ?cs;
-//@ ens thread_token(t) &*& [f]text.ptr[..text.len] |-> cs;
+//@ req thread_token(?t) &*& [?f](text as *u8)[..text.len()] |-> ?cs;
+//@ ens thread_token(t) &*& [f](text as *u8)[..text.len()] |-> cs;
 {
     let mut stdout = std::io::stdout();
     let result = stdout.write(text.as_bytes());

--- a/tests/rust/purely_unsafe/str.rs
+++ b/tests/rust/purely_unsafe/str.rs
@@ -1,8 +1,8 @@
 // verifast_options{ignore_ref_creation}
 
 unsafe fn is_hi<'a>(text: &'a str) -> bool
-//@ req [?f]text.ptr[..text.len] |-> ?cs;
-//@ ens [f]text.ptr[..text.len] |-> cs &*& result == (cs == ['H', 'i']);
+//@ req [?f](text as *u8)[..text.len()] |-> ?cs;
+//@ ens [f](text as *u8)[..text.len()] |-> cs &*& result == (cs == ['H', 'i']);
 {
     if text.len() != 2 {
         false


### PR DESCRIPTION
Breaking change: the element pointer and length of a str pointer p are now accessed using `p as *u8` and `p.len()`.