### PR TITLE
[Rust] Translate *[T] to PtrType (Slice T)

### DIFF
--- a/bin/rust/aliasing.rsspec
+++ b/bin/rust/aliasing.rsspec
@@ -99,12 +99,12 @@ fn create_ref_UnsafeCell(x: *_) -> *_;
 //@ ens ref_origin(result) == ref_origin(x);
 //@ on_unwind_ens false;
 
-fn create_slice_ref<T>(x: slice_ref<'static, T>) -> slice_ref<'static, T>;
+fn create_slice_ref<T>(x: &'static [T]) -> &'static [T];
 //@ req true; // TODO
 //@ ens result == x;
 //@ on_unwind_ens false;
 
-fn reborrow_slice_ref<T>(x: slice_ref<'static, T>) -> slice_ref<'static, T>;
+fn reborrow_slice_ref<T>(x: &'static [T]) -> &'static [T];
 //@ req true; // TODO
 //@ ens result == x;
 //@ on_unwind_ens false;

--- a/bin/rust/prelude.rsspec
+++ b/bin/rust/prelude.rsspec
@@ -43,12 +43,6 @@ lem close_tuple_4_own<T1, T2, T3, T4>(t: thread_id_t, v: (T1, T2, T3, T4));
 
 @*/
 
-struct slice_ptr<T> { ptr: *T, len: usize }
-
-struct slice_ref<'a, T> { ptr: *T, len: usize }
-
-struct slice_ref_mut<'a, T> { ptr: *T, len: usize }
-
 /*@
 
 pred junk();

--- a/bin/rust/std/lib.rsspec
+++ b/bin/rust/std/lib.rsspec
@@ -512,9 +512,9 @@ mod ptr {
     //@ req true;
     //@ ens result == addr as *T;
     
-    fn slice_from_raw_parts_mut<T>(data: *T, len: usize) -> slice_ptr<T>;
+    fn slice_from_raw_parts_mut<T>(data: *T, len: usize) -> *[T];
     //@ req true;
-    //@ ens result == slice_ptr::<T> { ptr: data, len };
+    //@ ens result as *T == data &*& result.len() == len;
     //@ on_unwind_ens false;
 
     unsafe fn drop_in_place<T>(to_drop: *mut T);
@@ -1218,8 +1218,22 @@ mod boxed {
         //@ ens Box_in(t, result, alloc_id, value);
         //@ on_unwind_ens false;
     
-        fn from_raw_slice_in(x: slice_ptr<T>, alloc: A) -> Box_slice0<T, A>;
-        //@ req std::alloc::Allocator(?t, alloc, ?alloc_id) &*& array_at_lft(alloc_id.lft, x.ptr, x.len, ?vs) &*& if x.len * std::mem::size_of::<T>() == 0 { true } else { std::alloc::alloc_block_in(alloc_id, x.ptr as *u8, std::alloc::Layout::from_size_align(x.len * std::mem::size_of::<T>(), std::mem::align_of::<T>())) };
+        fn from_raw_slice_in(x: *[T], alloc: A) -> Box_slice0<T, A>;
+        /*@
+        req std::alloc::Allocator(?t, alloc, ?alloc_id) &*&
+            array_at_lft(alloc_id.lft, x as *T, x.len(), ?vs) &*&
+            if x.len() * std::mem::size_of::<T>() == 0 {
+                true
+            } else {
+                std::alloc::alloc_block_in(
+                    alloc_id,
+                    x as *u8,
+                    std::alloc::Layout::from_size_align(
+                        x.len() * std::mem::size_of::<T>(),
+                        std::mem::align_of::<T>()
+                    ))
+            };
+        @*/
         //@ ens Box_slice_in(t, result, alloc_id, vs);
         //@ on_unwind_ens false;
     
@@ -1530,7 +1544,7 @@ mod vec {
 
         fn spare_capacity_mut<'a>(self: &'a Vec<T, A>) -> &'a [T];
         //@ req [?f](*self |-> ?self_) &*& [f]Vec_minus_buffer::<T, A>(self_, ?capacity, ?len, ?buffer);
-        //@ ens [f](*self |-> self_) &*& [f]Vec_minus_buffer::<T, A>(self_, capacity, len, buffer) &*& result.ptr == buffer + len &*& result.len == capacity - len;
+        //@ ens [f](*self |-> self_) &*& [f]Vec_minus_buffer::<T, A>(self_, capacity, len, buffer) &*& result as *T == buffer + len &*& result.len() == capacity - len;
         //@ on_unwind_ens false;
 
         fn set_len<'a>(self: &'a Vec<T, A>, new_len: usize);
@@ -1551,9 +1565,9 @@ mod io {
     trait Write {
     
         fn write<'a, 'b>(self: &'a Self, buf: &'b [u8]) -> Result<usize>;
-        //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0) &*& [?f]buf.ptr[..buf.len] |-> ?bs;
-        //@ ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1) &*& [f]buf.ptr[..buf.len] |-> bs &*& std::result::Result_own::<usize, Error>(t, result);
-        //@ on_unwind_ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1) &*& [f]buf.ptr[..buf.len] |-> _;
+        //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0) &*& [?f](buf as *u8)[..buf.len()] |-> ?bs;
+        //@ ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1) &*& [f](buf as *u8)[..buf.len()] |-> bs &*& std::result::Result_own::<usize, Error>(t, result);
+        //@ on_unwind_ens thread_token(t) &*& *self |-> ?self1 &*& <Self>.own(t, self1) &*& [f](buf as *u8)[..buf.len()] |-> _;
         
         fn flush<'a>(self: &'a Self) -> Result<()>;
         //@ req thread_token(?t) &*& *self |-> ?self0 &*& <Self>.own(t, self0);

--- a/src/frontend/ocaml_expr_of_ast.ml
+++ b/src/frontend/ocaml_expr_of_ast.ml
@@ -77,6 +77,7 @@ let rec of_type = function
 | AbstractType s -> C ("AbstractType", [S s])
 | StaticLifetime -> c "StaticLifetime"
 | Str -> c "Str"
+| Slice t -> C ("Slice", [of_type t])
 and of_inferred_type_state = function
   Unconstrained -> c "Unconstrained"
 | ContainsAnyConstraint b -> C ("ContainsAnyConstraint", [B b])
@@ -240,6 +241,11 @@ let rec of_type_expr = function
   ])
 | InferredTypeExpr l ->
   C ("InferredTypeExpr", [of_loc l])
+| SliceTypeExpr (l, tp) ->
+  C ("SliceTypeExpr", [
+    of_loc l;
+    of_type_expr tp
+  ])
 and of_tparam_bounds_expr {sized} =
   T [
     B sized;

--- a/src/frontend/verifast0.ml
+++ b/src/frontend/verifast0.ml
@@ -273,6 +273,7 @@ let rec rust_string_of_type t =
   | StaticLifetime -> "'static"
   | ProjectionType (t, traitName, traitArgs, assocTypeName) -> Printf.sprintf "<%s as %s<%s>>::%s" (rust_string_of_type t) traitName (String.concat ", " (List.map rust_string_of_type traitArgs)) assocTypeName
   | Str -> "str"
+  | Slice t -> "[" ^ rust_string_of_type t ^ "]"
 
 let string_of_type lang dialect =
   match lang, dialect with

--- a/src/rust_frontend/vf_mir_translator/ast_to_src.ml
+++ b/src/rust_frontend/vf_mir_translator/ast_to_src.ml
@@ -8,6 +8,7 @@ let rec string_of_type_expr = function
 | ConstructedTypeExpr (l, tn, targs) -> Printf.sprintf "%s%s" tn (string_of_type_targs targs)
 | RustRefTypeExpr (l, lft, mut, tp) -> Printf.sprintf "&%s%s %s" (string_of_type_expr lft) (match mut with Mutable -> " mut" | Shared -> "") (string_of_type_expr tp)
 | PtrTypeExpr (l, tp) -> Printf.sprintf "*%s" (string_of_type_expr tp)
+| SliceTypeExpr (l, tp) -> Printf.sprintf "[%s]" (string_of_type_expr tp)
 | te -> failwith (Printf.sprintf "string_of_type_expr: %s" (Ocaml_expr_formatter.string_of_ocaml_expr true (Ocaml_expr_of_ast.of_type_expr te)))
 and string_of_type_targs = function
   [] -> ""

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -402,7 +402,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
             in
             let fttpenv = fttpenv_with_bounds |> List.map begin fun ((x, {sized}), tp) ->
               if sized then
-                if not (is_definitely_sized_type tp) then
+                if not (sizedness_of_type tp = Some true) then
                   static_error l ("Type argument for type parameter '" ^ x ^ "' must be a sized type.") None;
               (x, tp)
             end in
@@ -2262,7 +2262,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         if is_rust then begin
           tpenv_with_bounds |> List.iter @@ fun ((tp, {sized}), ta) ->
             if sized then
-              if not (is_definitely_sized_type ta) then
+              if not (sizedness_of_type ta = Some true) then
                 static_error l (Printf.sprintf "Type argument %s for type parameter %s must implement trait Sized" (string_of_type ta) tp) None
         end;
         let (result_var, post) =

--- a/tests/rust/purely_unsafe/httpd.rs
+++ b/tests/rust/purely_unsafe/httpd.rs
@@ -147,8 +147,8 @@ unsafe fn read_line(socket: platform::sockets::Socket, buffer: *mut Buffer)
 }
 
 unsafe fn send_bytes<'a>(socket: platform::sockets::Socket, bytes: &'a [u8])
-//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]bytes.ptr[..bytes.len] |-> ?cs;
-//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]bytes.ptr[..bytes.len] |-> cs;
+//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft](bytes as *u8)[..bytes.len()] |-> ?cs;
+//@ ens [fs]platform::sockets::Socket(socket) &*& [ft](bytes as *u8)[..bytes.len()] |-> cs;
 {
     socket.send(bytes.as_ptr(), bytes.len());
 }

--- a/tests/rust/purely_unsafe/httpd_vec.rs
+++ b/tests/rust/purely_unsafe/httpd_vec.rs
@@ -66,8 +66,8 @@ unsafe fn read_line<'a>(socket: platform::sockets::Socket, buffer: &'a mut Vec<u
 }
 
 unsafe fn send_bytes<'a>(socket: platform::sockets::Socket, bytes: &'a [u8])
-//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft]bytes.ptr[..bytes.len] |-> ?bs;
-//@ ens [fs]platform::sockets::Socket(socket) &*& [ft]bytes.ptr[..bytes.len] |-> bs;
+//@ req [?fs]platform::sockets::Socket(socket) &*& [?ft](bytes as *u8)[..bytes.len()] |-> ?bs;
+//@ ens [fs]platform::sockets::Socket(socket) &*& [ft](bytes as *u8)[..bytes.len()] |-> bs;
 {
     socket.send(bytes.as_ptr(), bytes.len());
 }

--- a/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
+++ b/tests/rust/safe_abstraction/raw_vec/verified/raw_vec.rs
@@ -1222,7 +1222,7 @@ impl<T, A: Allocator> RawVec<T, A> {
             //@ close_points_to(me_ref1, 1/2);
             //@ end_ref_readonly(me_ref1);
             //@ open_points_to(&me);
-            //@ std::mem::array_at_lft__to_array_at_lft_MaybeUninit(slice.ptr as *T);
+            //@ std::mem::array_at_lft__to_array_at_lft_MaybeUninit(slice as *T);
             //@ open RawVec(_, _, _, _, _);
             //@ open RawVecInner(_, _, _, _, _, _);
             //@ size_align::<T>();


### PR DESCRIPTION
Breaking change: to access the element pointer and length of a slice pointer p, now write `p as *T` and `p.len()`.