### PR TITLE
Support triggers on zero-param pure autolemmas

### DIFF
--- a/src/redux.ml
+++ b/src/redux.ml
@@ -1705,7 +1705,7 @@ and context () =
     method end_formal = formal_depth <- formal_depth - 1
     method mk_bound (i: int) (s: unit): (symbol, termnode) term = BoundVar i
     method assume_forall (description: string) (pats: ((symbol, termnode) term) list) (tps: unit list) (body: (symbol, termnode) term): unit =
-      if tps = [] then ignore (self#assume body) else
+      if tps = [] && pats = [] then ignore (self#assume body) else
       let pats =
         if pats = [] then
           let check_pat pat =
@@ -1759,6 +1759,7 @@ and context () =
       pats |> List.iter (fun pat ->
         match pat with
           App (symb, args, _) ->
+          if args = [] then ignore (self#assume body) else
           (* We ignore existing applications of this symbol for now. *)
           symb#add_apply_listener (self :> context) (fun term ->
             (* printff "Axiom %s: toplevel symbol listener triggered\n" (self#pprint body); *)

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -221,6 +221,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         (zip2 xmap xmap0)
     end;
     if nonghost_callers_only <> nonghost_callers_only0 then static_error l (msg ^ "nonghost_callers_only clauses do not match.") None;
+    check_focus l l $. fun () ->
     execute_branch begin fun () ->
     with_context (Executing ([], [], l, msg0 ^ ": " ^ msg1)) $. fun () ->
     let tparam_typeid_env = tparams0_with_bounds |> flatmap @@ fun (x, _) ->


### PR DESCRIPTION
Until now, trigger patterns specified for zero-parameter pure autolemmas were ignored. They no longer are.

In particular, this improves treatment of is_Send and is_Sync definition lemmas generated by the MIR translator. The definitions are now subject to a trigger, preventing Redux from case splitting on them inappropriately.