### PR TITLE
On leak error, don't show empty chunks

### DIFF
--- a/src/verifast.ml
+++ b/src/verifast.ml
@@ -2057,7 +2057,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         assert_term dec_check2 h' env''' (expr_loc dec) "Cannot prove that the loop measure remains non-negative." None;
         cont h'''
       end $. fun h''' ->
-      check_leaks h''' env endBodyLoc "Loop leaks heap chunks."
+      check_leaks h''' env endBodyLoc "Loop leaks heap chunks"
     | WhileStmt (l, e, Some (LoopSpec (pre, post)), dec, ss, final_ss) ->
       if not pure then begin
         match ss with PureStmt (lp, _)::_ -> static_error lp "Pure statement not allowed here." None | _ -> ()
@@ -2757,7 +2757,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         reportStmtExec l;
         consume_asn rules [] h env ghostenv env inv true real_unit (fun _ h _ _ _ ->
           check_backedge_termination (List.assoc current_thread_name env) leminfo l tenv h env $. fun h ->
-          check_leaks h env l "Loop leaks heap chunks."
+          check_leaks h env l "Loop leaks heap chunks"
         )
       | (false, None) ->
         let blocks_done = block::blocks_done in
@@ -3606,7 +3606,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       let return_cont h tenv2 env2 retval =
         consume_asn rules [] h env ghostenv env post true real_unit @@ fun _ h ghostenv env size_first -> 
         cleanup_heapy_locals (pn, ilist) close_brace_loc h env heapy_ps varargsLastParam @@ fun h ->
-        check_leaks h env close_brace_loc "Constructor leaks heap chunks."
+        check_leaks h env close_brace_loc "Constructor leaks heap chunks"
       in 
       begin fun tcont ->
         verify_cont (pn, ilist) [] [] [] boxes true leminfo funcmap predinstmap sizemap pre_tenv ghostenv h env prolog tcont (fun _ _ -> assert false) (fun _ _ _ -> assert false)
@@ -3713,7 +3713,7 @@ module VerifyProgram(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
         end @@ fun h ->
         consume_bases bases h env tenv this_term ghostenv leminfo sizemap @@ fun h env tenv ->
         consume_asn rules [] h env ghostenv env post true real_unit @@ fun _ h ghostenv env size_first ->
-        check_leaks h env close_brace_loc "Destructor leaks heap chunks."
+        check_leaks h env close_brace_loc "Destructor leaks heap chunks"
       in 
       begin fun tcont ->
         verify_cont (pn, ilist) [] [] [] boxes true leminfo funcmap predinstmap sizemap pre_tenv ghostenv h env prolog tcont (fun _ _ -> assert false) (fun _ _ _ -> assert false)

--- a/src/verify_expr.ml
+++ b/src/verify_expr.ml
@@ -183,10 +183,10 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
       check_breakpoint h env l;
       major_success ()
     | _ ->
-    with_context (Executing (h, env, l, "Cleaning up dummy fraction chunks")) $. fun () ->
+    with_context (Executing (h, env, l, "Cleaning up dummy fraction chunks and empty chunks")) $. fun () ->
     let h = List.filter (fun (Chunk (_, _, coef, _, _)) -> not (is_dummy_frac_term coef)) h in
-    with_context (Executing (h, env, l, "Leak check.")) $. fun () ->
     let h = List.filter (function (Chunk(name, targs, frac, args, _)) when is_empty_chunk name targs frac args -> false | _ -> true) h in
+    with_context (Executing (h, env, l, "Leak check.")) $. fun () ->
     if h <> [] then assert_false h env l msg (Some "leak");
     check_breakpoint [] env l;
     major_success ()
@@ -256,7 +256,7 @@ module VerifyExpr(VerifyProgramArgs: VERIFY_PROGRAM_ARGS) = struct
           produce_asn tparam_typeid_env tpenv h [] env post real_unit None None (fun h _ _ ->
             epilog h result @@ fun h ->
             consume_asn rules tpenv0 h tparam_typeid_env [] env0 post0 true real_unit (fun _ h _ env0 _ ->
-              check_leaks h env0 l (msg ^ "Implementation leaks heap chunks.")
+              check_leaks h env0 l (msg ^ "Implementation leaks heap chunks")
             )
           )
         end;

--- a/src/vfconsole/vfconsole.ml
+++ b/src/vfconsole/vfconsole.ml
@@ -377,8 +377,8 @@ let _ =
         let open StringOf(struct let string_of_type = string_of_type language dialect end) in
         print_endline "Symbolic execution failed:";
         let msg =
-          match msg, ctxts with
-            "Function leaks heap chunks", (Executing (h, env, l, _)::_) ->
+          match ctxts with
+            (Executing (h, env, l, _)::_) when String.ends_with ~suffix:" leaks heap chunks" msg ->
             msg ^ ": " ^ String.concat ", " (List.map string_of_chunk h)
           | _ -> msg
         in


### PR DESCRIPTION
Also, in the CLI, print leaked chunks at all leak errors, not just function leak errors.